### PR TITLE
Skip plugins and theme when executing pattern extract

### DIFF
--- a/commands/GitHub_Pattern_To_Repo_Export.php
+++ b/commands/GitHub_Pattern_To_Repo_Export.php
@@ -99,7 +99,7 @@ final class GitHub_Pattern_To_Repo_Export extends Command {
 		}
 
 		// Run script.
-		$result = $ssh_connection->exec( sprintf( "wp eval-file /htdocs/pattern-extract.php %s", escapeshellarg( $this->pattern_name ) ) );
+		$result = $ssh_connection->exec( sprintf( "wp --skip-plugins --skip-theme eval-file /htdocs/pattern-extract.php %s", escapeshellarg( $this->pattern_name ) ) );
 		$output->writeln( "<comment>Pattern extraction result: {$result}</comment>", Output::VERBOSITY_DEBUG );
 
 		// Delete script.


### PR DESCRIPTION
On the `github:export-pattern-to-repo` command, if a site has errors or warning (like deprecation notices), that output gets picked up in the JSON file that's returned from the `wp eval` command. This update adds the `--skip-plugins --skip-theme` parameters to the command so those debug messages are avoided.