### PR TITLE
Added a working example of how we can use site name aliases to allow …

### DIFF
--- a/commands/DeployHQ_Project_Server_Create.php
+++ b/commands/DeployHQ_Project_Server_Create.php
@@ -262,7 +262,7 @@ final class DeployHQ_Project_Server_Create extends Command {
 	private function prompt_pressable_site_input( InputInterface $input, OutputInterface $output ): ?string {
 		$question = new Question( '<question>Enter the domain or numeric Pressable ID of the site to connect the server to:</question> ' );
 		if ( ! $input->getOption( 'no-autocomplete' ) ) {
-			$question->setAutocompleterValues( array_column( get_pressable_sites() ?? array(), 'url' ) );
+			$question->setAutocompleterValues( \array_column( get_pressable_sites( include_aliases: true ) ?? array(), 'url' ) );
 		}
 
 		return $this->getHelper( 'question' )->ask( $input, $output, $question );

--- a/commands/GitHub_Pattern_To_Repo_Export.php
+++ b/commands/GitHub_Pattern_To_Repo_Export.php
@@ -183,7 +183,7 @@ final class GitHub_Pattern_To_Repo_Export extends Command {
 	private function prompt_site_input( InputInterface $input, OutputInterface $output ): ?string {
 		$question = new Question( '<question>Enter the site ID or URL to extract the pattern from:</question> ' );
 		if ( ! $input->getOption( 'no-autocomplete' ) ) {
-			$question->setAutocompleterValues( array_column( get_pressable_sites() ?? array(), 'url' ) );
+			$question->setAutocompleterValues( \array_column( get_pressable_sites( include_aliases: true ) ?? array(), 'url' ) );
 		}
 
 		return $this->getHelper( 'question' )->ask( $input, $output, $question );

--- a/commands/Pressable_Site_Clone.php
+++ b/commands/Pressable_Site_Clone.php
@@ -300,7 +300,7 @@ final class Pressable_Site_Clone extends Command {
 	private function prompt_site_input( InputInterface $input, OutputInterface $output ): ?string {
 		$question = new Question( '<question>Enter the domain or Pressable site ID to clone:</question> ' );
 		if ( ! $input->getOption( 'no-autocomplete' ) ) {
-			$question->setAutocompleterValues( \array_column( get_pressable_sites() ?? array(), 'url' ) );
+			$question->setAutocompleterValues( \array_column( get_pressable_sites( include_aliases: true ) ?? array(), 'url' ) );
 		}
 
 		return $this->getHelper( 'question' )->ask( $input, $output, $question );

--- a/commands/Pressable_Site_Collaborator_Create.php
+++ b/commands/Pressable_Site_Collaborator_Create.php
@@ -102,7 +102,7 @@ final class Pressable_Site_Collaborator_Create extends Command {
 	private function prompt_site_input( InputInterface $input, OutputInterface $output ): ?string {
 		$question = new Question( '<question>Enter the domain or Pressable site ID to create the collaborator on:</question> ' );
 		if ( ! $input->getOption( 'no-autocomplete' ) ) {
-			$question->setAutocompleterValues( array_column( get_pressable_sites() ?? array(), 'url' ) );
+			$question->setAutocompleterValues( \array_column( get_pressable_sites( include_aliases: true ) ?? array(), 'url' ) );
 		}
 
 		return $this->getHelper( 'question' )->ask( $input, $output, $question );

--- a/commands/Pressable_Site_Collaborator_Delete.php
+++ b/commands/Pressable_Site_Collaborator_Delete.php
@@ -181,7 +181,7 @@ final class Pressable_Site_Collaborator_Delete extends Command {
 	private function prompt_site_input( InputInterface $input, OutputInterface $output ): ?string {
 		$question = new Question( '<question>Enter the site ID or URL to delete the collaborator from:</question> ' );
 		if ( ! $input->getOption( 'no-autocomplete' ) ) {
-			$question->setAutocompleterValues( array_column( get_pressable_sites() ?? array(), 'url' ) );
+			$question->setAutocompleterValues( \array_column( get_pressable_sites( include_aliases: true ) ?? array(), 'url' ) );
 		}
 
 		return $this->getHelper( 'question' )->ask( $input, $output, $question );

--- a/commands/Pressable_Site_Domain_Add.php
+++ b/commands/Pressable_Site_Domain_Add.php
@@ -199,7 +199,7 @@ final class Pressable_Site_Domain_Add extends Command {
 	private function prompt_site_input( InputInterface $input, OutputInterface $output ): ?string {
 		$question = new Question( '<question>Enter the domain or Pressable site ID to add the domain to:</question> ' );
 		if ( ! $input->getOption( 'no-autocomplete' ) ) {
-			$question->setAutocompleterValues( \array_column( get_pressable_sites() ?? array(), 'url' ) );
+			$question->setAutocompleterValues( \array_column( get_pressable_sites( include_aliases: true ) ?? array(), 'url' ) );
 		}
 
 		return $this->getHelper( 'question' )->ask( $input, $output, $question );

--- a/commands/Pressable_Site_Icon_Upload.php
+++ b/commands/Pressable_Site_Icon_Upload.php
@@ -121,7 +121,7 @@ final class Pressable_Site_Icon_Upload extends Command {
 	private function prompt_site_input( InputInterface $input, OutputInterface $output ): ?string {
 		$question = new Question( '<question>Enter the domain or Pressable site ID to upload the icon to:</question> ' );
 		if ( ! $input->getOption( 'no-autocomplete' ) ) {
-			$question->setAutocompleterValues( \array_column( get_pressable_sites() ?? array(), 'url' ) );
+			$question->setAutocompleterValues( \array_column( get_pressable_sites( include_aliases: true ) ?? array(), 'url' ) );
 		}
 
 		return $this->getHelper( 'question' )->ask( $input, $output, $question );

--- a/commands/Pressable_Site_PHP_Errors_List.php
+++ b/commands/Pressable_Site_PHP_Errors_List.php
@@ -206,7 +206,7 @@ final class Pressable_Site_PHP_Errors_List extends Command {
 	private function prompt_site_input( InputInterface $input, OutputInterface $output ): ?string {
 		$question = new Question( '<question>Enter the site ID or URL to display the errors for:</question> ' );
 		if ( ! $input->getOption( 'no-autocomplete' ) ) {
-			$question->setAutocompleterValues( \array_column( get_pressable_sites() ?? array(), 'url' ) );
+			$question->setAutocompleterValues( \array_column( get_pressable_sites( include_aliases: true ) ?? array(), 'url' ) );
 		}
 
 		return $this->getHelper( 'question' )->ask( $input, $output, $question );

--- a/commands/Pressable_Site_SFTP_User_Password_Rotate.php
+++ b/commands/Pressable_Site_SFTP_User_Password_Rotate.php
@@ -193,7 +193,7 @@ final class Pressable_Site_SFTP_User_Password_Rotate extends Command {
 	private function prompt_site_input( InputInterface $input, OutputInterface $output ): ?string {
 		$question = new Question( '<question>Enter the site ID or URL to rotate the SFTP user password on:</question> ' );
 		if ( ! $input->getOption( 'no-autocomplete' ) ) {
-			$question->setAutocompleterValues( \array_column( get_pressable_sites() ?? array(), 'url' ) );
+			$question->setAutocompleterValues( \array_column( get_pressable_sites( include_aliases: true ) ?? array(), 'url' ) );
 		}
 
 		return $this->getHelper( 'question' )->ask( $input, $output, $question );

--- a/commands/Pressable_Site_Shell_Open.php
+++ b/commands/Pressable_Site_Shell_Open.php
@@ -129,7 +129,7 @@ final class Pressable_Site_Shell_Open extends Command {
 	private function prompt_site_input( InputInterface $input, OutputInterface $output ): ?string {
 		$question = new Question( '<question>Enter the domain or Pressable site ID to connect to:</question> ' );
 		if ( ! $input->getOption( 'no-autocomplete' ) ) {
-			$question->setAutocompleterValues( \array_column( get_pressable_sites() ?? array(), 'url' ) );
+			$question->setAutocompleterValues( \array_column( get_pressable_sites( include_aliases: true ) ?? array(), 'url' ) );
 		}
 
 		return $this->getHelper( 'question' )->ask( $input, $output, $question );

--- a/commands/Pressable_Site_WP_CLI_Command_Run.php
+++ b/commands/Pressable_Site_WP_CLI_Command_Run.php
@@ -160,7 +160,7 @@ final class Pressable_Site_WP_CLI_Command_Run extends Command {
 	private function prompt_site_input( InputInterface $input, OutputInterface $output ): ?string {
 		$question = new Question( '<question>Enter the domain or Pressable site ID to run the WP-CLI command on:</question> ' );
 		if ( ! $input->getOption( 'no-autocomplete' ) ) {
-			$question->setAutocompleterValues( \array_column( get_pressable_sites() ?? array(), 'url' ) );
+			$question->setAutocompleterValues( \array_column( get_pressable_sites( include_aliases: true ) ?? array(), 'url' ) );
 		}
 
 		return $this->getHelper( 'question' )->ask( $input, $output, $question );

--- a/commands/Pressable_Site_WP_User_Password_Rotate.php
+++ b/commands/Pressable_Site_WP_User_Password_Rotate.php
@@ -173,7 +173,7 @@ final class Pressable_Site_WP_User_Password_Rotate extends Command {
 	private function prompt_site_input( InputInterface $input, OutputInterface $output ): ?string {
 		$question = new Question( '<question>Enter the site ID or URL to rotate the WP user password on:</question> ' );
 		if ( ! $input->getOption( 'no-autocomplete' ) ) {
-			$question->setAutocompleterValues( \array_column( get_pressable_sites() ?? array(), 'url' ) );
+			$question->setAutocompleterValues( \array_column( get_pressable_sites( include_aliases: true ) ?? array(), 'url' ) );
 		}
 
 		return $this->getHelper( 'question' )->ask( $input, $output, $question );

--- a/includes/functions-pressable.php
+++ b/includes/functions-pressable.php
@@ -30,12 +30,36 @@ function get_pressable_collaborators(): ?array {
  * @return  stdClass[]|null
  */
 function get_pressable_sites( array $params = array() ): ?array {
+	global $site_aliases;
+	// Set as an empty array if not set.
+	$site_aliases = $site_aliases ?? array();
+
 	$endpoint = 'sites';
 	if ( ! empty( $params ) ) {
 		$endpoint .= '?' . http_build_query( $params );
 	}
 
-	return API_Helper::make_pressable_request( $endpoint )?->records;
+	$sites = API_Helper::make_pressable_request( $endpoint )?->records;
+
+	// If we dont have any sites, return early.
+	if ( is_null( $sites ) ) {
+		return null;
+	}
+
+	// Add any aliases to the site list.
+	foreach ( $sites as $site ) {
+		if ( strpos( $site->url, 'www' ) === 0 ) {
+			// Copy the site to the end of the array without the www.
+			$copy      = clone $site;
+			$copy->url = substr( $site->url, 4 ) . ' → ' . $site->url;
+			$sites[]   = $copy;
+
+			// Add to the aliases array.
+			$site_aliases[ $copy->url ] = $site->url;
+		}
+	}
+
+	return $sites;
 }
 
 /**
@@ -46,6 +70,7 @@ function get_pressable_sites( array $params = array() ): ?array {
  * @return  stdClass|null
  */
 function get_pressable_root_site( string $site_id_or_url ): ?stdClass {
+	$site_id_or_url = pressable_resolve_site_alias( $site_id_or_url );
 	return API_Helper::make_pressable_request( "sites/$site_id_or_url/root" );
 }
 
@@ -59,7 +84,8 @@ function get_pressable_root_site( string $site_id_or_url ): ?stdClass {
  * @return  stdClass[]|null
  */
 function get_pressable_related_sites( string $site_id_or_url, bool $find_root = true, ?callable $node_generator = null ): ?array {
-	$related_sites = API_Helper::make_pressable_request( "sites/$site_id_or_url/related?find_root=$find_root" );
+	$site_id_or_url = pressable_resolve_site_alias( $site_id_or_url );
+	$related_sites  = API_Helper::make_pressable_request( "sites/$site_id_or_url/related?find_root=$find_root" );
 	if ( ! is_array( $related_sites ) ) {
 		return null;
 	}
@@ -83,6 +109,7 @@ function get_pressable_related_sites( string $site_id_or_url, bool $find_root = 
  * @return  stdClass|null
  */
 function get_pressable_site( string $site_id_or_url ): ?stdClass {
+	$site_id_or_url = pressable_resolve_site_alias( $site_id_or_url );
 	$site_id_or_url = is_numeric( $site_id_or_url ) ? (string) $site_id_or_url : urlencode( $site_id_or_url );
 	return API_Helper::make_pressable_request( "sites/$site_id_or_url" );
 }
@@ -95,6 +122,7 @@ function get_pressable_site( string $site_id_or_url ): ?stdClass {
  * @return  stdClass|null
  */
 function convert_pressable_site( string $site_id_or_url ): ?stdClass {
+	$site_id_or_url = pressable_resolve_site_alias( $site_id_or_url );
 	return API_Helper::make_pressable_request( "sites/$site_id_or_url/convert", 'POST' );
 }
 
@@ -107,7 +135,8 @@ function convert_pressable_site( string $site_id_or_url ): ?stdClass {
  * @return  stdClass[]|null
  */
 function get_pressable_site_notes( string $site_id_or_url, array $params = array() ): ?array {
-	$endpoint = "site-notes/$site_id_or_url";
+	$site_id_or_url = pressable_resolve_site_alias( $site_id_or_url );
+	$endpoint       = "site-notes/$site_id_or_url";
 	if ( ! empty( $params ) ) {
 		$endpoint .= '?' . http_build_query( $params );
 	}
@@ -125,6 +154,7 @@ function get_pressable_site_notes( string $site_id_or_url, array $params = array
  * @return  stdClass|null
  */
 function create_pressable_site_note( string $site_id_or_url, string $subject, string $content ): ?stdClass {
+	$site_id_or_url = pressable_resolve_site_alias( $site_id_or_url );
 	return API_Helper::make_pressable_request(
 		"site-notes/$site_id_or_url",
 		'POST',
@@ -143,7 +173,8 @@ function create_pressable_site_note( string $site_id_or_url, string $subject, st
  * @return  stdClass|null
  */
 function get_pressable_site_deployhq_config( string $site_id_or_url ): ?stdClass {
-	$config = API_Helper::make_pressable_request( "sites/$site_id_or_url/deployhq" );
+	$site_id_or_url = pressable_resolve_site_alias( $site_id_or_url );
+	$config         = API_Helper::make_pressable_request( "sites/$site_id_or_url/deployhq" );
 	if ( is_null( $config ) ) {
 		return null;
 	}
@@ -164,6 +195,7 @@ function get_pressable_site_deployhq_config( string $site_id_or_url ): ?stdClass
  * @return  stdClass|null
  */
 function update_pressable_site_deployhq_project( string $site_id_or_url, string $project ): ?stdClass {
+	$site_id_or_url = pressable_resolve_site_alias( $site_id_or_url );
 	return API_Helper::make_pressable_request( "sites/$site_id_or_url/deployhq", 'POST', array( 'project' => $project ) );
 }
 
@@ -177,6 +209,7 @@ function update_pressable_site_deployhq_project( string $site_id_or_url, string 
  * @return  stdClass|null
  */
 function update_pressable_site_deployhq_server( string $site_id_or_url, string $project, string $server ): ?stdClass {
+	$site_id_or_url = pressable_resolve_site_alias( $site_id_or_url );
 	return API_Helper::make_pressable_request(
 		"sites/$site_id_or_url/deployhq",
 		'POST',
@@ -196,6 +229,7 @@ function update_pressable_site_deployhq_server( string $site_id_or_url, string $
  * @return  stdClass|null
  */
 function create_pressable_site_collaborator( string $site_id_or_url, string $collaborator_email ): ?stdClass {
+	$site_id_or_url = pressable_resolve_site_alias( $site_id_or_url );
 	return API_Helper::make_pressable_request( "site-collaborators/$site_id_or_url", 'POST', array( 'email' => $collaborator_email ) );
 }
 
@@ -207,6 +241,7 @@ function create_pressable_site_collaborator( string $site_id_or_url, string $col
  * @return  stdClass[]|null
  */
 function get_pressable_site_sftp_users( string $site_id_or_url ): ?array {
+	$site_id_or_url = pressable_resolve_site_alias( $site_id_or_url );
 	return API_Helper::make_pressable_request( "site-sftp-users/$site_id_or_url" )?->records;
 }
 
@@ -218,6 +253,7 @@ function get_pressable_site_sftp_users( string $site_id_or_url ): ?array {
  * @return  stdClass[]|null
  */
 function get_pressable_site_domains( string $site_id_or_url ): ?array {
+	$site_id_or_url = pressable_resolve_site_alias( $site_id_or_url );
 	return API_Helper::make_pressable_request( "site-domains/$site_id_or_url" )?->records;
 }
 
@@ -244,6 +280,7 @@ function get_pressable_site_primary_domain( string $site_id_or_url ): ?stdClass 
  * @return  stdClass|null
  */
 function set_pressable_site_primary_domain( string $site_id_or_url, string $domain_id ): ?stdClass {
+	$site_id_or_url = pressable_resolve_site_alias( $site_id_or_url );
 	return API_Helper::make_pressable_request( "site-domains/$site_id_or_url/$domain_id", 'PUT' );
 }
 
@@ -256,6 +293,7 @@ function set_pressable_site_primary_domain( string $site_id_or_url, string $doma
  * @return  stdClass[]|null
  */
 function add_pressable_site_domain( string $site_id_or_url, string $domain ): ?array {
+	$site_id_or_url = pressable_resolve_site_alias( $site_id_or_url );
 	return API_Helper::make_pressable_request( "site-domains/$site_id_or_url", 'POST', array( 'name' => $domain ) )?->records;
 }
 
@@ -267,6 +305,7 @@ function add_pressable_site_domain( string $site_id_or_url, string $domain ): ?a
  * @return  stdClass|null
  */
 function get_pressable_site_sftp_owner( string $site_id_or_url ): ?stdClass {
+	$site_id_or_url = pressable_resolve_site_alias( $site_id_or_url );
 	return API_Helper::make_pressable_request( "site-sftp-users/$site_id_or_url/owner" );
 }
 
@@ -279,6 +318,7 @@ function get_pressable_site_sftp_owner( string $site_id_or_url ): ?stdClass {
  * @return  object|null
  */
 function get_pressable_site_sftp_user( string $site_id_or_url, string $uname_or_email_or_id ): ?stdClass {
+	$site_id_or_url = pressable_resolve_site_alias( $site_id_or_url );
 	return API_Helper::make_pressable_request( "site-sftp-users/$site_id_or_url/$uname_or_email_or_id" );
 }
 
@@ -291,6 +331,7 @@ function get_pressable_site_sftp_user( string $site_id_or_url, string $uname_or_
  * @return  stdClass|null
  */
 function rotate_pressable_site_sftp_user_password( string $site_id_or_url, string $username ): ?stdClass {
+	$site_id_or_url = pressable_resolve_site_alias( $site_id_or_url );
 	return API_Helper::make_pressable_request( "site-sftp-users/$site_id_or_url/$username/rotate-password", 'POST' );
 }
 
@@ -302,6 +343,7 @@ function rotate_pressable_site_sftp_user_password( string $site_id_or_url, strin
  * @return  stdClass[]|null
  */
 function get_pressable_site_wp_users( string $site_id_or_url ): ?array {
+	$site_id_or_url = pressable_resolve_site_alias( $site_id_or_url );
 	return API_Helper::make_pressable_request( "site-wp-users/$site_id_or_url" )?->records;
 }
 
@@ -314,6 +356,7 @@ function get_pressable_site_wp_users( string $site_id_or_url ): ?array {
  * @return  object|null
  */
 function get_pressable_site_wp_user( string $site_id_or_url, string $user ): ?stdClass {
+	$site_id_or_url = pressable_resolve_site_alias( $site_id_or_url );
 	return API_Helper::make_pressable_request( "site-wp-users/$site_id_or_url/$user" );
 }
 
@@ -326,7 +369,8 @@ function get_pressable_site_wp_user( string $site_id_or_url, string $user ): ?st
  * @return  stdClass|null
  */
 function rotate_pressable_site_wp_user_password( string $site_id_or_url, string $user ): ?stdClass {
-	$credentials = API_Helper::make_pressable_request( "site-wp-users/$site_id_or_url/$user/rotate-password", 'POST' );
+	$site_id_or_url = pressable_resolve_site_alias( $site_id_or_url );
+	$credentials    = API_Helper::make_pressable_request( "site-wp-users/$site_id_or_url/$user/rotate-password", 'POST' );
 	if ( is_null( $credentials ) || is_null( $credentials->password ) ) {
 		$exit_code = run_pressable_site_wp_cli_command( $site_id_or_url, "user reset-password $user --skip-email --porcelain" );
 		if ( Command::SUCCESS === $exit_code ) {
@@ -372,7 +416,8 @@ function get_pressable_datacenters(): ?array {
  *
  * @return  true|null
  */
-function delete_pressable_site_collaborator( string $site_id_or_url, string $collaborator, bool $delete_wp_user = false ): true|null {
+function delete_pressable_site_collaborator( string $site_id_or_url, string $collaborator, bool $delete_wp_user = false ): true | null {
+	$site_id_or_url = pressable_resolve_site_alias( $site_id_or_url );
 	return API_Helper::make_pressable_request( "site-collaborators/$site_id_or_url/$collaborator", 'DELETE', array( 'delete_wp_user' => $delete_wp_user ) );
 }
 
@@ -406,6 +451,7 @@ function create_pressable_site( string $name, string $datacenter ): ?stdClass {
  * @return  stdClass|null
  */
 function create_pressable_site_clone( string $site_id_or_url, string $name, ?string $datacenter = null, bool $staging = true ): ?stdClass {
+	$site_id_or_url = pressable_resolve_site_alias( $site_id_or_url );
 	return API_Helper::make_pressable_request(
 		'sites',
 		'POST',
@@ -428,6 +474,7 @@ function create_pressable_site_clone( string $site_id_or_url, string $name, ?str
  * @return  stdClass|null
  */
 function wait_on_pressable_site_state( string $site_id_or_url, string $state, OutputInterface $output ): ?stdClass {
+	$site_id_or_url = pressable_resolve_site_alias( $site_id_or_url );
 	$output->writeln( "<comment>Waiting for Pressable site $site_id_or_url to exit $state state.</comment>" );
 
 	$progress_bar = new ProgressBar( $output );
@@ -458,6 +505,7 @@ function wait_on_pressable_site_state( string $site_id_or_url, string $state, Ou
  * @return  SSH2|null
  */
 function wait_on_pressable_site_ssh( string $site_id_or_url, OutputInterface $output ): ?SSH2 {
+	$site_id_or_url = pressable_resolve_site_alias( $site_id_or_url );
 	$output->writeln( "<comment>Waiting for Pressable site $site_id_or_url to accept SSH connections.</comment>" );
 
 	$progress_bar = new ProgressBar( $output );
@@ -721,6 +769,23 @@ function get_pressable_site_php_logs( string $site_id, ?string $status = null, i
 	} while ( ! $page->paging->is_last_page && 0 < $max_entries );
 
 	return array_merge( ...$logs );
+}
+
+/**
+ * Maybe Resolve an aliases site name.
+ *
+ * @param   string $site_name The site name to resolve.
+ *
+ * @return  string
+ */
+function pressable_resolve_site_alias( string $site_name ): string {
+	global $site_aliases;
+
+	if ( is_array( $site_aliases ) && array_key_exists( $site_name, $site_aliases ) ) {
+		return $site_aliases[ $site_name ];
+	}
+
+	return $site_name;
 }
 
 // endregion


### PR DESCRIPTION
…sites starting www.url to be found just searching with url

# This is POC

Adds an alias for all sites that start with www., so they can be found without the www.

It works by looping over all sites when fetched from Pressable API and adding an alias.
When we access the URL or ID in handlers, we check over a global to see if we need to resolve it

```cli
 ______                                ______     _
/\__  _\                              /\  ___\  /' \
\/_/\ \/    __     __      ___ ___    \ \ \__/ /\_, \
   \ \ \  /'__`\ /'__`\  /' __` __`\   \ \___``\/_/\ \
    \ \ \/\  __//\ \L\.\_/\ \/\ \/\ \   \/\ \L\ \ \ \ \
     \ \_\ \____\ \__/.\_\ \_\ \_\ \_\   \ \____/  \ \_\
      \/_/\/____/\/__/\/_/\/_/\/_/\/_/    \/___/    \/_/


Running in developer mode. Skipping update check.
Enter the domain or Pressable site ID to create the collaborator on: some-url.com → www.some-url.com
```
> In this example, access to www.some-url.com would granted but found by typing just `some-`

I'm not fully familiar with other commands, but the ones I checked use the same autocomplete, so I added the resolver to most of the command handlers.
