### PR TITLE
Add comma separated to multiple option

### DIFF
--- a/commands/Jetpack_Site_Plugins_Export.php
+++ b/commands/Jetpack_Site_Plugins_Export.php
@@ -61,7 +61,7 @@ final class Jetpack_Site_Plugins_Export extends Command {
 
 		$this->addArgument( 'site', InputArgument::OPTIONAL, 'Domain or WPCOM ID of the site to list the plugins for.' );
 
-		$this->addOption( 'multiple', null, InputOption::VALUE_REQUIRED, 'Determines whether the `site` argument is optional or not. Accepted value is `all`.' )
+		$this->addOption( 'multiple', null, InputOption::VALUE_REQUIRED, 'Determines whether the `site` argument is optional or not. Accepted values are `all` or a comma-separated list of site IDs or domains.' )
 			->addOption( 'destination', 'd', InputOption::VALUE_REQUIRED, 'The destination file to export the plugins to.' );
 	}
 
@@ -73,45 +73,25 @@ final class Jetpack_Site_Plugins_Export extends Command {
 		$this->destination = get_string_input( $input, 'destination', fn() => $this->prompt_destination_input( $input, $output ) );
 		$this->stream      = get_file_handle( $this->destination, 'csv' );
 
-		// If processing a given site, retrieve it from the input.
-		$multiple = get_enum_input( $input, 'multiple', array( 'all' ) );
-		if ( 'all' !== $multiple ) {
+		$multiple = $input->getOption( 'multiple' );
+		if ( null === $multiple ) {
+			// Single site operation
 			$site = get_wpcom_site_input( $input, fn() => $this->prompt_site_input( $input, $output ) );
 			$input->setArgument( 'site', $site );
-
 			$this->sites = array(
 				$site->ID => (object) array(
 					'userblog_id' => $site->ID,
 					'siteurl'     => $site->URL, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 				),
 			);
+		} elseif ( 'all' === $multiple ) {
+			// All sites
+			$this->sites = $this->get_all_sites();
 		} else {
-			$this->sites = \array_filter(
-				\array_map(
-					static function ( \stdClass $site ) {
-						$exclude_domains = array(
-							'mystagingwebsite.com',
-							'go-vip.co',
-							'wpcomstaging.com',
-							'wpengine.com',
-							'jurassic.ninja',
-							'atomicsites.blog',
-							'woocommerce.com',
-							'woo.com',
-						);
-
-						foreach ( $exclude_domains as $exclude_domain ) {
-							if ( \str_contains( $site->siteurl, $exclude_domain ) ) {
-								return null;
-							}
-						}
-
-						return $site;
-					},
-					get_wpcom_jetpack_sites()
-				)
-			);
+			// Comma-separated list of sites
+			$this->sites = $this->get_sites_from_multiple_input( $multiple );
 		}
+
 		$output->writeln( '<comment>Successfully fetched ' . \count( $this->sites ) . ' Jetpack site(s).</comment>' );
 
 		// Compile the list of plugins to process.
@@ -182,6 +162,63 @@ final class Jetpack_Site_Plugins_Export extends Command {
 		}
 
 		return $this->getHelper( 'question' )->ask( $input, $output, $question );
+	}
+
+	/**
+	 * Get all sites, excluding certain domains.
+	 *
+	 * @return array
+	 */
+	private function get_all_sites(): array {
+		return \array_filter(
+			\array_map(
+				static function ( \stdClass $site ) {
+					$exclude_domains = array(
+						'mystagingwebsite.com',
+						'go-vip.co',
+						'wpcomstaging.com',
+						'wpengine.com',
+						'jurassic.ninja',
+						'atomicsites.blog',
+						'woocommerce.com',
+						'woo.com',
+					);
+
+					foreach ( $exclude_domains as $exclude_domain ) {
+						if ( \str_contains( $site->siteurl, $exclude_domain ) ) {
+							return null;
+						}
+					}
+
+					return $site;
+				},
+				get_wpcom_jetpack_sites()
+			)
+		);
+	}
+
+	/**
+	 * Get sites from the multiple input option.
+	 *
+	 * @param   string $multiple The multiple input option.
+	 *
+	 * @return  array
+	 */
+	private function get_sites_from_multiple_input( string $multiple ): array {
+		// Comma-separated list of sites
+		$site_identifiers = array_map( 'trim', explode( ',', $multiple ) );
+		$sites            = array();
+		foreach ( $site_identifiers as $identifier ) {
+			$site = get_wpcom_site( $identifier );
+			if ( $site ) {
+				$sites[ $site->ID ] = (object) array(
+					'userblog_id' => $site->ID,
+					'siteurl'     => $site->URL, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				);
+			}
+		}
+
+		return $sites;
 	}
 
 	// endregion

--- a/commands/Pressable_Site_Collaborator_Delete.php
+++ b/commands/Pressable_Site_Collaborator_Delete.php
@@ -56,7 +56,7 @@ final class Pressable_Site_Collaborator_Delete extends Command {
 		$this->addArgument( 'email', InputArgument::REQUIRED, 'The email address of the collaborator to delete.' )
 			->addArgument( 'site', InputArgument::OPTIONAL, 'The site ID or domain to delete the collaborator from.' );
 
-		$this->addOption( 'multiple', null, InputOption::VALUE_REQUIRED, 'Determines whether the `site` argument is optional or not. Accepted values are `related` and `all`.' )
+		$this->addOption( 'multiple', null, InputOption::VALUE_REQUIRED, 'Process multiple sites. Use `all` for all sites, `related` for related sites, or a comma-separated list of site IDs or domains.' )
 			->addOption( 'delete-wp-user', null, InputOption::VALUE_NONE, 'Also delete the WordPress user associated with the collaborator.' );
 	}
 
@@ -70,18 +70,19 @@ final class Pressable_Site_Collaborator_Delete extends Command {
 		$this->email = get_email_input( $input, fn() => $this->prompt_email_input( $input, $output ) );
 		$input->setArgument( 'email', $this->email );
 
-		// If processing a given site, retrieve it from the input.
-		$multiple = get_enum_input( $input, 'multiple', array( 'all', 'related' ) );
-		if ( 'all' !== $multiple ) {
+		// Process the multiple option
+		$multiple = $input->getOption( 'multiple' );
+		if ( null === $multiple ) {
 			$site = get_pressable_site_input( $input, fn() => $this->prompt_site_input( $input, $output ) );
 			$input->setArgument( 'site', $site );
-
-			$sites = match ( $multiple ) {
-				'related' => \array_merge( ...get_pressable_related_sites( $site->id ) ),
-				default => array( $site ),
-			};
+			$sites = array( $site );
+		} elseif ( 'all' === $multiple ) {
+			$sites = get_pressable_sites();
+		} elseif ( 'related' === $multiple ) {
+			$site  = get_pressable_site_input( $input, fn() => $this->prompt_site_input( $input, $output ) );
+			$sites = array_merge( ...get_pressable_related_sites( $site->id ) );
 		} else {
-			$sites = null;
+			$sites = $this->get_sites_from_multiple_input( $multiple );
 		}
 
 		// Compile the list of collaborators to process.
@@ -185,6 +186,18 @@ final class Pressable_Site_Collaborator_Delete extends Command {
 		}
 
 		return $this->getHelper( 'question' )->ask( $input, $output, $question );
+	}
+
+	/**
+	 * Get sites from the multiple input option.
+	 *
+	 * @param   string $multiple The multiple input option.
+	 *
+	 * @return array
+	 */
+	private function get_sites_from_multiple_input( string $multiple ): array {
+		$site_identifiers = array_map( 'trim', explode( ',', $multiple ) );
+		return array_filter( array_map( fn( $identifier ) => get_pressable_site( $identifier ), $site_identifiers ) );
 	}
 
 	// endregion

--- a/includes/functions-wpcom.php
+++ b/includes/functions-wpcom.php
@@ -509,7 +509,7 @@ function wait_until_jetpack_token_regenerated( string $site_id_or_url, OutputInt
 	$output->writeln( '<fg=magenta;options=bold>Pinging site to regenerate Jetpack user token. This will cause an error and the token will be regenerated.</>' );
 	$output->writeln( "<comment>Waiting for WordPress.com site $site_id_or_url to regenerate the Jetpack user token.</comment>" );
 
-	$regenerated = false;
+	$regenerated  = false;
 	$progress_bar = new ProgressBar( $output );
 	$progress_bar->start();
 	$progress_bar->advance();


### PR DESCRIPTION
### Changes proposed in this PR

- Add support for a comma-separated list of sites for the `--multiple` parameter

### Testing

1. Run any command that allows the `--multiple` option with comma-separated list lie `--multiple=site1.com,site2.com` etc.
2. The command should run only on the listed sites.