### PR TITLE
Replace images with placeholders before sending to repo

### DIFF
--- a/commands/GitHub_Pattern_To_Repo_Export.php
+++ b/commands/GitHub_Pattern_To_Repo_Export.php
@@ -6,6 +6,7 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\Output;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
@@ -41,6 +42,13 @@ final class GitHub_Pattern_To_Repo_Export extends Command {
 	protected ?string $category_slug = null;
 
 	/**
+	 * Whether to preserve images in the pattern.
+	 *
+	 * @var bool
+	 */
+	protected bool $preserve_images = false;
+
+	/**
 	 * {@inheritDoc}
 	 */
 	protected function configure() {
@@ -49,14 +57,14 @@ final class GitHub_Pattern_To_Repo_Export extends Command {
 			->setHelp( 'This command exports a specified block pattern into a category within a GitHub repository.' )
 			->addArgument( 'site', InputArgument::REQUIRED, 'ID or URL of the Pressable site to run the command on.' )
 			->addArgument( 'pattern-name', InputArgument::REQUIRED, 'The unique identifier of the block pattern to export (e.g., `namespace/pattern-name`).' )
-			->addArgument( 'category-slug', InputArgument::REQUIRED, 'The slug of the category under which the pattern should be exported. It should be lowercase with hyphens instead of spaces (e.g., `featured-patterns`).' );
+			->addArgument( 'category-slug', InputArgument::REQUIRED, 'The slug of the category under which the pattern should be exported. It should be lowercase with hyphens instead of spaces (e.g., `featured-patterns`).' )
+			->addOption( 'preserve-images', null, InputOption::VALUE_NONE, 'Skip substition of placeholder images.' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
 	protected function initialize( InputInterface $input, OutputInterface $output ): void {
-
 		// Retrieve the given site.
 		$this->pressable_site = get_pressable_site_input( $input, fn() => $this->prompt_site_input( $input, $output ) );
 		$output->writeln( "<comment>Site {$this->pressable_site->id}: {$this->pressable_site->url}</comment>", Output::VERBOSITY_VERBOSE );
@@ -66,18 +74,21 @@ final class GitHub_Pattern_To_Repo_Export extends Command {
 
 		// Check if the pattern name was already provided as an argument. If not, prompt the user for it.
 		$this->pattern_name = get_string_input( $input, 'pattern-name', fn() => $this->prompt_pattern_name_input( $input, $output ) );
-		$output->writeln( "<comment>Pattern name: {$this->pattern_name}</comment>", Output::VERBOSITY_DEBUG );
+		$output->writeln( "<comment>Pattern name: {$this->pattern_name}</comment>", Output::VERBOSITY_VERBOSE );
 
 		// Check if the category slug was already provided as an argument. If not, prompt the user for it.
 		$this->category_slug = slugify( get_string_input( $input, 'category-slug', fn() => $this->prompt_category_slug_input( $input, $output ) ) );
 		$output->writeln( "<comment>Category slug: {$this->category_slug}</comment>", Output::VERBOSITY_VERBOSE );
+
+		// Set preserve-images option.
+		$this->preserve_images = get_bool_input( $input, 'preserve-images' );
+		$output->writeln( sprintf( '<comment>Preserve images: %s</comment>', ( $this->preserve_images ? 'Yes' : 'No' ) ), Output::VERBOSITY_VERBOSE );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
 	protected function execute( InputInterface $input, OutputInterface $output ): int {
-
 		$output->writeln( "<fg=magenta;options=bold>Exporting {$this->pattern_name} (Category: {$this->category_slug}) from {$this->pressable_site->displayName} (ID {$this->pressable_site->id}, URL {$this->pressable_site->url})</>" );
 
 		// Upload script.
@@ -100,15 +111,37 @@ final class GitHub_Pattern_To_Repo_Export extends Command {
 
 		// Run script.
 		$result = $ssh_connection->exec( sprintf( 'wp --skip-plugins --skip-theme eval-file /htdocs/pattern-extract.php %s', escapeshellarg( $this->pattern_name ) ) );
-		$output->writeln( "<comment>Pattern extraction result: {$result}</comment>", Output::VERBOSITY_DEBUG );
-
+		$output->writeln( '<comment>Pattern extraction result: ' . var_export( $result, true ) . '</comment>', Output::VERBOSITY_DEBUG );
 		// Delete script.
 		$ssh_connection->exec( 'rm /htdocs/pattern-extract.php' );
 
 		if ( ! empty( $result ) ) {
 
+			// Replace placeholder images with actual images.
+			if ( ! $this->preserve_images ) {
+				$decoded = decode_json_content( $result );
+				$output->writeln( sprintf( '<comment>Decoded content: %s</comment>', var_export( $decoded, true ) ), Output::VERBOSITY_DEBUG );
+				$content = $decoded->content ?? '';
+				$output->writeln( "<comment>Original content: {$content}</comment>", Output::VERBOSITY_DEBUG );
+				if ( ! empty( $content ) ) {
+					$replacements = array();
+					$matches      = array();
+					preg_match_all( '/<img[^>]+src="([^"]+)"[^>]*>/i', $content, $matches );
+					foreach ( $matches[1] as $image_url ) {
+						// Download the image and determine its size.
+						$image_data = $this->get_image_details( $image_url );
+						// Replace the image URL with the placeholder image URL on picsum.photos.
+						$replacements[ $image_url ] = 'https://picsum.photos/' . $image_data['width'] . '/' . $image_data['height'];
+					}
+					$decoded->content = str_replace( array_keys( $replacements ), array_values( $replacements ), $content );
+					$output->writeln( "<comment>Updated content: {$content}</comment>", Output::VERBOSITY_DEBUG );
+					$result = encode_json_content( $decoded );
+					$output->writeln( "<comment>Re-encoded result: {$result}</comment>", Output::VERBOSITY_DEBUG );
+				}
+			}
 			// Temporary directory to clone the repository
 			$temp_dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid( 'team51-patterns_', true );
+			$output->writeln( "<comment>Local repo clone: {$temp_dir}</comment>", Output::VERBOSITY_VERBOSE );
 			$repo_url = 'git@github.com:a8cteam51/team51-patterns.git';
 
 			// Clone the repository
@@ -223,5 +256,37 @@ final class GitHub_Pattern_To_Repo_Export extends Command {
 			$category_slug = $this->getHelper( 'question' )->ask( $input, $output, $question );
 
 			return $category_slug;
+	}
+
+	/**
+	 * Downloads an image from a URL and returns its dimensions and extension.
+	 *
+	 * @param string $image_url The URL of the image to download.
+	 *
+	 * @return array
+	 */
+	private function get_image_details( $image_url ) {
+		// Download the image
+		$image_data = file_get_contents( $image_url );
+		if ( false === $image_data ) {
+			throw new Exception( "Failed to download image from URL: $image_url" );
+		}
+
+		// Determine the image size
+		$image_size = getimagesizefromstring( $image_data );
+		if ( false === $image_size ) {
+			throw new Exception( "Failed to determine the size of the image from URL: $image_url" );
+		}
+
+		// Determine the image extension
+		$extension = image_type_to_extension( $image_size[2], false );
+
+		return array(
+			'data'      => $image_data,
+			'width'     => $image_size[0],
+			'height'    => $image_size[1],
+			'mime_type' => $image_size['mime'],
+			'extension' => $extension,
+		);
 	}
 }


### PR DESCRIPTION
Fixes #42 

Automatically replaces images in block patterns with similarly sized images from picsum.photos. It does this by:
- Decoding the downloaded JSON file.
- Locating all image tags.
- Downloading the image and determining its dimensions.
- Replacing the `src` URL with the equivalent sized photo from picsum.photos.
- Re-encoding and saving the JSON.

I also added several debug outputs that I left in, but with debug verbosity.