### PR TITLE
Update platform PHP version to 8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,7 +60,7 @@
       "phpstan/extension-installer": true
     },
     "platform": {
-      "php": "8.2"
+      "php": "8.3"
     }
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "385bc396626408df118b933724e728f9",
+    "content-hash": "b190a9c1bdc9667f337c3ecb523271da",
     "packages": [
         {
             "name": "paragonie/constant_time_encoding",
@@ -3805,7 +3805,7 @@
         "a8cteam51/team51-configs": 20,
         "roave/security-advisories": 20
     },
-    "prefer-stable": true,
+    "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "ext-gd": "*",
@@ -3814,7 +3814,7 @@
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.2"
+        "php": "8.3"
     },
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Fixes error when running CLI:

```
Error running command: composer install --working-dir /Users/taco/team51-cli --no-interaction
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Warning: The lock file is not up to date with the latest changes in composer.json. You may be getting outdated dependencies. It is recommended that you run `composer update` or `composer update <package name>`.
Your lock file does not contain a compatible set of packages. Please run composer update.

  Problem 1
    - a8cteam51/team51-configs is locked to version dev-trunk and an update of this package was not requested.
    - a8cteam51/team51-configs dev-trunk requires php >=8.3 -> your php version (8.2; overridden via config.platform, actual: 8.4.2) does not satisfy that requirement.
```

Update was generated by running `composer config platform.php 8.3` followed by `composer update`