### PR TITLE
jp connection triage command

### DIFF
--- a/commands/Jetpack_Site_Connection_Triage.php
+++ b/commands/Jetpack_Site_Connection_Triage.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace WPCOMSpecialProjects\CLI\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use WPCOMSpecialProjects\CLI\Helper\AutocompleteTrait;
+
+/**
+ * Triages the connection status of a given list of sites
+ */
+#[AsCommand( name: 'jetpack:connection-triage' )]
+final class Jetpack_Site_Connection_triage extends Command {
+	use AutocompleteTrait;
+
+	// region FIELDS AND CONSTANTS
+
+	/**
+	 * WPCOM site definition to fetch the information for.
+	 *
+	 * @var \stdClass|null
+	 */
+	private ?\stdClass $site = null;
+
+	// endregion
+
+	// region INHERITED METHODS
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function configure(): void {
+		$this->setDescription( 'Lists the status of Jetpack modules on a given site.' )
+			->setHelp( 'Use this command to show a list of Jetpack modules on a given site together with their status. This command requires that the given site has an active Jetpack connection to WPCOM.' );
+
+		$this->addArgument( 'csv-path', InputArgument::REQUIRED, 'A path to a CSV with 2 columns, blog ID and url' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( InputInterface $input, OutputInterface $output ): int {
+		$output->writeln( "<fg=magenta;options=bold>Listing Jetpack modules information for {$this->site->name} (ID {$this->site->ID}, URL {$this->site->URL}).</>" );
+
+		// Read in the CSV
+		$csv_path = $input->getArgument( 'csv-path' );
+
+		// For each row in the CSV, check the connection status
+		if ( ! file_exists( $csv_path ) ) {
+			$output->writeln( "<fg=red;options=bold>CSV file not found at {$csv_path}.</>" );
+			return Command::FAILURE;
+		} else {
+			// Read the CSV. Column 1: Site ID, Column 2: Site URL, Column 3: Connection Status
+			$csv = file_get_contents( $csv_path );
+			$csv = explode( "\n", $csv );
+			unset( $csv[0] );
+			$broken_site_data = array();
+			foreach ( $csv as $row ) {
+				$line             = str_getcsv( $row );
+				$site_id          = $line[0];
+				$site_url         = $line[1];
+				$jetpack_endpoint = $site_url . '/wp-json/jetpack/v4';
+
+				//fetch
+				$result = get_remote_content( $site_url );
+				// get the status code
+				$status_code = $result['headers']['http_code'];
+
+				if ( 410 === $status_code && strpos( $site_url, 'mystagingwebsite.com' ) !== false ) {
+					// Probably deactivated
+					$notes = 'Site is probably deactivated';
+					// Check Pressable?
+				} elseif ( 404 === $status_code strpos( $site_url, 'mystagingwebsite.com' ) !== false ) {
+					// probably deleted or Jetpack not installed. Next step is to curl the homepage
+				} elseif ( 500 === $status_code strpos( $site_url, 'mystagingwebsite.com' ) !== false ) {
+					// curl the contents and check for the error message
+
+				}
+
+				// wp-json/jetpack/v4/connection/data
+
+				$broken_site_data[] = array(
+					'site_id'  => $site_id,
+					'site_url' => $site_url,
+					'status'   => $status_code,
+					'notes'    => $notes,
+				);
+			}
+			// Write a new CSV from the array
+
+		}
+
+		return Command::SUCCESS;
+	}
+
+	// endregion
+
+	// region HELPERS
+
+	// endregion
+}

--- a/commands/Jetpack_Site_Connection_Triage.php
+++ b/commands/Jetpack_Site_Connection_Triage.php
@@ -14,19 +14,8 @@ use WPCOMSpecialProjects\CLI\Helper\AutocompleteTrait;
  * Triages the connection status of a given list of sites
  */
 #[AsCommand( name: 'jetpack:connection-triage' )]
-final class Jetpack_Site_Connection_triage extends Command {
+final class Jetpack_Site_Connection_Triage extends Command {
 	use AutocompleteTrait;
-
-	// region FIELDS AND CONSTANTS
-
-	/**
-	 * WPCOM site definition to fetch the information for.
-	 *
-	 * @var \stdClass|null
-	 */
-	private ?\stdClass $site = null;
-
-	// endregion
 
 	// region INHERITED METHODS
 
@@ -44,10 +33,10 @@ final class Jetpack_Site_Connection_triage extends Command {
 	 * {@inheritDoc}
 	 */
 	protected function execute( InputInterface $input, OutputInterface $output ): int {
-		$output->writeln( "<fg=magenta;options=bold>Listing Jetpack modules information for {$this->site->name} (ID {$this->site->ID}, URL {$this->site->URL}).</>" );
-
 		// Read in the CSV
 		$csv_path = $input->getArgument( 'csv-path' );
+
+		$output->writeln( "<fg=magenta;options=bold>Reading sites from {$csv_path}...</>" );
 
 		// For each row in the CSV, check the connection status
 		if ( ! file_exists( $csv_path ) ) {
@@ -63,24 +52,26 @@ final class Jetpack_Site_Connection_triage extends Command {
 				$line             = str_getcsv( $row );
 				$site_id          = $line[0];
 				$site_url         = $line[1];
+				$domain           = parse_url( $site_url, PHP_URL_HOST );
 				$jetpack_endpoint = $site_url . '/wp-json/jetpack/v4';
 				$notes            = '';
-				$status_code	  = '';
+				$status_code      = '';
+				$new_blog_id      = '';
 
-				$output->writeln( 'Checking ' . $site_url . '...');
+				$output->writeln( 'Checking ' . $site_url . '...' );
 
 				//fetch
-				$options = array(
+				$options     = array(
 					'http' => array(
-	
+
 						'method'        => 'GET',
 						'timeout'       => 60,
 						'ignore_errors' => true,
-					)
+					),
 				);
-				$context = stream_context_create( $options );
-				$result = @file_get_contents( $site_url, false, $context );
-				$headers = parse_http_headers( $http_response_header );
+				$context     = stream_context_create( $options );
+				$result      = @file_get_contents( $site_url, false, $context );
+				$headers     = parse_http_headers( $http_response_header );
 				$status_code = $headers['http_code'];
 
 				if ( 410 === $status_code && strpos( $site_url, 'mystagingwebsite.com' ) !== false ) {
@@ -90,32 +81,53 @@ final class Jetpack_Site_Connection_triage extends Command {
 				} elseif ( 404 === $status_code && strpos( $site_url, 'mystagingwebsite.com' ) !== false ) {
 					// probably deleted or Jetpack not installed. Next step is to curl the homepage
 					//$notes = $result['body'];
-					$notes = "404, check site";
+					$notes = '404, check site';
 					if ( strpos( $result, 'Domain not found' ) !== false ) {
 						$notes = 'Domain not found, probably deleted from Pressable';
 					}
 				} elseif ( 500 === $status_code ) {
 					//$notes = $result['body'];
-					$notes = "Check site, internal server error";
-				} elseif ( 200 === $status_code && strpos( $site_url, 'mystagingwebsite.com' ) == false ) {
-					$notes = 'Site either moved hosts or has a new JP connection. Check DARC and NA: https://mc.a8c.com/tools/reportcard/domain/?domain=' . $site_url . ' and https://wordpress.com/wp-admin/network/sites.php?s=' . $site_url;
+					$notes = 'Check site, internal server error';
+				} elseif ( 200 === $status_code && strpos( $site_url, 'mystagingwebsite.com' ) === false ) {
+					$notes = 'Site either moved hosts or has a new JP connection. Check DARC and NA: https://mc.a8c.com/tools/reportcard/domain/?domain=' . $domain . ' and https://wordpress.com/wp-admin/network/sites.php?s=' . $site_url;
+				} elseif ( 200 === $status_code && strpos( $site_url, 'mystagingwebsite.com' ) !== false ) {
+					// Check WPCOM API for site information
+					$wpcom_api_url = 'https://public-api.wordpress.com/rest/v1.1/sites/' . rawurlencode( $domain );
+					$wpcom_result  = @file_get_contents( $wpcom_api_url, false, $context );
+					$wpcom_status  = $http_response_header ? parse_http_headers( $http_response_header )['http_code'] : '';
+
+					if ( '400' === $wpcom_status ) {
+						$notes = 'Site is not connected to WordPress.com. If site loads, it may have moved hosts.';
+					} else {
+						$wpcom_data = json_decode( $wpcom_result, true );
+
+						if ( $wpcom_data && isset( $wpcom_data['ID'] ) ) {
+							if ( (int) $wpcom_data['ID'] !== (int) $site_id ) {
+								$notes       = 'Site has a new Jetpack connection. Old ID: ' . $site_id . ', New ID: ' . $wpcom_data['ID'];
+								$new_blog_id = $wpcom_data['ID'];
+							} else {
+								$notes = 'Site connection appears valid. Original error may have been intermittent.';
+							}
+						}
+					}
 				}
 				// wp-json/jetpack/v4/connection/data
 
 				$broken_site_data[] = array(
-					'site_id'  => $site_id,
-					'site_url' => $site_url,
-					'status'   => $status_code,
-					'notes'    => $notes,
+					'site_id'     => $site_id,
+					'site_url'    => $site_url,
+					'status'      => $status_code,
+					'new_blog_id' => $new_blog_id,
+					'notes'       => $notes,
 				);
 
 				//var_dump( $broken_site_data );
 			}
 			// Write a new CSV from the array
 			$output->writeln( '<info>Making the CSV...<info>' );
-			$timestamp = date( 'Y-m-d-H-i-s' );
+			$timestamp = gmdate( 'Y-m-d-H-i-s' );
 			$fp        = fopen( 'jp-connection-' . $timestamp . '.csv', 'w' );
-			fputcsv( $fp, array( 'Site ID', 'Site URL', 'Status', 'Notes' ) );
+			fputcsv( $fp, array( 'Site ID', 'Site URL', 'Status', 'New Blog ID', 'Notes' ) );
 			foreach ( $broken_site_data as $fields ) {
 				fputcsv( $fp, $fields );
 			}

--- a/commands/Jetpack_Site_Connection_Triage.php
+++ b/commands/Jetpack_Site_Connection_Triage.php
@@ -24,14 +24,24 @@ final class Jetpack_Site_Connection_Triage extends Command {
 	 */
 	private ?array $sites = null;
 
+	/**
+	 * List of known staging domains to check against.
+	 *
+	 * @var array
+	 */
+	private array $staging_domains = array(
+		'mystagingwebsite.com',
+		'jurassic.ninja',
+	);
+
 	protected function configure(): void {
 		$this->setDescription( 'Triages Jetpack connection issues for sites and generates a report.' )
 			->setHelp( 'Use this command to identify and analyze sites with Jetpack connection problems. It will check connection status and generate a CSV report with details about problematic connections. You can either provide a CSV of specific sites to check, or run it without arguments to check all connected Jetpack sites.' );
-	
-		$this->addArgument( 
-			'csv-path', 
-			InputArgument::OPTIONAL, 
-			'A path to a CSV with 2 columns, blog ID and url. If not provided, will check all connected Jetpack sites.' 
+
+		$this->addArgument(
+			'csv-path',
+			InputArgument::OPTIONAL,
+			'A path to a CSV with 2 columns, blog ID and url. If not provided, will check all connected Jetpack sites.'
 		);
 	}
 
@@ -47,17 +57,17 @@ final class Jetpack_Site_Connection_Triage extends Command {
 	 */
 	protected function execute( InputInterface $input, OutputInterface $output ): int {
 		$broken_site_data = array();
-		$csv_path = $input->getArgument( 'csv-path' );
-	
+		$csv_path         = $input->getArgument( 'csv-path' );
+
 		// Get the list of sites to check, either from CSV or from Jetpack
 		if ( $csv_path ) {
 			$output->writeln( "<fg=magenta;options=bold>Reading sites from {$csv_path}...</>" );
-	
+
 			if ( ! file_exists( $csv_path ) ) {
 				$output->writeln( "<fg=red;options=bold>CSV file not found at {$csv_path}.</>" );
 				return Command::FAILURE;
 			}
-	
+
 			// Read the CSV. Column 1: Site ID, Column 2: Site URL
 			$csv = file_get_contents( $csv_path );
 			$csv = explode( "\n", $csv );
@@ -73,16 +83,16 @@ final class Jetpack_Site_Connection_Triage extends Command {
 				}
 			}
 		} else {
-			$output->writeln( "<fg=magenta;options=bold>Checking all Jetpack sites with connection issues...</>" );
-			$output->writeln( "<comment>This initial check may take a few minutes, please be patient...</comment>" );
+			$output->writeln( '<fg=magenta;options=bold>Checking all Jetpack sites with connection issues...</>' );
+			$output->writeln( '<comment>This initial check may take a few minutes, please be patient...</comment>' );
 
 			// Process sites in chunks to avoid memory issues
 			$sites_to_check = array();
 			foreach ( array_chunk( $this->sites, 100, true ) as $sites_chunk ) {
 				$modules = get_jetpack_site_modules_batch( \array_column( $sites_chunk, 'userblog_id' ), $errors );
-				
+
 				foreach ( $errors as $site_id => $error ) {
-					$site = $this->sites[$site_id];
+					$site             = $this->sites[ $site_id ];
 					$sites_to_check[] = array(
 						'blog_id' => $site->userblog_id,
 						'url'     => $site->siteurl,
@@ -90,37 +100,47 @@ final class Jetpack_Site_Connection_Triage extends Command {
 				}
 			}
 		}
-	
+
+		// Helper function to check if domain is a staging domain
+		$is_staging_domain = function( $url ) {
+			foreach ( $this->staging_domains as $staging_domain ) {
+				if ( false !== strpos( $url, $staging_domain ) ) {
+					return true;
+				}
+			}
+			return false;
+		};
+
 		// Process each site through our connection check logic
 		foreach ( $sites_to_check as $site ) {
-			$site_id = $site['blog_id'];
-			$site_url = $site['url'];
-			$domain = parse_url( $site_url, PHP_URL_HOST );
+			$site_id          = $site['blog_id'];
+			$site_url         = $site['url'];
+			$domain           = parse_url( $site_url, PHP_URL_HOST );
 			$jetpack_endpoint = $site_url . '/wp-json/jetpack/v4';
-			$notes = '';
-			$status_code = '';
-			$new_blog_id = '';
-	
+			$notes            = '';
+			$status_code      = '';
+			$new_blog_id      = '';
+
 			$output->writeln( 'Checking ' . $site_url . '...' );
-	
+
 			//fetch
-			$options = array(
+			$options     = array(
 				'http' => array(
 					'method'        => 'GET',
 					'timeout'       => 60,
 					'ignore_errors' => true,
 				),
 			);
-			$context = stream_context_create( $options );
-			$result = @file_get_contents( $site_url, false, $context );
-			$headers = parse_http_headers( $http_response_header );
+			$context     = stream_context_create( $options );
+			$result      = @file_get_contents( $site_url, false, $context );
+			$headers     = parse_http_headers( $http_response_header );
 			$status_code = $headers['http_code'];
-	
-			if ( 410 === $status_code && strpos( $site_url, 'mystagingwebsite.com' ) !== false ) {
+
+			if ( 410 === $status_code && $is_staging_domain( $site_url ) ) {
 				// Probably deactivated
 				$notes = 'Site is probably deactivated';
 				// Check Pressable?
-			} elseif ( 404 === $status_code && strpos( $site_url, 'mystagingwebsite.com' ) !== false ) {
+			} elseif ( 404 === $status_code && $is_staging_domain( $site_url ) ) {
 				// probably deleted or Jetpack not installed. Next step is to curl the homepage
 				//$notes = $result['body'];
 				$notes = '404, check site';
@@ -130,30 +150,32 @@ final class Jetpack_Site_Connection_Triage extends Command {
 			} elseif ( 500 === $status_code ) {
 				//$notes = $result['body'];
 				$notes = 'Check site, internal server error';
-			} elseif ( 200 === $status_code && strpos( $site_url, 'mystagingwebsite.com' ) === false ) {
+			} elseif ( 200 === $status_code && ! $is_staging_domain( $site_url ) ) {
 				$notes = 'Site either moved hosts or has a new JP connection. Check DARC and NA: https://mc.a8c.com/tools/reportcard/domain/?domain=' . $domain . ' and https://wordpress.com/wp-admin/network/sites.php?s=' . $site_url;
-			} elseif ( 200 === $status_code && strpos( $site_url, 'mystagingwebsite.com' ) !== false ) {
+			} elseif ( 200 === $status_code && $is_staging_domain( $site_url ) ) {
 				// Check WPCOM API for site information
 				$wpcom_api_url = 'https://public-api.wordpress.com/rest/v1.1/sites/' . rawurlencode( $domain );
-				$wpcom_result = @file_get_contents( $wpcom_api_url, false, $context );
-				$wpcom_status = $http_response_header ? parse_http_headers( $http_response_header )['http_code'] : '';
-	
+				$wpcom_result  = @file_get_contents( $wpcom_api_url, false, $context );
+				$wpcom_status  = $http_response_header ? parse_http_headers( $http_response_header )['http_code'] : '';
+
 				if ( '400' === $wpcom_status ) {
 					$notes = 'Site is not connected to WordPress.com. If site loads, it may have moved hosts.';
 				} else {
 					$wpcom_data = json_decode( $wpcom_result, true );
-	
+
 					if ( $wpcom_data && isset( $wpcom_data['ID'] ) ) {
 						if ( (int) $wpcom_data['ID'] !== (int) $site_id ) {
-							$notes = 'Site has a new Jetpack connection. Old ID: ' . $site_id . ', New ID: ' . $wpcom_data['ID'];
+							$notes       = 'Site has a new Jetpack connection. Old ID: ' . $site_id . ', New ID: ' . $wpcom_data['ID'];
 							$new_blog_id = $wpcom_data['ID'];
 						} else {
 							$notes = 'Site connection appears valid. Original error may have been intermittent.';
 						}
+					} else {
+						$notes = 'Jetpack is probably disconnected. Log in and reconnect.';
 					}
 				}
 			}
-	
+
 			$broken_site_data[] = array(
 				'site_id'     => $site_id,
 				'site_url'    => $site_url,
@@ -162,21 +184,21 @@ final class Jetpack_Site_Connection_Triage extends Command {
 				'notes'       => $notes,
 			);
 		}
-	
+
 		// Write results to CSV
 		$output->writeln( '<info>Making the CSV...<info>' );
 		$timestamp = gmdate( 'Y-m-d-H-i-s' );
-		$filename = 'jp-connection-' . $timestamp . '.csv';
-		$filepath = getcwd() . DIRECTORY_SEPARATOR . $filename;
-		$fp = fopen( $filepath, 'w' );
-		fputcsv( $fp, array( 'Site ID', 'Site URL', 'Status', 'New Blog ID', 'Notes' ), ",", '"', "\\");
+		$filename  = 'jp-connection-' . $timestamp . '.csv';
+		$filepath  = getcwd() . DIRECTORY_SEPARATOR . $filename;
+		$fp        = fopen( $filepath, 'w' );
+		fputcsv( $fp, array( 'Site ID', 'Site URL', 'Status', 'New Blog ID', 'Notes' ), ',', '"', '\\' );
 		foreach ( $broken_site_data as $fields ) {
-			fputcsv( $fp, $fields, ",", '"', "\\");
+			fputcsv( $fp, $fields, ',', '"', '\\' );
 		}
 		fclose( $fp );
 
 		$output->writeln( sprintf( '<info>Done, CSV saved to: %s</info>', $filepath ) );
-	
+
 		return Command::SUCCESS;
 	}
 

--- a/commands/Jetpack_Site_Connection_Triage.php
+++ b/commands/Jetpack_Site_Connection_Triage.php
@@ -189,13 +189,11 @@ EOT
 				// Check Pressable?
 			} elseif ( 404 === $status_code && $this->is_staging_domain( $site_url ) ) {
 				// probably deleted or Jetpack not installed. Next step is to curl the homepage
-				//$notes = $result['body'];
 				$notes = '404, check site';
 				if ( strpos( $result, 'Domain not found' ) !== false ) {
 					$notes = 'Domain not found, probably deleted from Pressable';
 				}
 			} elseif ( 500 === $status_code ) {
-				//$notes = $result['body'];
 				$notes = 'Check site, internal server error';
 			} elseif ( 200 === $status_code && ! $this->is_staging_domain( $site_url ) ) {
 				$notes = 'Site either moved hosts or has a new JP connection. Check DARC and NA: https://mc.a8c.com/tools/reportcard/domain/?domain=' . $domain . ' and https://wordpress.com/wp-admin/network/sites.php?s=' . $site_url;

--- a/commands/Jetpack_Site_Connection_Triage.php
+++ b/commands/Jetpack_Site_Connection_Triage.php
@@ -17,132 +17,168 @@ use WPCOMSpecialProjects\CLI\Helper\AutocompleteTrait;
 final class Jetpack_Site_Connection_Triage extends Command {
 	use AutocompleteTrait;
 
-	// region INHERITED METHODS
-
 	/**
-	 * {@inheritDoc}
+	 * The list of connected sites.
+	 *
+	 * @var array|null
 	 */
-	protected function configure(): void {
-		$this->setDescription( 'Lists the status of Jetpack modules on a given site.' )
-			->setHelp( 'Use this command to show a list of Jetpack modules on a given site together with their status. This command requires that the given site has an active Jetpack connection to WPCOM.' );
+	private ?array $sites = null;
 
-		$this->addArgument( 'csv-path', InputArgument::REQUIRED, 'A path to a CSV with 2 columns, blog ID and url' );
+	protected function configure(): void {
+		$this->setDescription( 'Triages Jetpack connection issues for sites and generates a report.' )
+			->setHelp( 'Use this command to identify and analyze sites with Jetpack connection problems. It will check connection status and generate a CSV report with details about problematic connections. You can either provide a CSV of specific sites to check, or run it without arguments to check all connected Jetpack sites.' );
+	
+		$this->addArgument( 
+			'csv-path', 
+			InputArgument::OPTIONAL, 
+			'A path to a CSV with 2 columns, blog ID and url. If not provided, will check all connected Jetpack sites.' 
+		);
+	}
+
+	protected function initialize( InputInterface $input, OutputInterface $output ): void {
+		if ( ! $input->getArgument( 'csv-path' ) ) {
+			$this->sites = get_wpcom_jetpack_sites();
+			$output->writeln( '<comment>Successfully fetched ' . \count( $this->sites ) . ' Jetpack site(s).</comment>' );
+		}
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
 	protected function execute( InputInterface $input, OutputInterface $output ): int {
-		// Read in the CSV
+		$broken_site_data = array();
 		$csv_path = $input->getArgument( 'csv-path' );
-
-		$output->writeln( "<fg=magenta;options=bold>Reading sites from {$csv_path}...</>" );
-
-		// For each row in the CSV, check the connection status
-		if ( ! file_exists( $csv_path ) ) {
-			$output->writeln( "<fg=red;options=bold>CSV file not found at {$csv_path}.</>" );
-			return Command::FAILURE;
-		} else {
-			// Read the CSV. Column 1: Site ID, Column 2: Site URL, Column 3: Connection Status
+	
+		// Get the list of sites to check, either from CSV or from Jetpack
+		if ( $csv_path ) {
+			$output->writeln( "<fg=magenta;options=bold>Reading sites from {$csv_path}...</>" );
+	
+			if ( ! file_exists( $csv_path ) ) {
+				$output->writeln( "<fg=red;options=bold>CSV file not found at {$csv_path}.</>" );
+				return Command::FAILURE;
+			}
+	
+			// Read the CSV. Column 1: Site ID, Column 2: Site URL
 			$csv = file_get_contents( $csv_path );
 			$csv = explode( "\n", $csv );
-			unset( $csv[0] );
-			$broken_site_data = array();
+			unset( $csv[0] ); // Remove header row
+			$sites_to_check = array();
 			foreach ( $csv as $row ) {
-				$line             = str_getcsv( $row );
-				$site_id          = $line[0];
-				$site_url         = $line[1];
-				$domain           = parse_url( $site_url, PHP_URL_HOST );
-				$jetpack_endpoint = $site_url . '/wp-json/jetpack/v4';
-				$notes            = '';
-				$status_code      = '';
-				$new_blog_id      = '';
+				$line = str_getcsv( $row );
+				if ( isset( $line[0], $line[1] ) ) {
+					$sites_to_check[] = array(
+						'blog_id' => $line[0],
+						'url'     => $line[1],
+					);
+				}
+			}
+		} else {
+			$output->writeln( "<fg=magenta;options=bold>Checking all Jetpack sites with connection issues...</>" );
+			$output->writeln( "<comment>This initial check may take a few minutes, please be patient...</comment>" );
 
-				$output->writeln( 'Checking ' . $site_url . '...' );
-
-				//fetch
-				$options     = array(
-					'http' => array(
-
-						'method'        => 'GET',
-						'timeout'       => 60,
-						'ignore_errors' => true,
-					),
-				);
-				$context     = stream_context_create( $options );
-				$result      = @file_get_contents( $site_url, false, $context );
-				$headers     = parse_http_headers( $http_response_header );
-				$status_code = $headers['http_code'];
-
-				if ( 410 === $status_code && strpos( $site_url, 'mystagingwebsite.com' ) !== false ) {
-					// Probably deactivated
-					$notes = 'Site is probably deactivated';
-					// Check Pressable?
-				} elseif ( 404 === $status_code && strpos( $site_url, 'mystagingwebsite.com' ) !== false ) {
-					// probably deleted or Jetpack not installed. Next step is to curl the homepage
-					//$notes = $result['body'];
-					$notes = '404, check site';
-					if ( strpos( $result, 'Domain not found' ) !== false ) {
-						$notes = 'Domain not found, probably deleted from Pressable';
-					}
-				} elseif ( 500 === $status_code ) {
-					//$notes = $result['body'];
-					$notes = 'Check site, internal server error';
-				} elseif ( 200 === $status_code && strpos( $site_url, 'mystagingwebsite.com' ) === false ) {
-					$notes = 'Site either moved hosts or has a new JP connection. Check DARC and NA: https://mc.a8c.com/tools/reportcard/domain/?domain=' . $domain . ' and https://wordpress.com/wp-admin/network/sites.php?s=' . $site_url;
-				} elseif ( 200 === $status_code && strpos( $site_url, 'mystagingwebsite.com' ) !== false ) {
-					// Check WPCOM API for site information
-					$wpcom_api_url = 'https://public-api.wordpress.com/rest/v1.1/sites/' . rawurlencode( $domain );
-					$wpcom_result  = @file_get_contents( $wpcom_api_url, false, $context );
-					$wpcom_status  = $http_response_header ? parse_http_headers( $http_response_header )['http_code'] : '';
-
-					if ( '400' === $wpcom_status ) {
-						$notes = 'Site is not connected to WordPress.com. If site loads, it may have moved hosts.';
-					} else {
-						$wpcom_data = json_decode( $wpcom_result, true );
-
-						if ( $wpcom_data && isset( $wpcom_data['ID'] ) ) {
-							if ( (int) $wpcom_data['ID'] !== (int) $site_id ) {
-								$notes       = 'Site has a new Jetpack connection. Old ID: ' . $site_id . ', New ID: ' . $wpcom_data['ID'];
-								$new_blog_id = $wpcom_data['ID'];
-							} else {
-								$notes = 'Site connection appears valid. Original error may have been intermittent.';
-							}
+			// Process sites in chunks to avoid memory issues
+			$sites_to_check = array();
+			foreach ( array_chunk( $this->sites, 100, true ) as $sites_chunk ) {
+				$modules = get_jetpack_site_modules_batch( \array_column( $sites_chunk, 'userblog_id' ), $errors );
+				
+				foreach ( $errors as $site_id => $error ) {
+					$site = $this->sites[$site_id];
+					$sites_to_check[] = array(
+						'blog_id' => $site->userblog_id,
+						'url'     => $site->siteurl,
+					);
+				}
+			}
+		}
+	
+		// Process each site through our connection check logic
+		foreach ( $sites_to_check as $site ) {
+			$site_id = $site['blog_id'];
+			$site_url = $site['url'];
+			$domain = parse_url( $site_url, PHP_URL_HOST );
+			$jetpack_endpoint = $site_url . '/wp-json/jetpack/v4';
+			$notes = '';
+			$status_code = '';
+			$new_blog_id = '';
+	
+			$output->writeln( 'Checking ' . $site_url . '...' );
+	
+			//fetch
+			$options = array(
+				'http' => array(
+					'method'        => 'GET',
+					'timeout'       => 60,
+					'ignore_errors' => true,
+				),
+			);
+			$context = stream_context_create( $options );
+			$result = @file_get_contents( $site_url, false, $context );
+			$headers = parse_http_headers( $http_response_header );
+			$status_code = $headers['http_code'];
+	
+			if ( 410 === $status_code && strpos( $site_url, 'mystagingwebsite.com' ) !== false ) {
+				// Probably deactivated
+				$notes = 'Site is probably deactivated';
+				// Check Pressable?
+			} elseif ( 404 === $status_code && strpos( $site_url, 'mystagingwebsite.com' ) !== false ) {
+				// probably deleted or Jetpack not installed. Next step is to curl the homepage
+				//$notes = $result['body'];
+				$notes = '404, check site';
+				if ( strpos( $result, 'Domain not found' ) !== false ) {
+					$notes = 'Domain not found, probably deleted from Pressable';
+				}
+			} elseif ( 500 === $status_code ) {
+				//$notes = $result['body'];
+				$notes = 'Check site, internal server error';
+			} elseif ( 200 === $status_code && strpos( $site_url, 'mystagingwebsite.com' ) === false ) {
+				$notes = 'Site either moved hosts or has a new JP connection. Check DARC and NA: https://mc.a8c.com/tools/reportcard/domain/?domain=' . $domain . ' and https://wordpress.com/wp-admin/network/sites.php?s=' . $site_url;
+			} elseif ( 200 === $status_code && strpos( $site_url, 'mystagingwebsite.com' ) !== false ) {
+				// Check WPCOM API for site information
+				$wpcom_api_url = 'https://public-api.wordpress.com/rest/v1.1/sites/' . rawurlencode( $domain );
+				$wpcom_result = @file_get_contents( $wpcom_api_url, false, $context );
+				$wpcom_status = $http_response_header ? parse_http_headers( $http_response_header )['http_code'] : '';
+	
+				if ( '400' === $wpcom_status ) {
+					$notes = 'Site is not connected to WordPress.com. If site loads, it may have moved hosts.';
+				} else {
+					$wpcom_data = json_decode( $wpcom_result, true );
+	
+					if ( $wpcom_data && isset( $wpcom_data['ID'] ) ) {
+						if ( (int) $wpcom_data['ID'] !== (int) $site_id ) {
+							$notes = 'Site has a new Jetpack connection. Old ID: ' . $site_id . ', New ID: ' . $wpcom_data['ID'];
+							$new_blog_id = $wpcom_data['ID'];
+						} else {
+							$notes = 'Site connection appears valid. Original error may have been intermittent.';
 						}
 					}
 				}
-				// wp-json/jetpack/v4/connection/data
-
-				$broken_site_data[] = array(
-					'site_id'     => $site_id,
-					'site_url'    => $site_url,
-					'status'      => $status_code,
-					'new_blog_id' => $new_blog_id,
-					'notes'       => $notes,
-				);
-
-				//var_dump( $broken_site_data );
 			}
-			// Write a new CSV from the array
-			$output->writeln( '<info>Making the CSV...<info>' );
-			$timestamp = gmdate( 'Y-m-d-H-i-s' );
-			$fp        = fopen( 'jp-connection-' . $timestamp . '.csv', 'w' );
-			fputcsv( $fp, array( 'Site ID', 'Site URL', 'Status', 'New Blog ID', 'Notes' ) );
-			foreach ( $broken_site_data as $fields ) {
-				fputcsv( $fp, $fields );
-			}
-			fclose( $fp );
-
-			$output->writeln( '<info>Done, CSV saved to your current working directory: jp-connection-' . $timestamp . '.csv<info>' );
-
+	
+			$broken_site_data[] = array(
+				'site_id'     => $site_id,
+				'site_url'    => $site_url,
+				'status'      => $status_code,
+				'new_blog_id' => $new_blog_id,
+				'notes'       => $notes,
+			);
 		}
+	
+		// Write results to CSV
+		$output->writeln( '<info>Making the CSV...<info>' );
+		$timestamp = gmdate( 'Y-m-d-H-i-s' );
+		$filename = 'jp-connection-' . $timestamp . '.csv';
+		$filepath = getcwd() . DIRECTORY_SEPARATOR . $filename;
+		$fp = fopen( $filepath, 'w' );
+		fputcsv( $fp, array( 'Site ID', 'Site URL', 'Status', 'New Blog ID', 'Notes' ), ",", '"', "\\");
+		foreach ( $broken_site_data as $fields ) {
+			fputcsv( $fp, $fields, ",", '"', "\\");
+		}
+		fclose( $fp );
 
+		$output->writeln( sprintf( '<info>Done, CSV saved to: %s</info>', $filepath ) );
+	
 		return Command::SUCCESS;
 	}
-
-	// endregion
-
-	// region HELPERS
 
 	// endregion
 }


### PR DESCRIPTION
## Description

Adds a new command: `team51 jetpack:connection-triage`. This command is designed to output a CSV of sites that needs their Jetpack connection fixed. It will optionally accept a CSV file as input for sites to triage.

This command piggybacks on other Jetpack commands, but only uses the sites that return an error. It then processes them through some hardcoded logic and output a CSV of sites that will need to be manually checked or fixed.

Related: https://github.com/a8cteam51/team51-dev-requests/issues/4751