### PR TITLE
Adds an ignore list to JP Connection Triage

### DIFF
--- a/commands/Jetpack_Site_Connection_Triage.php
+++ b/commands/Jetpack_Site_Connection_Triage.php
@@ -37,6 +37,15 @@ final class Jetpack_Site_Connection_Triage extends Command {
 	);
 
 	/**
+	 * List of domains to ignore.
+	 *
+	 * @var array
+	 */
+	private array $ignored_domains = array(
+		'https://brodo.kinsta.cloud',
+	);
+
+	/**
 	 * Configures the command definition, arguments and help documentation.
 	 *
 	 * @since 1.0.0
@@ -160,6 +169,12 @@ EOT
 
 		// Process each site through our connection check logic
 		foreach ( $sites_to_check as $site ) {
+			// Skip ignored domains.
+			if ( in_array( $site['url'], $this->ignored_domains, true ) ) {
+				$output->writeln( 'Skipping ' . $site['url'] . '...' );
+				continue;
+			}
+
 			$site_id          = $site['blog_id'];
 			$site_url         = $site['url'];
 			$domain           = parse_url( $site_url, PHP_URL_HOST );


### PR DESCRIPTION
Adds an ignore list array to the JP Connection Triage command.

Not currently a wildcard system,it's a pure 1:1 check.