### PR TITLE
Changes the API URL to use the most current one (adds /hosting to the REST API url)

### DIFF
--- a/includes/functions-wpcom.php
+++ b/includes/functions-wpcom.php
@@ -544,7 +544,7 @@ function wait_until_jetpack_token_regenerated( string $site_id_or_url, OutputInt
  */
 function create_wpcom_site_code_deployment( string $site_id_or_url, string $external_repository_id, string $branch_name, string $target_dir, ?array $params = null ): ?stdClass {
 	return API_Helper::make_wpcom_request(
-		"sites/$site_id_or_url/code-deployments",
+		"sites/$site_id_or_url/hosting/code-deployments",
 		'POST',
 		array(
 			'external_repository_id' => $external_repository_id,
@@ -564,7 +564,7 @@ function create_wpcom_site_code_deployment( string $site_id_or_url, string $exte
  * @return  stdClass|null
  */
 function create_wpcom_site_code_deployment_run( string $site_id_or_url, string $code_deployment_id ): ?stdClass {
-	return API_Helper::make_wpcom_request( "sites/$site_id_or_url/code-deployments/$code_deployment_id/runs", 'POST' );
+	return API_Helper::make_wpcom_request( "sites/$site_id_or_url/hosting/code-deployments/$code_deployment_id/runs", 'POST' );
 }
 
 /**
@@ -575,7 +575,7 @@ function create_wpcom_site_code_deployment_run( string $site_id_or_url, string $
  * @return  stdClass[]|null
  */
 function get_wpcom_site_code_deployments( string $site_id_or_url ): ?array {
-	return API_Helper::make_wpcom_request( "sites/$site_id_or_url/code-deployments" )?->records;
+	return API_Helper::make_wpcom_request( "sites/$site_id_or_url/hosting/code-deployments" )?->records;
 }
 
 /**


### PR DESCRIPTION
WE're having issues with the following command not working:

`team51 wpcom:connect-site-repository 242967371 psychedelic-safety --branch=develop` a 500 is thrown with an error about a bad request.

This PR changes the API URL to take into account the wpcom URL: https://opengrok.a8c.com/source/search?project=wpcom&full=code-deployments&defs=&refs=&path=&hist=&type=&xrd=&nn=1 which has /hosting in the API URL.

https://developer.wordpress.com/docs/api/
https://developer.wordpress.com/docs/api/2/post/sites/$wpcom_site/hosting/code-deployments/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of code deployment features for WordPress.com sites by updating internal connections to the latest deployment endpoints. No visible changes to workflows or interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->