### PR TITLE
Add/no code template

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -19,4 +19,7 @@
 	<rule ref="Universal.Operators">
 		<exclude name="Universal.Operators.DisallowShortTernary.Found"/>
 	</rule>
+
+	<!-- Add this section to exclude .history directory -->
+	<exclude-pattern>/.history/*</exclude-pattern>
 </ruleset>

--- a/commands/GitHub_Repository_Create.php
+++ b/commands/GitHub_Repository_Create.php
@@ -210,6 +210,9 @@ final class GitHub_Repository_Create extends Command {
 		if ( ! isset( $custom_properties['human-title'] ) ) {
 			$custom_properties['human-title'] = $this->name;
 		}
+		if ( ! isset( $custom_properties['parent-theme'] ) ) {
+			$custom_properties['parent-theme'] = $this->no_code_theme;
+		}
 		if ( ! isset( $custom_properties['php-globals-long-prefix'] ) ) {
 			$custom_properties['php-globals-long-prefix'] = \str_replace( '-', '_', $this->name );
 		}
@@ -225,6 +228,8 @@ final class GitHub_Repository_Create extends Command {
 	 *
 	 * @param InputInterface  $input  The input interface.
 	 * @param OutputInterface $output The output interface.
+	 *
+	 * @return void
 	 */
 	private function setup_no_code_theme( InputInterface $input, OutputInterface $output ): void {
 		$folders = get_a8c_theme_choices( $output );
@@ -287,10 +292,10 @@ final class GitHub_Repository_Create extends Command {
 		$copy_command = sprintf(
 			'cd %s && mkdir -p themes/%s && cp -r %s/%s/* themes/%s',
 			$temp_dir,
-			$this->name,
+			$this->no_code_theme,
 			dirname( TEAM51_CLI_ROOT_DIR ) . '/a8c-themes',
 			$this->no_code_theme,
-			$this->name
+			$this->no_code_theme
 		);
 
 		exec( $copy_command, $exec_output, $return_code );

--- a/commands/GitHub_Repository_Create.php
+++ b/commands/GitHub_Repository_Create.php
@@ -200,7 +200,9 @@ final class GitHub_Repository_Create extends Command {
 			}
 		}
 
-		$this->wait_for_fill_in_scaffold_placeholders_action_to_complete( $output, $repository->name );
+		if ( 'no-code-project' === $this->type && ! empty( $this->no_code_theme ) ) {
+			$this->wait_for_fill_in_scaffold_placeholders_action_to_complete( $output, $repository->name );
+		}
 
 		$output->writeln( "<fg=green;options=bold>Repository $this->name created successfully.</>" );
 		return Command::SUCCESS;

--- a/commands/GitHub_Repository_Create.php
+++ b/commands/GitHub_Repository_Create.php
@@ -85,13 +85,6 @@ final class GitHub_Repository_Create extends Command {
 		'empty'           => 'Empty Repo',
 	);
 
-	/**
-	 * Whether the user selected the "wpcom-theme" option.
-	 *
-	 * @var bool
-	 */
-	private bool $use_wpcom_theme = false;
-
 	// endregion
 
 	// region INHERITED METHODS
@@ -138,7 +131,7 @@ final class GitHub_Repository_Create extends Command {
 			exit( 2 );
 		}
 
-		if ( 'no-code-project' === $this->type ) {
+		if ( 'no-code-project' === $this->type && empty( $this->no_code_theme ) ) {
 			$this->setup_no_code_theme( $input, $output );
 
 			if ( ! empty( $this->no_code_theme ) ) {
@@ -176,26 +169,22 @@ final class GitHub_Repository_Create extends Command {
 		}
 
 		// Check if the selected no code theme is child theme.
-		if ( 'no-code-project' === $this->type && ! empty( $this->no_code_theme ) && ! $this->use_wpcom_theme ) {
+		if ( 'no-code-project' === $this->type && ! empty( $this->no_code_theme ) ) {
 			if ( null === $this->themes ) {
-				$this->themes = get_wporg_theme_choices( $output );
+				$this->themes = get_wporg_theme_choices();
 			}
 
-			if ( ! isset( $this->themes[ $this->no_code_theme ] ) ) {
-				$output->writeln( '<error>The selected no-code theme is not available.</error>' );
-				$output->writeln( '<error>Please select a different theme.</error>' );
-				return Command::FAILURE;
-			}
+			if ( isset( $this->themes[ $this->no_code_theme ] ) ) {
+				$theme = $this->themes[ $this->no_code_theme ];
 
-			$theme = $this->themes[ $this->no_code_theme ];
-
-			if ( isset( $theme->parent ) && ! empty( $theme->parent ) ) {
-				$output->writeln( "<comment>The selected no-code theme $this->no_code_theme is a child theme.</comment>" );
-				$output->writeln( '<fg=magenta;options=bold>Replacing the default theme with the child theme.</>' );
-				$result = $this->add_no_code_theme_files( $output, $repository );
-				if ( false === $result ) {
-					$output->writeln( '<error>Failed to add theme files.</error>' );
-					return Command::FAILURE;
+				if ( isset( $theme->parent ) && ! empty( $theme->parent ) ) {
+					$output->writeln( "<comment>The selected no-code theme $this->no_code_theme is a child theme.</comment>" );
+					$output->writeln( '<fg=magenta;options=bold>Replacing the default theme with the child theme.</>' );
+					$result = $this->add_no_code_theme_files( $output, $repository );
+					if ( false === $result ) {
+						$output->writeln( '<error>Failed to add theme files.</error>' );
+						return Command::FAILURE;
+					}
 				}
 			}
 		}
@@ -287,7 +276,9 @@ final class GitHub_Repository_Create extends Command {
 	 * @return void
 	 */
 	private function setup_no_code_theme( InputInterface $input, OutputInterface $output ): void {
-		$this->themes = get_wporg_theme_choices( $output );
+		$output->writeln( '<fg=magenta;options=bold>Fetching WordPress.org themes...</>' );
+
+		$this->themes = get_wporg_theme_choices();
 
 		// Inject the "wpcom-theme" option
 		$this->themes[] = (object) array(
@@ -313,10 +304,9 @@ final class GitHub_Repository_Create extends Command {
 		$this->no_code_theme = $this->prompt_no_code_theme_input( $input, $output, $this->themes );
 
 		if ( 'wpcom-theme' === $this->no_code_theme ) {
-			$this->use_wpcom_theme = true;
-			$question              = new Question( '<question>Please enter the slug of the WPCOM theme to use:</question> ' );
-			$theme_slug            = $this->getHelper( 'question' )->ask( $input, $output, $question );
-			$this->no_code_theme   = $theme_slug;
+			$question            = new Question( '<question>Please enter the slug of the WPCOM theme to use:</question> ' );
+			$theme_slug          = $this->getHelper( 'question' )->ask( $input, $output, $question );
+			$this->no_code_theme = $theme_slug;
 		}
 	}
 

--- a/commands/GitHub_Repository_Create.php
+++ b/commands/GitHub_Repository_Create.php
@@ -72,6 +72,13 @@ final class GitHub_Repository_Create extends Command {
 	 */
 	private ?array $custom_properties = null;
 
+	/**
+	 * Whether the user selected the "wpcom-theme" option.
+	 *
+	 * @var bool
+	 */
+	private bool $use_wpcom_theme = false;
+
 	// endregion
 
 	// region INHERITED METHODS
@@ -157,7 +164,7 @@ final class GitHub_Repository_Create extends Command {
 		}
 
 		// Check if the selected no code theme is child theme.
-		if ( 'no-code-project' === $this->type && ! empty( $this->no_code_theme ) ) {
+		if ( 'no-code-project' === $this->type && ! empty( $this->no_code_theme ) && ! $this->use_wpcom_theme ) {
 			$theme = $this->themes[ $this->no_code_theme ];
 
 			if ( isset( $theme->parent ) && ! empty( $theme->parent ) ) {
@@ -256,6 +263,12 @@ final class GitHub_Repository_Create extends Command {
 	private function setup_no_code_theme( InputInterface $input, OutputInterface $output ): void {
 		$this->themes = get_wporg_theme_choices( $output );
 
+		// Inject the "wpcom-theme" option
+		$this->themes[] = (object) array(
+			'slug' => 'wpcom-theme',
+			'name' => 'WPCOM theme, other theme',
+		);
+
 		if ( empty( $this->themes ) ) {
 			$output->writeln( '<error>Failed to fetch .org themes.</error>' );
 			return;
@@ -272,6 +285,13 @@ final class GitHub_Repository_Create extends Command {
 		}
 
 		$this->no_code_theme = $this->prompt_no_code_theme_input( $input, $output, $this->themes );
+
+		if ( 'wpcom-theme' === $this->no_code_theme ) {
+			$this->use_wpcom_theme = true;
+			$question              = new Question( '<question>Please enter the slug of the WPCOM theme to use:</question> ' );
+			$theme_slug            = $this->getHelper( 'question' )->ask( $input, $output, $question );
+			$this->no_code_theme   = $theme_slug;
+		}
 	}
 
 	/**
@@ -398,12 +418,29 @@ final class GitHub_Repository_Create extends Command {
 	 * @return  string|null
 	 */
 	private function prompt_no_code_theme_input( InputInterface $input, OutputInterface $output, array $themes ): ?string {
-		$themes   = array_combine(
-			array_map( fn( $theme ) => $theme->slug, $themes ),
-			array_map( fn( $theme ) => $theme->name, $themes )
+		$theme_slugs  = array_map( fn( $theme ) => $theme->slug, $themes );
+		$theme_names  = array_map( fn( $theme ) => $theme->name, $themes );
+		$slug_to_name = array_combine( $theme_slugs, $theme_names );
+		$name_to_slug = array_combine( $theme_names, $theme_slugs );
+
+		$autocompleter_values = array_merge( $theme_slugs, $theme_names );
+
+		$question = new Question(
+			'<question>Please start typing the slug or name of the no-code theme to use. Choose "wpcom-theme" for internal or unlisted themes:</question> '
 		);
-		$question = new ChoiceQuestion( '<question>Please select the no-code theme to use:</question> ', $themes, 'project' );
-		return $this->getHelper( 'question' )->ask( $input, $output, $question );
+		$question->setAutocompleterValues( $autocompleter_values );
+
+		$selected = $this->getHelper( 'question' )->ask( $input, $output, $question );
+
+		// Normalize input: if it's a name, convert to slug
+		if ( in_array( $selected, $theme_slugs, true ) ) {
+			return $selected;
+		} elseif ( isset( $name_to_slug[ $selected ] ) ) {
+			return $name_to_slug[ $selected ];
+		} else {
+			$output->writeln( '<error>Invalid theme slug or name selected.</error>' );
+			return null;
+		}
 	}
 
 	// endregion

--- a/commands/GitHub_Repository_Create.php
+++ b/commands/GitHub_Repository_Create.php
@@ -59,6 +59,13 @@ final class GitHub_Repository_Create extends Command {
 	private ?string $no_code_theme = null;
 
 	/**
+	 * The list of available themes.
+	 *
+	 * @var array|null
+	 */
+	private ?array $themes = null;
+
+	/**
 	 * The custom properties to set for the repository.
 	 *
 	 * @var array|null
@@ -149,14 +156,20 @@ final class GitHub_Repository_Create extends Command {
 			set_github_repository_topics( $repository->name, array( 'team51-empty' ) );
 		}
 
-		// Add theme files for no-code-project repositories
-		// if ( 'no-code-project' === $this->type && ! empty( $this->no_code_theme ) ) {
-		//  $result = $this->add_no_code_theme_files( $output, $repository );
-		//  if ( false === $result ) {
-		//      $output->writeln( '<error>Failed to add theme files.</error>' );
-		//      return Command::FAILURE;
-		//  }
-		// }
+		// Check if the selected no code theme is child theme.
+		if ( 'no-code-project' === $this->type && ! empty( $this->no_code_theme ) ) {
+			$theme = $this->themes[ $this->no_code_theme ];
+
+			if ( isset( $theme->parent ) && ! empty( $theme->parent ) ) {
+				$output->writeln( "<comment>The selected no-code theme $this->no_code_theme is a child theme.</comment>" );
+				$output->writeln( '<fg=magenta;options=bold>Replacing the default theme with the child theme.</>' );
+				$result = $this->add_no_code_theme_files( $output, $repository );
+				if ( false === $result ) {
+					$output->writeln( '<error>Failed to add theme files.</error>' );
+					return Command::FAILURE;
+				}
+			}
+		}
 
 		$output->writeln( "<fg=green;options=bold>Repository $this->name created successfully.</>" );
 		return Command::SUCCESS;
@@ -233,7 +246,7 @@ final class GitHub_Repository_Create extends Command {
 	}
 
 	/**
-	 * Sets up the no-code theme by cloning/pulling the a8c-themes repo and prompting for theme selection.
+	 * Sets up the no-code theme by cloning/pulling the themes repo and prompting for theme selection.
 	 *
 	 * @param InputInterface  $input  The input interface.
 	 * @param OutputInterface $output The output interface.
@@ -241,15 +254,15 @@ final class GitHub_Repository_Create extends Command {
 	 * @return void
 	 */
 	private function setup_no_code_theme( InputInterface $input, OutputInterface $output ): void {
-		$themes = get_wporg_theme_choices( $output );
+		$this->themes = get_wporg_theme_choices( $output );
 
-		if ( empty( $themes ) ) {
+		if ( empty( $this->themes ) ) {
 			$output->writeln( '<error>Failed to fetch .org themes.</error>' );
 			return;
 		}
 
 		if ( ! empty( $this->no_code_theme ) ) {
-			if ( ! in_array( $this->no_code_theme, $themes, true ) ) {
+			if ( ! in_array( $this->no_code_theme, $this->themes, true ) ) {
 				$output->writeln( '<error>The selected no-code theme is not available.</error>' );
 				$output->writeln( '<error>Please select a different theme or press enter to skip.</error>' );
 				$this->no_code_theme = null;
@@ -258,12 +271,7 @@ final class GitHub_Repository_Create extends Command {
 			}
 		}
 
-		$question            = new ChoiceQuestion(
-			'<question>Please select the no-code theme to use:</question> ',
-			$themes,
-			0
-		);
-		$this->no_code_theme = $this->getHelper( 'question' )->ask( $input, $output, $question );
+		$this->no_code_theme = $this->prompt_no_code_theme_input( $input, $output, $this->themes );
 	}
 
 	/**
@@ -275,8 +283,6 @@ final class GitHub_Repository_Create extends Command {
 	 * @return  boolean
 	 */
 	private function add_no_code_theme_files( OutputInterface $output, stdClass $repository ): bool {
-		$output->writeln( "<comment>Adding theme files from {$this->no_code_theme}...</comment>" );
-
 		// Create a temporary directory for the main repository
 		$temp_dir = sys_get_temp_dir() . '/' . uniqid( 'github-repo-' );
 		mkdir( $temp_dir );
@@ -298,75 +304,62 @@ final class GitHub_Repository_Create extends Command {
 			return false;
 		}
 
-		// Check for "Template:" entry in the chosen theme's style.css
-		$a8c_themes_dir    = dirname( TEAM51_CLI_ROOT_DIR ) . '/a8c-themes';
-		$theme_path        = $a8c_themes_dir . '/' . $this->no_code_theme;
-		$parent_theme_slug = get_theme_template_entry( $theme_path );
-
-		if ( $parent_theme_slug ) {
-			$output->writeln( "<comment>The theme {$this->no_code_theme} is a child theme. Using {$parent_theme_slug} as the parent theme.</comment>" );
-
-			// Rename the theme folder
-			$custom_theme_name = $this->no_code_theme . '-custom';
-			$custom_theme_path = $temp_dir . '/themes/' . $custom_theme_name;
-			mkdir( $custom_theme_path, 0777, true );
-
-			// Copy theme files to the new custom folder
-			$copy_command = sprintf(
-				'cp -r %s/* %s',
-				$theme_path,
-				$custom_theme_path
-			);
-			exec( $copy_command, $exec_output, $return_code );
+		// Delete the scaffold folder if it exists
+		$scaffold_path = $temp_dir . '/themes/a8csp-no-code-project-scaffold';
+		if ( is_dir( $scaffold_path ) ) {
+			$output->writeln( '<fg=magenta;options=bold>Removing scaffold theme folder...</>' );
+			exec( sprintf( 'rm -rf %s', $scaffold_path ), $exec_output, $return_code );
 			if ( 0 !== $return_code ) {
-				$output->writeln( '<error>Failed to copy theme files.</error>' );
-				$output->writeln( '<error>Command output: ' . implode( "\n", $exec_output ) . '</error>' );
+				$output->writeln( '<error>Failed to remove scaffold theme folder.</error>' );
 				return false;
 			}
+		}
 
-			// Modify the theme name in style.css after copying
-			$style_css_path = $custom_theme_path . '/style.css';
+		// Create themes directory if it doesn't exist
+		$themes_dir = $temp_dir . '/themes';
+		if ( ! is_dir( $themes_dir ) ) {
+			mkdir( $themes_dir, 0777, true );
+		}
+
+		// Download and extract theme
+		$download_url = 'https://downloads.wordpress.org/theme/' . $this->no_code_theme . '.zip';
+		$zip_path     = $temp_dir . '/' . $this->no_code_theme . '.zip';
+
+		$output->writeln( "<fg=magenta;options=bold>Downloading theme files from {$download_url}...</>" );
+
+		if ( false === file_put_contents( $zip_path, file_get_contents( $download_url ) ) ) {
+			$output->writeln( '<error>Failed to download theme files.</error>' );
+			return false;
+		}
+
+		// Extract the theme
+		$zip = new \ZipArchive();
+		if ( true !== $zip->open( $zip_path ) ) {
+			$output->writeln( '<error>Failed to open theme zip file.</error>' );
+			return false;
+		}
+
+		// Create a custom theme name TBD if needed
+		$custom_theme_name = $this->no_code_theme;
+		$custom_theme_path = $themes_dir . '/' . $custom_theme_name;
+
+		// Extract to a temporary location first
+		$extract_path = $temp_dir . '/theme-extract';
+		mkdir( $extract_path );
+		$zip->extractTo( $extract_path );
+		$zip->close();
+
+		// Move the extracted theme to the correct location with the custom name
+		rename( $extract_path . '/' . $this->no_code_theme, $custom_theme_path );
+		rmdir( $extract_path );
+		unlink( $zip_path );
+
+		// Modify the theme name in style.css
+		$style_css_path = $custom_theme_path . '/style.css';
+		if ( file_exists( $style_css_path ) ) {
 			$style_contents = file_get_contents( $style_css_path );
 			$style_contents = preg_replace( '/Theme Name:\s*(.+)/', 'Theme Name: $1 Custom', $style_contents );
 			file_put_contents( $style_css_path, $style_contents );
-
-			// Check if the parent theme exists
-			$available_themes = get_a8c_theme_choices( $output );
-			if ( in_array( $parent_theme_slug, $available_themes, true ) ) {
-				// Copy the parent theme files to the main repository
-				$parent_theme_path         = $a8c_themes_dir . '/' . $parent_theme_slug;
-				$parent_theme_copy_command = sprintf(
-					'cp -r %s %s/themes/',
-					$parent_theme_path,
-					$temp_dir
-				);
-				exec( $parent_theme_copy_command, $exec_output, $return_code );
-				if ( 0 !== $return_code ) {
-					$output->writeln( '<error>Failed to copy parent theme files.</error>' );
-					$output->writeln( '<error>Command output: ' . implode( "\n", $exec_output ) . '</error>' );
-					return false;
-				}
-			} else {
-				$output->writeln( "<error>Parent theme {$parent_theme_slug} not found.</error>" );
-			}
-		} else {
-			$output->writeln( "<comment>The theme {$this->no_code_theme} is not a child theme. Proceeding with default setup.</comment>" );
-
-			// Create themes directory and copy theme files
-			$copy_command = sprintf(
-				'cd %s && mkdir -p themes/%s && cp -r %s/%s/* themes/%s',
-				$temp_dir,
-				$this->no_code_theme,
-				$a8c_themes_dir,
-				$this->no_code_theme,
-				$this->no_code_theme
-			);
-			exec( $copy_command, $exec_output, $return_code );
-			if ( 0 !== $return_code ) {
-				$output->writeln( '<error>Failed to copy theme files.</error>' );
-				$output->writeln( '<error>Command output: ' . implode( "\n", $exec_output ) . '</error>' );
-				return false;
-			}
 		}
 
 		// Commit and push the theme files
@@ -384,16 +377,33 @@ final class GitHub_Repository_Create extends Command {
 			return false;
 		}
 
-		// Clean up main repository temporary directory
+		// Clean up temporary directory
 		exec( sprintf( 'rm -rf %s', $temp_dir ), $exec_output, $return_code );
 		if ( 0 !== $return_code ) {
 			$output->writeln( '<error>Failed to clean up temporary directory.</error>' );
-			$output->writeln( '<error>Command output: ' . implode( "\n", $exec_output ) . '</error>' );
 			return false;
 		}
 
 		$output->writeln( '<fg=green>Theme files added and pushed successfully.</>' );
 		return true;
+	}
+
+	/**
+	 * Prompts the user for a no-code theme.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 * @param   array           $themes The list of available themes.
+	 *
+	 * @return  string|null
+	 */
+	private function prompt_no_code_theme_input( InputInterface $input, OutputInterface $output, array $themes ): ?string {
+		$themes   = array_combine(
+			array_map( fn( $theme ) => $theme->slug, $themes ),
+			array_map( fn( $theme ) => $theme->name, $themes )
+		);
+		$question = new ChoiceQuestion( '<question>Please select the no-code theme to use:</question> ', $themes, 'project' );
+		return $this->getHelper( 'question' )->ask( $input, $output, $question );
 	}
 
 	// endregion

--- a/commands/GitHub_Repository_Create.php
+++ b/commands/GitHub_Repository_Create.php
@@ -176,6 +176,8 @@ final class GitHub_Repository_Create extends Command {
 					return Command::FAILURE;
 				}
 			}
+
+			$this->wait_for_fill_in_scaffold_placeholders_action_to_complete( $output, $repository->name );
 		}
 
 		$output->writeln( "<fg=green;options=bold>Repository $this->name created successfully.</>" );
@@ -435,11 +437,28 @@ final class GitHub_Repository_Create extends Command {
 		// Normalize input: if it's a name, convert to slug
 		if ( in_array( $selected, $theme_slugs, true ) ) {
 			return $selected;
-		} elseif ( isset( $name_to_slug[ $selected ] ) ) {
+		}
+
+		if ( isset( $name_to_slug[ $selected ] ) ) {
 			return $name_to_slug[ $selected ];
-		} else {
-			$output->writeln( '<error>Invalid theme slug or name selected.</error>' );
-			return null;
+		}
+
+		$output->writeln( '<error>Invalid theme slug or name selected.</error>' );
+		return null;
+	}
+
+	/**
+	 * Waits for the fill in the scaffold placeholders workflow to complete.
+	 *
+	 * @param   OutputInterface $output     The output interface.
+	 * @param   string          $repository The name of the repository to wait for the workflow run in.
+	 *
+	 * @return  void
+	 */
+	private function wait_for_fill_in_scaffold_placeholders_action_to_complete( OutputInterface $output, string $repository ): void {
+		$finished = wait_for_github_repository_workflow_run_to_complete( $repository, 'Fill in the Scaffold Placeholders', $output );
+		if ( ! $finished ) {
+			$output->writeln( '<error>The fill in the scaffold placeholders workflow did not complete, check the repository actions for errors.</error>' );
 		}
 	}
 

--- a/commands/GitHub_Repository_Create.php
+++ b/commands/GitHub_Repository_Create.php
@@ -78,10 +78,11 @@ final class GitHub_Repository_Create extends Command {
 	 * @var array
 	 */
 	private const REPO_TYPES = array(
-		'project' => 'Full Project Repo',
-		'plugin'  => 'Plugin Specific Repo',
-		'issues'  => 'Issues Only Repo',
-		'empty'   => 'Empty Repo',
+		'project'         => 'Full Project Repo',
+		'no-code-project' => 'No-Code Project Repo',
+		'plugin'          => 'Plugin Specific Repo',
+		'issues'          => 'Issues Only Repo',
+		'empty'           => 'Empty Repo',
 	);
 
 	/**

--- a/commands/GitHub_Repository_Create.php
+++ b/commands/GitHub_Repository_Create.php
@@ -200,7 +200,7 @@ final class GitHub_Repository_Create extends Command {
 			}
 		}
 
-		if ( 'no-code-project' === $this->type && ! empty( $this->no_code_theme ) ) {
+		if ( in_array( $this->type, array( 'no-code-project', 'project', 'plugin' ), true ) ) {
 			$this->wait_for_fill_in_scaffold_placeholders_action_to_complete( $output, $repository->name );
 		}
 

--- a/commands/GitHub_Repository_Create.php
+++ b/commands/GitHub_Repository_Create.php
@@ -98,9 +98,6 @@ final class GitHub_Repository_Create extends Command {
 
 		$this->type = get_enum_input( $input, 'type', array( 'project', 'no-code-project', 'plugin', 'issues' ), fn() => $this->prompt_type_input( $input, $output ) );
 		$input->setOption( 'type', $this->type );
-
-		$this->custom_properties = $this->process_custom_properties( $input );
-		$input->setOption( 'custom-properties', $this->custom_properties );
 	}
 
 	/**
@@ -116,6 +113,14 @@ final class GitHub_Repository_Create extends Command {
 
 		if ( 'no-code-project' === $this->type ) {
 			$this->setup_no_code_theme( $input, $output );
+
+			if ( ! empty( $this->no_code_theme ) ) {
+				$question = new ConfirmationQuestion( "<question>Are you sure you want to use the theme $this->no_code_theme as the parent theme for the $type repository $this->name? [y/N]</question> ", false );
+				if ( true !== $this->getHelper( 'question' )->ask( $input, $output, $question ) ) {
+					$output->writeln( '<comment>Command aborted by user.</comment>' );
+					exit( 2 );
+				}
+			}
 		}
 	}
 
@@ -125,6 +130,9 @@ final class GitHub_Repository_Create extends Command {
 	protected function execute( InputInterface $input, OutputInterface $output ): int {
 		$type = $this->type ?? 'empty';
 		$output->writeln( "<fg=magenta;options=bold>Creating the $type repository $this->name.</>" );
+
+		$this->custom_properties = $this->process_custom_properties( $input );
+		$input->setOption( 'custom-properties', $this->custom_properties );
 
 		// Create the repository.
 		$repository = create_github_repository( $this->name, $this->type, $this->homepage, $this->description, $this->custom_properties );
@@ -142,13 +150,13 @@ final class GitHub_Repository_Create extends Command {
 		}
 
 		// Add theme files for no-code-project repositories
-		if ( 'no-code-project' === $this->type && ! empty( $this->no_code_theme ) ) {
-			$result = $this->add_no_code_theme_files( $output, $repository );
-			if ( false === $result ) {
-				$output->writeln( '<error>Failed to add theme files.</error>' );
-				return Command::FAILURE;
-			}
-		}
+		// if ( 'no-code-project' === $this->type && ! empty( $this->no_code_theme ) ) {
+		//  $result = $this->add_no_code_theme_files( $output, $repository );
+		//  if ( false === $result ) {
+		//      $output->writeln( '<error>Failed to add theme files.</error>' );
+		//      return Command::FAILURE;
+		//  }
+		// }
 
 		$output->writeln( "<fg=green;options=bold>Repository $this->name created successfully.</>" );
 		return Command::SUCCESS;
@@ -233,14 +241,15 @@ final class GitHub_Repository_Create extends Command {
 	 * @return void
 	 */
 	private function setup_no_code_theme( InputInterface $input, OutputInterface $output ): void {
-		$folders = get_a8c_theme_choices( $output );
-		if ( empty( $folders ) ) {
-			$output->writeln( '<error>Failed to fetch a8c themes.</error>' );
+		$themes = get_wporg_theme_choices( $output );
+
+		if ( empty( $themes ) ) {
+			$output->writeln( '<error>Failed to fetch .org themes.</error>' );
 			return;
 		}
 
 		if ( ! empty( $this->no_code_theme ) ) {
-			if ( ! in_array( $this->no_code_theme, $folders, true ) ) {
+			if ( ! in_array( $this->no_code_theme, $themes, true ) ) {
 				$output->writeln( '<error>The selected no-code theme is not available.</error>' );
 				$output->writeln( '<error>Please select a different theme or press enter to skip.</error>' );
 				$this->no_code_theme = null;
@@ -251,7 +260,7 @@ final class GitHub_Repository_Create extends Command {
 
 		$question            = new ChoiceQuestion(
 			'<question>Please select the no-code theme to use:</question> ',
-			$folders,
+			$themes,
 			0
 		);
 		$this->no_code_theme = $this->getHelper( 'question' )->ask( $input, $output, $question );

--- a/commands/GitHub_Repository_Create.php
+++ b/commands/GitHub_Repository_Create.php
@@ -181,6 +181,7 @@ final class GitHub_Repository_Create extends Command {
 	 */
 	private function prompt_type_input( InputInterface $input, OutputInterface $output ): ?string {
 		$question = new Question( '<question>Please enter the type of repository to create or press enter for an empty repo:</question> ' );
+		// TODO: Show choices in a list.
 		if ( ! $input->getOption( 'no-autocomplete' ) ) {
 			$question->setAutocompleterValues( array( 'project', 'no-code-project', 'plugin', 'issues' ) );
 		}
@@ -267,7 +268,7 @@ final class GitHub_Repository_Create extends Command {
 	private function add_no_code_theme_files( OutputInterface $output, stdClass $repository ): bool {
 		$output->writeln( "<comment>Adding theme files from {$this->no_code_theme}...</comment>" );
 
-		// Create a temporary directory
+		// Create a temporary directory for the main repository
 		$temp_dir = sys_get_temp_dir() . '/' . uniqid( 'github-repo-' );
 		mkdir( $temp_dir );
 		if ( ! is_dir( $temp_dir ) ) {
@@ -288,21 +289,75 @@ final class GitHub_Repository_Create extends Command {
 			return false;
 		}
 
-		// Create themes directory and copy theme files
-		$copy_command = sprintf(
-			'cd %s && mkdir -p themes/%s && cp -r %s/%s/* themes/%s',
-			$temp_dir,
-			$this->no_code_theme,
-			dirname( TEAM51_CLI_ROOT_DIR ) . '/a8c-themes',
-			$this->no_code_theme,
-			$this->no_code_theme
-		);
+		// Check for "Template:" entry in the chosen theme's style.css
+		$a8c_themes_dir    = dirname( TEAM51_CLI_ROOT_DIR ) . '/a8c-themes';
+		$theme_path        = $a8c_themes_dir . '/' . $this->no_code_theme;
+		$parent_theme_slug = get_theme_template_entry( $theme_path );
 
-		exec( $copy_command, $exec_output, $return_code );
-		if ( 0 !== $return_code ) {
-			$output->writeln( '<error>Failed to copy theme files.</error>' );
-			$output->writeln( '<error>Command output: ' . implode( "\n", $exec_output ) . '</error>' );
-			return false;
+		if ( $parent_theme_slug ) {
+			$output->writeln( "<comment>The theme {$this->no_code_theme} is a child theme. Using {$parent_theme_slug} as the parent theme.</comment>" );
+
+			// Rename the theme folder
+			$custom_theme_name = $this->no_code_theme . '-custom';
+			$custom_theme_path = $temp_dir . '/themes/' . $custom_theme_name;
+			mkdir( $custom_theme_path, 0777, true );
+
+			// Copy theme files to the new custom folder
+			$copy_command = sprintf(
+				'cp -r %s/* %s',
+				$theme_path,
+				$custom_theme_path
+			);
+			exec( $copy_command, $exec_output, $return_code );
+			if ( 0 !== $return_code ) {
+				$output->writeln( '<error>Failed to copy theme files.</error>' );
+				$output->writeln( '<error>Command output: ' . implode( "\n", $exec_output ) . '</error>' );
+				return false;
+			}
+
+			// Modify the theme name in style.css after copying
+			$style_css_path = $custom_theme_path . '/style.css';
+			$style_contents = file_get_contents( $style_css_path );
+			$style_contents = preg_replace( '/Theme Name:\s*(.+)/', 'Theme Name: $1 Custom', $style_contents );
+			file_put_contents( $style_css_path, $style_contents );
+
+			// Check if the parent theme exists
+			$available_themes = get_a8c_theme_choices( $output );
+			if ( in_array( $parent_theme_slug, $available_themes, true ) ) {
+				// Copy the parent theme files to the main repository
+				$parent_theme_path         = $a8c_themes_dir . '/' . $parent_theme_slug;
+				$parent_theme_copy_command = sprintf(
+					'cp -r %s %s/themes/',
+					$parent_theme_path,
+					$temp_dir
+				);
+				exec( $parent_theme_copy_command, $exec_output, $return_code );
+				if ( 0 !== $return_code ) {
+					$output->writeln( '<error>Failed to copy parent theme files.</error>' );
+					$output->writeln( '<error>Command output: ' . implode( "\n", $exec_output ) . '</error>' );
+					return false;
+				}
+			} else {
+				$output->writeln( "<error>Parent theme {$parent_theme_slug} not found.</error>" );
+			}
+		} else {
+			$output->writeln( "<comment>The theme {$this->no_code_theme} is not a child theme. Proceeding with default setup.</comment>" );
+
+			// Create themes directory and copy theme files
+			$copy_command = sprintf(
+				'cd %s && mkdir -p themes/%s && cp -r %s/%s/* themes/%s',
+				$temp_dir,
+				$this->no_code_theme,
+				$a8c_themes_dir,
+				$this->no_code_theme,
+				$this->no_code_theme
+			);
+			exec( $copy_command, $exec_output, $return_code );
+			if ( 0 !== $return_code ) {
+				$output->writeln( '<error>Failed to copy theme files.</error>' );
+				$output->writeln( '<error>Command output: ' . implode( "\n", $exec_output ) . '</error>' );
+				return false;
+			}
 		}
 
 		// Commit and push the theme files
@@ -320,7 +375,7 @@ final class GitHub_Repository_Create extends Command {
 			return false;
 		}
 
-		// Clean up temporary directory
+		// Clean up main repository temporary directory
 		exec( sprintf( 'rm -rf %s', $temp_dir ), $exec_output, $return_code );
 		if ( 0 !== $return_code ) {
 			$output->writeln( '<error>Failed to clean up temporary directory.</error>' );

--- a/commands/GitHub_Repository_Create.php
+++ b/commands/GitHub_Repository_Create.php
@@ -9,7 +9,6 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 use Symfony\Component\Console\Question\Question;
 use WPCOMSpecialProjects\CLI\Helper\AutocompleteTrait;
@@ -165,6 +164,16 @@ final class GitHub_Repository_Create extends Command {
 
 		// Check if the selected no code theme is child theme.
 		if ( 'no-code-project' === $this->type && ! empty( $this->no_code_theme ) && ! $this->use_wpcom_theme ) {
+			if ( null === $this->themes ) {
+				$this->themes = get_wporg_theme_choices( $output );
+			}
+
+			if ( ! isset( $this->themes[ $this->no_code_theme ] ) ) {
+				$output->writeln( '<error>The selected no-code theme is not available.</error>' );
+				$output->writeln( '<error>Please select a different theme.</error>' );
+				return Command::FAILURE;
+			}
+
 			$theme = $this->themes[ $this->no_code_theme ];
 
 			if ( isset( $theme->parent ) && ! empty( $theme->parent ) ) {
@@ -176,9 +185,9 @@ final class GitHub_Repository_Create extends Command {
 					return Command::FAILURE;
 				}
 			}
-
-			$this->wait_for_fill_in_scaffold_placeholders_action_to_complete( $output, $repository->name );
 		}
+
+		$this->wait_for_fill_in_scaffold_placeholders_action_to_complete( $output, $repository->name );
 
 		$output->writeln( "<fg=green;options=bold>Repository $this->name created successfully.</>" );
 		return Command::SUCCESS;
@@ -422,7 +431,6 @@ final class GitHub_Repository_Create extends Command {
 	private function prompt_no_code_theme_input( InputInterface $input, OutputInterface $output, array $themes ): ?string {
 		$theme_slugs  = array_map( fn( $theme ) => $theme->slug, $themes );
 		$theme_names  = array_map( fn( $theme ) => $theme->name, $themes );
-		$slug_to_name = array_combine( $theme_slugs, $theme_names );
 		$name_to_slug = array_combine( $theme_names, $theme_slugs );
 
 		$autocompleter_values = array_merge( $theme_slugs, $theme_names );

--- a/commands/Pressable_Site_Create.php
+++ b/commands/Pressable_Site_Create.php
@@ -51,6 +51,20 @@ final class Pressable_Site_Create extends Command {
 	private ?string $no_code_theme = null;
 
 	/**
+	 * The list of available themes.
+	 *
+	 * @var array|null
+	 */
+	private ?array $themes = null;
+
+	/**
+	 * Whether the user selected the "wpcom-theme" option.
+	 *
+	 * @var bool
+	 */
+	private bool $use_wpcom_theme = false;
+
+	/**
 	 * The GitHub repository to deploy to the site from.
 	 *
 	 * @var \stdClass|null
@@ -214,12 +228,30 @@ final class Pressable_Site_Create extends Command {
 	 * @return  string|null
 	 */
 	private function prompt_no_code_theme_input( InputInterface $input, OutputInterface $output, array $themes ): ?string {
-		$themes   = array_combine(
-			array_map( fn( $theme ) => $theme->slug, $themes ),
-			array_map( fn( $theme ) => $theme->name, $themes )
+		$theme_slugs  = array_map( fn( $theme ) => $theme->slug, $themes );
+		$theme_names  = array_map( fn( $theme ) => $theme->name, $themes );
+		$name_to_slug = array_combine( $theme_names, $theme_slugs );
+
+		$autocompleter_values = array_merge( $theme_slugs, $theme_names );
+
+		$question = new Question(
+			'<question>Please start typing the slug or name of the no-code theme to use. Choose "wpcom-theme" for internal or unlisted themes:</question> '
 		);
-		$question = new ChoiceQuestion( '<question>Please select the no-code theme to use for the site:</question> ', $themes, 'project' );
-		return $this->getHelper( 'question' )->ask( $input, $output, $question );
+		$question->setAutocompleterValues( $autocompleter_values );
+
+		$selected = $this->getHelper( 'question' )->ask( $input, $output, $question );
+
+		// Normalize input: if it's a name, convert to slug
+		if ( in_array( $selected, $theme_slugs, true ) ) {
+			return $selected;
+		}
+
+		if ( isset( $name_to_slug[ $selected ] ) ) {
+			return $name_to_slug[ $selected ];
+		}
+
+		$output->writeln( '<error>Invalid theme slug or name selected.</error>' );
+		return null;
 	}
 
 	/**
@@ -275,13 +307,7 @@ final class Pressable_Site_Create extends Command {
 				$input->setOption( 'project-template', $this->project_template );
 
 				if ( 'no-code-project' === $this->project_template ) {
-					$themes = get_wporg_theme_choices( $output );
-					if ( empty( $themes ) ) {
-						$output->writeln( '<error>Failed to fetch wp.org themes.</error>' );
-						exit( 1 );
-					}
-
-					$this->no_code_theme = get_enum_input( $input, 'no-code-theme', array_keys( $themes ), fn() => $this->prompt_no_code_theme_input( $input, $output, $themes ), null );
+					$this->setup_no_code_theme( $input, $output );
 					$input->setOption( 'no-code-theme', $this->no_code_theme );
 				}
 
@@ -309,6 +335,48 @@ final class Pressable_Site_Create extends Command {
 		}
 
 		return $repository;
+	}
+
+	/**
+	 * Sets up the no-code theme by cloning/pulling the themes repo and prompting for theme selection.
+	 *
+	 * @param InputInterface  $input  The input interface.
+	 * @param OutputInterface $output The output interface.
+	 *
+	 * @return void
+	 */
+	private function setup_no_code_theme( InputInterface $input, OutputInterface $output ): void {
+		$this->themes = get_wporg_theme_choices( $output );
+
+		// Inject the "wpcom-theme" option
+		$this->themes[] = (object) array(
+			'slug' => 'wpcom-theme',
+			'name' => 'WPCOM theme, other theme',
+		);
+
+		if ( empty( $this->themes ) ) {
+			$output->writeln( '<error>Failed to fetch .org themes.</error>' );
+			return;
+		}
+
+		if ( ! empty( $this->no_code_theme ) ) {
+			if ( ! in_array( $this->no_code_theme, $this->themes, true ) ) {
+				$output->writeln( '<error>The selected no-code theme is not available.</error>' );
+				$output->writeln( '<error>Please select a different theme or press enter to skip.</error>' );
+				$this->no_code_theme = null;
+			} else {
+				return;
+			}
+		}
+
+		$this->no_code_theme = $this->prompt_no_code_theme_input( $input, $output, $this->themes );
+
+		if ( 'wpcom-theme' === $this->no_code_theme ) {
+			$this->use_wpcom_theme = true;
+			$question              = new Question( '<question>Please enter the slug of the WPCOM theme to use:</question> ' );
+			$theme_slug            = $this->getHelper( 'question' )->ask( $input, $output, $question );
+			$this->no_code_theme   = $theme_slug;
+		}
 	}
 
 	// endregion

--- a/commands/Pressable_Site_Create.php
+++ b/commands/Pressable_Site_Create.php
@@ -58,13 +58,6 @@ final class Pressable_Site_Create extends Command {
 	private ?array $themes = null;
 
 	/**
-	 * Whether the user selected the "wpcom-theme" option.
-	 *
-	 * @var bool
-	 */
-	private bool $use_wpcom_theme = false;
-
-	/**
 	 * The GitHub repository to deploy to the site from.
 	 *
 	 * @var \stdClass|null
@@ -346,7 +339,9 @@ final class Pressable_Site_Create extends Command {
 	 * @return void
 	 */
 	private function setup_no_code_theme( InputInterface $input, OutputInterface $output ): void {
-		$this->themes = get_wporg_theme_choices( $output );
+		$output->writeln( '<fg=magenta;options=bold>Fetching WordPress.org themes...</>' );
+
+		$this->themes = get_wporg_theme_choices();
 
 		// Inject the "wpcom-theme" option
 		$this->themes[] = (object) array(
@@ -372,10 +367,9 @@ final class Pressable_Site_Create extends Command {
 		$this->no_code_theme = $this->prompt_no_code_theme_input( $input, $output, $this->themes );
 
 		if ( 'wpcom-theme' === $this->no_code_theme ) {
-			$this->use_wpcom_theme = true;
-			$question              = new Question( '<question>Please enter the slug of the WPCOM theme to use:</question> ' );
-			$theme_slug            = $this->getHelper( 'question' )->ask( $input, $output, $question );
-			$this->no_code_theme   = $theme_slug;
+			$question            = new Question( '<question>Please enter the slug of the WPCOM theme to use:</question> ' );
+			$theme_slug          = $this->getHelper( 'question' )->ask( $input, $output, $question );
+			$this->no_code_theme = $theme_slug;
 		}
 	}
 

--- a/commands/Pressable_Site_Create.php
+++ b/commands/Pressable_Site_Create.php
@@ -271,9 +271,9 @@ final class Pressable_Site_Create extends Command {
 				$input->setOption( 'project-template', $this->project_template );
 
 				if ( 'no-code-project' === $this->project_template ) {
-					$folders = get_a8c_theme_choices( $output );
+					$folders = get_wporg_theme_choices( $output );
 					if ( empty( $folders ) ) {
-						$output->writeln( '<error>Failed to fetch a8c themes.</error>' );
+						$output->writeln( '<error>Failed to fetch wp.org themes.</error>' );
 						exit( 1 );
 					}
 

--- a/commands/Pressable_Site_Create.php
+++ b/commands/Pressable_Site_Create.php
@@ -207,14 +207,18 @@ final class Pressable_Site_Create extends Command {
 	/**
 	 * Prompts the user for a no-code theme.
 	 *
-	 * @param   InputInterface  $input   The input object.
-	 * @param   OutputInterface $output  The output object.
-	 * @param   array           $folders The list of available themes.
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 * @param   array           $themes The list of available themes.
 	 *
 	 * @return  string|null
 	 */
-	private function prompt_no_code_theme_input( InputInterface $input, OutputInterface $output, array $folders ): ?string {
-		$question = new ChoiceQuestion( '<question>Please select the no-code theme to use for the site:</question> ', $folders, 'project' );
+	private function prompt_no_code_theme_input( InputInterface $input, OutputInterface $output, array $themes ): ?string {
+		$themes   = array_combine(
+			array_map( fn( $theme ) => $theme->slug, $themes ),
+			array_map( fn( $theme ) => $theme->name, $themes )
+		);
+		$question = new ChoiceQuestion( '<question>Please select the no-code theme to use for the site:</question> ', $themes, 'project' );
 		return $this->getHelper( 'question' )->ask( $input, $output, $question );
 	}
 
@@ -271,13 +275,13 @@ final class Pressable_Site_Create extends Command {
 				$input->setOption( 'project-template', $this->project_template );
 
 				if ( 'no-code-project' === $this->project_template ) {
-					$folders = get_wporg_theme_choices( $output );
-					if ( empty( $folders ) ) {
+					$themes = get_wporg_theme_choices( $output );
+					if ( empty( $themes ) ) {
 						$output->writeln( '<error>Failed to fetch wp.org themes.</error>' );
 						exit( 1 );
 					}
 
-					$this->no_code_theme = get_enum_input( $input, 'no-code-theme', array_keys( $folders ), fn() => $this->prompt_no_code_theme_input( $input, $output, $folders ), null );
+					$this->no_code_theme = get_enum_input( $input, 'no-code-theme', array_keys( $themes ), fn() => $this->prompt_no_code_theme_input( $input, $output, $themes ), null );
 					$input->setOption( 'no-code-theme', $this->no_code_theme );
 				}
 

--- a/commands/WPCOM_Site_Create.php
+++ b/commands/WPCOM_Site_Create.php
@@ -233,9 +233,9 @@ final class WPCOM_Site_Create extends Command {
 				$input->setOption( 'project-template', $this->project_template );
 
 				if ( 'no-code-project' === $this->project_template ) {
-					$folders = get_a8c_theme_choices( $output );
+					$folders = get_wporg_theme_choices( $output );
 					if ( empty( $folders ) ) {
-						$output->writeln( '<error>Failed to fetch a8c themes.</error>' );
+						$output->writeln( '<error>Failed to fetch wp.org themes.</error>' );
 						exit( 1 );
 					}
 

--- a/commands/WPCOM_Site_Create.php
+++ b/commands/WPCOM_Site_Create.php
@@ -233,13 +233,13 @@ final class WPCOM_Site_Create extends Command {
 				$input->setOption( 'project-template', $this->project_template );
 
 				if ( 'no-code-project' === $this->project_template ) {
-					$folders = get_wporg_theme_choices( $output );
-					if ( empty( $folders ) ) {
+					$themes = get_wporg_theme_choices( $output );
+					if ( empty( $themes ) ) {
 						$output->writeln( '<error>Failed to fetch wp.org themes.</error>' );
 						exit( 1 );
 					}
 
-					$this->no_code_theme = get_enum_input( $input, 'no-code-theme', array_keys( $folders ), fn() => $this->prompt_no_code_theme_input( $input, $output, $folders ), null );
+					$this->no_code_theme = get_enum_input( $input, 'no-code-theme', array_keys( $themes ), fn() => $this->prompt_no_code_theme_input( $input, $output, $themes ), null );
 					$input->setOption( 'no-code-theme', $this->no_code_theme );
 				}
 
@@ -290,14 +290,18 @@ final class WPCOM_Site_Create extends Command {
 	/**
 	 * Prompts the user for a no-code theme.
 	 *
-	 * @param   InputInterface  $input   The input object.
-	 * @param   OutputInterface $output  The output object.
-	 * @param   array           $folders The list of available themes.
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 * @param   array           $themes The list of available themes.
 	 *
 	 * @return  string|null
 	 */
-	private function prompt_no_code_theme_input( InputInterface $input, OutputInterface $output, array $folders ): ?string {
-		$question = new ChoiceQuestion( '<question>Please select the no-code theme to use for the site:</question> ', $folders, 'project' );
+	private function prompt_no_code_theme_input( InputInterface $input, OutputInterface $output, array $themes ): ?string {
+		$themes   = array_combine(
+			array_map( fn( $theme ) => $theme->slug, $themes ),
+			array_map( fn( $theme ) => $theme->name, $themes )
+		);
+		$question = new ChoiceQuestion( '<question>Please select the no-code theme to use for the site:</question> ', $themes, 'project' );
 		return $this->getHelper( 'question' )->ask( $input, $output, $question );
 	}
 

--- a/commands/WPCOM_Site_Create.php
+++ b/commands/WPCOM_Site_Create.php
@@ -50,6 +50,20 @@ final class WPCOM_Site_Create extends Command {
 	 */
 	private ?string $no_code_theme = null;
 
+	/**
+	 * The list of available themes.
+	 *
+	 * @var array|null
+	 */
+	private ?array $themes = null;
+
+	/**
+	 * Whether the user selected the "wpcom-theme" option.
+	 *
+	 * @var bool
+	 */
+	private bool $use_wpcom_theme = false;
+
 	// endregion
 
 	// region INHERITED METHODS
@@ -233,13 +247,7 @@ final class WPCOM_Site_Create extends Command {
 				$input->setOption( 'project-template', $this->project_template );
 
 				if ( 'no-code-project' === $this->project_template ) {
-					$themes = get_wporg_theme_choices( $output );
-					if ( empty( $themes ) ) {
-						$output->writeln( '<error>Failed to fetch wp.org themes.</error>' );
-						exit( 1 );
-					}
-
-					$this->no_code_theme = get_enum_input( $input, 'no-code-theme', array_keys( $themes ), fn() => $this->prompt_no_code_theme_input( $input, $output, $themes ), null );
+					$this->setup_no_code_theme( $input, $output );
 					$input->setOption( 'no-code-theme', $this->no_code_theme );
 				}
 
@@ -288,6 +296,48 @@ final class WPCOM_Site_Create extends Command {
 	}
 
 	/**
+	 * Sets up the no-code theme by cloning/pulling the themes repo and prompting for theme selection.
+	 *
+	 * @param InputInterface  $input  The input interface.
+	 * @param OutputInterface $output The output interface.
+	 *
+	 * @return void
+	 */
+	private function setup_no_code_theme( InputInterface $input, OutputInterface $output ): void {
+		$this->themes = get_wporg_theme_choices( $output );
+
+		// Inject the "wpcom-theme" option
+		$this->themes[] = (object) array(
+			'slug' => 'wpcom-theme',
+			'name' => 'WPCOM theme, other theme',
+		);
+
+		if ( empty( $this->themes ) ) {
+			$output->writeln( '<error>Failed to fetch .org themes.</error>' );
+			return;
+		}
+
+		if ( ! empty( $this->no_code_theme ) ) {
+			if ( ! in_array( $this->no_code_theme, $this->themes, true ) ) {
+				$output->writeln( '<error>The selected no-code theme is not available.</error>' );
+				$output->writeln( '<error>Please select a different theme or press enter to skip.</error>' );
+				$this->no_code_theme = null;
+			} else {
+				return;
+			}
+		}
+
+		$this->no_code_theme = $this->prompt_no_code_theme_input( $input, $output, $this->themes );
+
+		if ( 'wpcom-theme' === $this->no_code_theme ) {
+			$this->use_wpcom_theme = true;
+			$question              = new Question( '<question>Please enter the slug of the WPCOM theme to use:</question> ' );
+			$theme_slug            = $this->getHelper( 'question' )->ask( $input, $output, $question );
+			$this->no_code_theme   = $theme_slug;
+		}
+	}
+
+	/**
 	 * Prompts the user for a no-code theme.
 	 *
 	 * @param   InputInterface  $input  The input object.
@@ -297,12 +347,30 @@ final class WPCOM_Site_Create extends Command {
 	 * @return  string|null
 	 */
 	private function prompt_no_code_theme_input( InputInterface $input, OutputInterface $output, array $themes ): ?string {
-		$themes   = array_combine(
-			array_map( fn( $theme ) => $theme->slug, $themes ),
-			array_map( fn( $theme ) => $theme->name, $themes )
+		$theme_slugs  = array_map( fn( $theme ) => $theme->slug, $themes );
+		$theme_names  = array_map( fn( $theme ) => $theme->name, $themes );
+		$name_to_slug = array_combine( $theme_names, $theme_slugs );
+
+		$autocompleter_values = array_merge( $theme_slugs, $theme_names );
+
+		$question = new Question(
+			'<question>Please start typing the slug or name of the no-code theme to use. Choose "wpcom-theme" for internal or unlisted themes:</question> '
 		);
-		$question = new ChoiceQuestion( '<question>Please select the no-code theme to use for the site:</question> ', $themes, 'project' );
-		return $this->getHelper( 'question' )->ask( $input, $output, $question );
+		$question->setAutocompleterValues( $autocompleter_values );
+
+		$selected = $this->getHelper( 'question' )->ask( $input, $output, $question );
+
+		// Normalize input: if it's a name, convert to slug
+		if ( in_array( $selected, $theme_slugs, true ) ) {
+			return $selected;
+		}
+
+		if ( isset( $name_to_slug[ $selected ] ) ) {
+			return $name_to_slug[ $selected ];
+		}
+
+		$output->writeln( '<error>Invalid theme slug or name selected.</error>' );
+		return null;
 	}
 
 	// endregion

--- a/commands/WPCOM_Site_Create.php
+++ b/commands/WPCOM_Site_Create.php
@@ -57,13 +57,6 @@ final class WPCOM_Site_Create extends Command {
 	 */
 	private ?array $themes = null;
 
-	/**
-	 * Whether the user selected the "wpcom-theme" option.
-	 *
-	 * @var bool
-	 */
-	private bool $use_wpcom_theme = false;
-
 	// endregion
 
 	// region INHERITED METHODS
@@ -304,7 +297,9 @@ final class WPCOM_Site_Create extends Command {
 	 * @return void
 	 */
 	private function setup_no_code_theme( InputInterface $input, OutputInterface $output ): void {
-		$this->themes = get_wporg_theme_choices( $output );
+		$output->writeln( '<fg=magenta;options=bold>Fetching WordPress.org themes...</>' );
+
+		$this->themes = get_wporg_theme_choices();
 
 		// Inject the "wpcom-theme" option
 		$this->themes[] = (object) array(
@@ -330,10 +325,9 @@ final class WPCOM_Site_Create extends Command {
 		$this->no_code_theme = $this->prompt_no_code_theme_input( $input, $output, $this->themes );
 
 		if ( 'wpcom-theme' === $this->no_code_theme ) {
-			$this->use_wpcom_theme = true;
-			$question              = new Question( '<question>Please enter the slug of the WPCOM theme to use:</question> ' );
-			$theme_slug            = $this->getHelper( 'question' )->ask( $input, $output, $question );
-			$this->no_code_theme   = $theme_slug;
+			$question            = new Question( '<question>Please enter the slug of the WPCOM theme to use:</question> ' );
+			$theme_slug          = $this->getHelper( 'question' )->ask( $input, $output, $question );
+			$this->no_code_theme = $theme_slug;
 		}
 	}
 

--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,8 @@
   "config": {
     "allow-plugins": {
       "composer/*": true,
-      "dealerdirect/phpcodesniffer-composer-installer": true
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "phpstan/extension-installer": true
     },
     "platform": {
       "php": "8.2"

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
       "includes/functions-github.php",
       "includes/functions-jetpack.php",
       "includes/functions-pressable.php",
+      "includes/functions-wporg.php",
       "includes/functions-wpcom.php"
     ]
   },

--- a/includes/api-helper.php
+++ b/includes/api-helper.php
@@ -71,6 +71,19 @@ final class API_Helper {
 		return self::make_request( self::get_request_base_url() . "wpcom/v1/$endpoint", $method, $body );
 	}
 
+	/**
+	 * Calls a given WordPress.org endpoint and returns the response.
+	 *
+	 * @param   string $endpoint The endpoint to call.
+	 * @param   string $method   The HTTP method to use. One of 'GET', 'POST', 'PUT', 'DELETE'.
+	 * @param   mixed  $body     The body to send with the request.
+	 *
+	 * @return  stdClass|stdClass[]|true|null
+	 */
+	public static function make_wporg_request( string $endpoint, string $method = 'GET', mixed $body = null ): stdClass|array|true|null {
+		return self::make_request( self::get_request_base_url() . "wporg/v1/$endpoint", $method, $body );
+	}
+
 	// endregion
 
 	// region HELPERS

--- a/includes/functions-github.php
+++ b/includes/functions-github.php
@@ -2,6 +2,7 @@
 
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Helper\ProgressBar;
 
 // region API
 
@@ -253,6 +254,64 @@ function get_github_repository_from_deployhq_project( string $project ): ?stdCla
 	}
 
 	return get_github_repository( $gh_repo_url->repo );
+}
+
+/**
+ * Returns a list of workflow runs for a given GitHub repository.
+ *
+ * @param   string $repository The name of the repository to get the workflow runs for.
+ * @param   array  $params     The parameters to filter the results by.
+ *
+ * @return  stdClass[]|null
+ *
+ * @link    https://docs.github.com/en/rest/actions/workflow-runs#list-workflow-runs-for-a-repository
+ */
+function get_github_repository_workflow_runs( string $repository, array $params = array() ): ?array {
+	$endpoint = "repositories/$repository/workflows/runs";
+	if ( ! empty( $params ) ) {
+		$endpoint .= '?' . http_build_query( $params );
+	}
+
+	return API_Helper::make_github_request( $endpoint )?->records;
+}
+
+/**
+ * Waits for a workflow run to complete.
+ *
+ * @param   string          $repository    The name of the repository to wait for the workflow run in.
+ * @param   string          $workflow_name The name of the workflow to wait for.
+ * @param   OutputInterface $output        The output interface.
+ *
+ * @return  boolean
+ */
+function wait_for_github_repository_workflow_run_to_complete( string $repository, string $workflow_name, OutputInterface $output ): bool {
+	$output->writeln( '<comment>Waiting for workflow run ' . $workflow_name . ' to complete it could take a few minutes...</comment>' );
+
+	$progress_bar = new ProgressBar( $output );
+	$progress_bar->start();
+
+	$wait_time = 60 * 10; // 10 minutes
+
+	for ( $try = 0; $try < $wait_time; $try++ ) {
+		if ( 0 === $try % 10 ) {
+			$runs = get_github_repository_workflow_runs( $repository, array( 'status' => 'completed' ) );
+			foreach ( $runs as $run ) {
+				if ( $workflow_name === $run->name ) {
+					$output->writeln( '' );
+					$output->writeln( '<fg=green;options=bold>Workflow run ' . $workflow_name . ' completed.</>' );
+					return true;
+				}
+			}
+		}
+
+		$progress_bar->advance();
+		sleep( 5 );
+	}
+
+	$progress_bar->finish();
+	$output->writeln( '' ); // Empty line for UX purposes.
+
+	return false;
 }
 
 // endregion

--- a/includes/functions-wporg.php
+++ b/includes/functions-wporg.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 function get_wporg_theme_choices( OutputInterface $output ): array {
 
-	$output->writeln( '<info>Fetching WordPress.org themes...</info>' );
+	$output->writeln( '<fg=magenta;options=bold>Fetching WordPress.org themes...</>' );
 
 	$endpoint = 'themes'; // Equivalent to 'sites?type=all'.
 

--- a/includes/functions-wporg.php
+++ b/includes/functions-wporg.php
@@ -18,9 +18,18 @@ function get_wporg_theme_choices(): array {
 		return array();
 	}
 
+	if ( ! is_object( $response ) || ! isset( $response->records ) || ! is_iterable( $response->records ) ) {
+		return array();
+	}
+
+	$valid_themes = array_filter( $response->records, fn( $theme ) => isset( $theme->slug ) );
+	if ( empty( $valid_themes ) ) {
+		return array();
+	}
+
 	return array_combine(
-		array_map( fn( $theme ) => $theme->slug, $response->records ),
-		$response->records
+		array_map( fn( $theme ) => $theme->slug, $valid_themes ),
+		$valid_themes
 	);
 }
 // endregion

--- a/includes/functions-wporg.php
+++ b/includes/functions-wporg.php
@@ -1,0 +1,32 @@
+<?php
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+// region API
+
+/**
+ * Fetches the list of WordPress.org themes and returns them as an array of slugs.
+ *
+ * @param   OutputInterface $output The output interface.
+ *
+ * @return  string[]
+ */
+function get_wporg_theme_choices( OutputInterface $output ): array {
+
+	$output->writeln( '<info>Fetching WordPress.org themes...</info>' );
+
+	$endpoint = 'themes'; // Equivalent to 'sites?type=all'.
+
+	$response = API_Helper::make_wporg_request( $endpoint );
+	if ( is_null( $response ) ) {
+		return array();
+	}
+
+	return array_map(
+		function ( $theme ) {
+			return $theme->slug;
+		},
+		$response->records
+	);
+}
+// endregion

--- a/includes/functions-wporg.php
+++ b/includes/functions-wporg.php
@@ -7,13 +7,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 /**
  * Fetches the list of WordPress.org themes.
  *
- * @param   OutputInterface $output The output interface.
- *
  * @return  string[]
  */
-function get_wporg_theme_choices( OutputInterface $output ): array {
-
-	$output->writeln( '<fg=magenta;options=bold>Fetching WordPress.org themes...</>' );
+function get_wporg_theme_choices(): array {
 
 	$endpoint = 'themes'; // Equivalent to 'sites?type=all'.
 

--- a/includes/functions-wporg.php
+++ b/includes/functions-wporg.php
@@ -5,7 +5,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 // region API
 
 /**
- * Fetches the list of WordPress.org themes and returns them as an array of slugs.
+ * Fetches the list of WordPress.org themes.
  *
  * @param   OutputInterface $output The output interface.
  *
@@ -24,7 +24,7 @@ function get_wporg_theme_choices( OutputInterface $output ): array {
 
 	return array_combine(
 		array_map( fn( $theme ) => $theme->slug, $response->records ),
-		array_map( fn( $theme ) => $theme->name, $response->records )
+		$response->records
 	);
 }
 // endregion

--- a/includes/functions-wporg.php
+++ b/includes/functions-wporg.php
@@ -22,11 +22,9 @@ function get_wporg_theme_choices( OutputInterface $output ): array {
 		return array();
 	}
 
-	return array_map(
-		function ( $theme ) {
-			return $theme->slug;
-		},
-		$response->records
+	return array_combine(
+		array_map( fn( $theme ) => $theme->slug, $response->records ),
+		array_map( fn( $theme ) => $theme->name, $response->records )
 	);
 }
 // endregion

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -406,6 +406,52 @@ function get_site_input( InputInterface $input, ?callable $no_input_func = null,
 }
 
 /**
+ * Fetches the list of a8c themes in the parent directory of the Team51 CLI.
+ *
+ * @param   OutputInterface $output The console output.
+ *
+ * @return  array
+ */
+function get_a8c_theme_choices( OutputInterface $output ): array {
+	$output->writeln( '<comment>Fetching a8c themes in the parent directory of the Team51 CLI...</comment>' );
+	$a8c_themes_dir = dirname( TEAM51_CLI_ROOT_DIR ) . '/a8c-themes';
+
+	if ( ! is_dir( $a8c_themes_dir ) ) {
+		$command     = sprintf(
+			'cd %s && git clone git@github.com:Automattic/themes.git a8c-themes',
+			dirname( getcwd() )
+		);
+		$exec_output = array();
+		exec( $command, $exec_output, $return_code );
+		if ( 0 !== $return_code ) {
+			$output->writeln( '<error>Failed to clone a8c-themes repository.</error>' );
+			return array();
+		}
+	} else {
+		$command     = sprintf(
+			'cd %s && git pull',
+			$a8c_themes_dir
+		);
+		$exec_output = array();
+		exec( $command, $exec_output, $return_code );
+		if ( 0 !== $return_code ) {
+			$output->writeln( '<error>Failed to pull latest changes from a8c-themes repository.</error>' );
+			return array();
+		}
+	}
+
+	// Get list of main folders in the repo and set as keys and values
+	$folders = array_filter(
+		scandir( $a8c_themes_dir ),
+		function ( $item ) use ( $a8c_themes_dir ) {
+			return is_dir( $a8c_themes_dir . '/' . $item ) && ! in_array( $item, array( '.', '..', '.git' ), true );
+		}
+	);
+
+	return array_combine( $folders, $folders );
+}
+
+/**
  * Validates a given user's choice against a list of choices, and returns the key of the valid choice.
  * Tries to handle the case where the user input was either the key or the value, and always returns the key.
  *

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -8,6 +8,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Symfony\Component\Process\Exception\ProcessFailedException;
 use Symfony\Component\Process\Process;
+use Symfony\Component\Console\Helper\ProgressBar;
 
 // region HTTP
 
@@ -403,52 +404,6 @@ function get_site_input( InputInterface $input, ?callable $no_input_func = null,
 	}
 
 	return $site_id_or_url;
-}
-
-/**
- * Fetches the list of a8c themes in the parent directory of the Team51 CLI.
- *
- * @param   OutputInterface $output The console output.
- *
- * @return  array
- */
-function get_a8c_theme_choices( OutputInterface $output ): array {
-	$output->writeln( '<comment>Fetching a8c themes in the parent directory of the Team51 CLI...</comment>' );
-	$a8c_themes_dir = dirname( TEAM51_CLI_ROOT_DIR ) . '/a8c-themes';
-
-	if ( ! is_dir( $a8c_themes_dir ) ) {
-		$command     = sprintf(
-			'cd %s && git clone git@github.com:Automattic/themes.git a8c-themes',
-			dirname( getcwd() )
-		);
-		$exec_output = array();
-		exec( $command, $exec_output, $return_code );
-		if ( 0 !== $return_code ) {
-			$output->writeln( '<error>Failed to clone a8c-themes repository.</error>' );
-			return array();
-		}
-	} else {
-		$command     = sprintf(
-			'cd %s && git pull',
-			$a8c_themes_dir
-		);
-		$exec_output = array();
-		exec( $command, $exec_output, $return_code );
-		if ( 0 !== $return_code ) {
-			$output->writeln( '<error>Failed to pull latest changes from a8c-themes repository.</error>' );
-			return array();
-		}
-	}
-
-	// Get list of main folders in the repo and set as keys and values
-	$folders = array_filter(
-		scandir( $a8c_themes_dir ),
-		function ( $item ) use ( $a8c_themes_dir ) {
-			return is_dir( $a8c_themes_dir . '/' . $item ) && ! in_array( $item, array( '.', '..', '.git' ), true );
-		}
-	);
-
-	return array_combine( $folders, $folders );
 }
 
 /**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -452,6 +452,27 @@ function get_a8c_theme_choices( OutputInterface $output ): array {
 }
 
 /**
+ * Fetches the template entry from a theme's style.css file.
+ *
+ * @param   string $theme_path The path to the theme.
+ *
+ * @return  string|null
+ */
+function get_theme_template_entry( string $theme_path ): ?string {
+	$style_css_path = $theme_path . '/style.css';
+	if ( ! file_exists( $style_css_path ) ) {
+		return null;
+	}
+
+	$style_contents = file_get_contents( $style_css_path );
+	if ( preg_match( '/Template:\s*(\S+)/', $style_contents, $matches ) ) {
+		return $matches[1];
+	}
+
+	return null;
+}
+
+/**
  * Validates a given user's choice against a list of choices, and returns the key of the valid choice.
  * Tries to handle the case where the user input was either the key or the value, and always returns the key.
  *

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -435,9 +435,13 @@ function get_theme_template_entry( string $theme_path ): ?string {
 		return null;
 	}
 
-	$style_contents = file_get_contents( $style_css_path );
-	if ( preg_match( '/Template:\s*(\S+)/', $style_contents, $matches ) ) {
-		return $matches[1];
+	$style_contents = file_get_contents( $style_css_path, false, null, 0, 8192 );
+	if ( false === $style_contents ) {
+		return null;
+	}
+
+	if ( preg_match( '/Template:\s*(.+)$/mi', $style_contents, $matches ) ) {
+		return trim( $matches[1] );
 	}
 
 	return null;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for creating "no-code-project" repositories and sites, including interactive selection of project templates and no-code themes.
  * Users can now choose and customize WordPress.org themes during site or repository creation for "no-code-project" types.
  * Enhanced confirmation and prompt messages to reflect selected project templates and themes.
  * Introduced new commands to monitor GitHub workflow completion during repository setup.
  * Added functionality to fetch and display WordPress.org theme choices with autocompletion support.

* **Bug Fixes**
  * Excluded `.history` directory from code quality scans for improved performance and accuracy.

* **Chores**
  * Updated autoload configuration to include new helper functions for WordPress.org theme integration.
  * Added utility functions for theme template detection and GitHub workflow management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->