### PR TITLE
Add initial DeployHQ deployment trigger after site creation

### DIFF
--- a/commands/Pressable_Site_Create.php
+++ b/commands/Pressable_Site_Create.php
@@ -127,7 +127,19 @@ final class Pressable_Site_Create extends Command {
 		if ( ! \is_null( $this->gh_repository ) ) {
 			$deployhq_project = create_deployhq_project_for_pressable_site( $site, $this->gh_repository, $this->name );
 			if ( ! \is_null( $deployhq_project ) ) {
-				create_deployhq_project_server_for_pressable_site( $site, $deployhq_project, 'Production', 'trunk' );
+				$deployhq_server = create_deployhq_project_server_for_pressable_site( $site, $deployhq_project, 'Production', 'trunk' );
+
+				// Trigger initial deployment
+				if ( ! \is_null( $deployhq_server ) ) {
+					$output->writeln( '<fg=magenta;options=bold>Triggering initial deployment...</>' );
+
+					$deployment_success = trigger_deployhq_deployment( $deployhq_project, $this->gh_repository, 'trunk' );
+					if ( $deployment_success ) {
+						$output->writeln( '<fg=green;options=bold>Initial deployment triggered successfully.</>' );
+					} else {
+						$output->writeln( '<error>Failed to trigger initial deployment. You may need to manually deploy from the DeployHQ dashboard.</error>' );
+					}
+				}
 			}
 		}
 

--- a/includes/functions-deployhq.php
+++ b/includes/functions-deployhq.php
@@ -153,6 +153,43 @@ function create_deployhq_project_server( string $project, string $name, array $p
 	);
 }
 
+/**
+ * Triggers a deployment for a DeployHQ project using its auto deploy webhook URL.
+ *
+ * @param   stdClass $deployhq_project The DeployHQ project object.
+ * @param   stdClass $github_repository The GitHub repository object.
+ * @param   string   $branch           The branch to deploy from.
+ * @param   string   $email            The email address to notify on completion.
+ *
+ * @return  bool
+ */
+function trigger_deployhq_deployment( stdClass $deployhq_project, stdClass $github_repository, string $branch = 'trunk', string $email = 'concierge@wordpress.com' ): bool {
+	$payload = array(
+		'payload' => array(
+			'new_ref'   => 'latest',
+			'branch'    => $branch,
+			'email'     => $email,
+			'clone_url' => $github_repository->ssh_url,
+		),
+	);
+
+	$response = get_remote_content(
+		$deployhq_project->auto_deploy_url,
+		array(
+			'Content-Type' => 'application/json',
+		),
+		'POST',
+		encode_json_content( $payload )
+	);
+
+	if ( is_null( $response ) ) {
+		return false;
+	}
+
+	// Check if the response indicates success (2xx status codes)
+	return str_starts_with( (string) $response['headers']['http_code'], '2' );
+}
+
 // endregion
 
 // region CONSOLE

--- a/includes/functions-deployhq.php
+++ b/includes/functions-deployhq.php
@@ -164,6 +164,12 @@ function create_deployhq_project_server( string $project, string $name, array $p
  * @return  bool
  */
 function trigger_deployhq_deployment( stdClass $deployhq_project, stdClass $github_repository, string $branch = 'trunk', string $email = 'concierge@wordpress.com' ): bool {
+	// Validate required properties
+	if ( empty( $deployhq_project->auto_deploy_url ) || empty( $github_repository->ssh_url ) ) {
+		console_writeln( '❌ DeployHQ deployment failed: missing auto_deploy_url or ssh_url.' );
+		return false;
+	}
+
 	$payload = array(
 		'payload' => array(
 			'new_ref'   => 'latest',
@@ -183,11 +189,18 @@ function trigger_deployhq_deployment( stdClass $deployhq_project, stdClass $gith
 	);
 
 	if ( is_null( $response ) ) {
+		console_writeln( '❌ DeployHQ deployment failed: no response from auto_deploy_url.' );
 		return false;
 	}
 
-	// Check if the response indicates success (2xx status codes)
-	return str_starts_with( (string) $response['headers']['http_code'], '2' );
+	// Ensure we have an HTTP status code and it’s 2xx
+	$http_code = $response['headers']['http_code'] ?? null;
+	if ( ! $http_code || ! str_starts_with( (string) $http_code, '2' ) ) {
+		console_writeln( "❌ DeployHQ deployment failed with HTTP code: {$http_code}" );
+		return false;
+	}
+
+	return true;
 }
 
 // endregion


### PR DESCRIPTION
After a new Pressable site is created, the repository isn't deployed, and requires a either a manual deployment in DeployHQ or a commit to trunk (to trigger a deployment).

This PR introduces a new function, `trigger_deployhq_deployment`, to programmatically trigger an initial deployment via DeployHQ after creating a project server. It also updates `Pressable_Site_Create` to call this function and provide user feedback on deployment status.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic triggering of an initial deployment after creating a DeployHQ project server for a site.
  * Users now receive clear success or error messages regarding the deployment initiation, with guidance for manual action if needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->