### PR TITLE
Adding --skip-themes --skip-plugins to safetynet install command on the site cloning

### DIFF
--- a/commands/Pressable_Site_Clone.php
+++ b/commands/Pressable_Site_Clone.php
@@ -243,7 +243,7 @@ final class Pressable_Site_Clone extends Command {
 			);
 
 			if ( ! $safety_net_installed ) {
-				run_pressable_site_wp_cli_command( $site_clone->id, 'plugin install https://github.com/a8cteam51/safety-net/releases/latest/download/safety-net.zip' );
+				run_pressable_site_wp_cli_command( $site_clone->id, 'plugin install https://github.com/a8cteam51/safety-net/releases/latest/download/safety-net.zip --skip-plugins --skip-themes' );
 				$ssh_connection->exec( 'mv -f htdocs/wp-content/plugins/safety-net htdocs/wp-content/mu-plugins/safety-net' );
 				$ssh_connection->exec(
 					'ls htdocs/wp-content/mu-plugins',
@@ -280,8 +280,6 @@ final class Pressable_Site_Clone extends Command {
 			);
 		}
 
-		// Done last because it seems to cause issues sometimes with the connection breaking off.
-		run_pressable_site_wp_cli_command( $site_clone->id, "search-replace {$this->site->url} $site_clone->url" );
 		run_pressable_site_wp_cli_command( $site_clone->id, 'cache flush' );
 
 		return Command::SUCCESS;

--- a/commands/WPCOM_Site_Clone.php
+++ b/commands/WPCOM_Site_Clone.php
@@ -180,7 +180,6 @@ final class WPCOM_Site_Clone extends Command {
 		);
 
 		run_wpcom_site_wp_cli_command( $staging_site->id, 'config set WP_ENVIRONMENT_TYPE development --type=constant' );
-		run_wpcom_site_wp_cli_command( $staging_site->id, "search-replace {$this->site->URL} $staging_site_https_url" );
 		run_wpcom_site_wp_cli_command( $staging_site->id, 'cache flush' );
 
 		if ( $this->skip_safety_net ) {
@@ -201,7 +200,7 @@ final class WPCOM_Site_Clone extends Command {
 			);
 
 			if ( ! $safety_net_installed ) {
-				run_wpcom_site_wp_cli_command( $transfer->blog_id, 'plugin install https://github.com/a8cteam51/safety-net/releases/latest/download/safety-net.zip' );
+				run_wpcom_site_wp_cli_command( $transfer->blog_id, 'plugin install https://github.com/a8cteam51/safety-net/releases/latest/download/safety-net.zip --skip-plugins --skip-themes' );
 				$ssh_connection->exec( 'mv -f htdocs/wp-content/plugins/safety-net htdocs/wp-content/mu-plugins/safety-net' );
 				$ssh_connection->exec(
 					'ls htdocs/wp-content/mu-plugins',


### PR DESCRIPTION
# In this PR
- Add --skip-themes --skip-plugins to the safetynet install command on the site cloning (in case there's an issue with the site, we're still able to install safety.net)
- Remove the search-replace step from the site cloning processes as WP Cloud already includes this on the infrastructure cloning process

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of SafetyNet plugin installation during site cloning and staging by skipping the loading of other plugins and themes.
  * Removed the automatic URL search-and-replace step during site clone and staging processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->