### PR TITLE
Adding an SSH troubleshooting note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,4 +111,4 @@ You will then need to run `brew link php@8.2` so that PHP gets symlinked properl
 
 ### `git@github.com: Permission denied (publickey)`
 
-This is likely to happen if you moved/migrated from another computer and the key you used to authenticate with GitHub is not working anymore. This [guide](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) should help you set up a new SSH key.  
+This is likely to happen if you moved/migrated from another computer and the key you used to authenticate with GitHub is not working anymore. This [guide](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) should help you set up a new SSH key. Alternatively, you can bypass this issue by cloning the repository using GitHub Desktop, which handles authentication automatically.

--- a/README.md
+++ b/README.md
@@ -111,4 +111,4 @@ You will then need to run `brew link php@8.2` so that PHP gets symlinked properl
 
 ### `git@github.com: Permission denied (publickey)`
 
-This is likely to happen if you moved/migrated from another computer and the key you used to authenticate with GitHub is not working anymore. This [guide](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) should help you set up a new SSH key. Alternatively, you can bypass this issue by cloning the repository using GitHub Desktop, which handles authentication automatically.
+This is likely to happen if you moved/migrated from another computer and the key you used to authenticate with GitHub is not working anymore. This [guide](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent) should help you set up a new SSH key. Alternatively, you can bypass this issue by [cloning the repository using GitHub Desktop](https://docs.github.com/en/desktop/adding-and-cloning-repositories/cloning-a-repository-from-github-to-github-desktop), which handles authentication automatically.


### PR DESCRIPTION
I kept running into the `Permission denied (publickey)` error when trying to clone the repo. I'm not sure if the process is slightly different for full-timers, but as a contractor, I didn't receive the "AutoProxy passphrase" mentioned in the [installation guide](https://github.com/a8cteam51/team51-cli?tab=readme-ov-file#installation). The only thing that worked for me was cloning the repo via GitHub Desktop, which handled the authentication automatically.

This PR adds a note to the README with a suggestion to use GitHub Desktop as a workaround. :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the troubleshooting section in the README to include an alternative solution for resolving the `git@github.com: Permission denied (publickey)` error by suggesting the use of GitHub Desktop for cloning repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->