### PR TITLE
Add site-redesign conditional tag

### DIFF
--- a/commands/GitHub_Checklist_Add.php
+++ b/commands/GitHub_Checklist_Add.php
@@ -69,6 +69,10 @@ final class GitHub_Checklist_Add extends Command {
 			'question'    => 'Has the site previously been hosted on WordPress.com or WordPress VIP?',
 			'description' => 'The site has previously been hosted on WordPress.com or WordPress VIP.',
 		),
+		'site-redesign' => array(
+			'question'    => 'Is this a redesign of a site that has an existing T51 repo?',
+			'description' => 'This site already has a Team 51 GitHub code repository',
+		),
 	);
 
 	/**

--- a/commands/GitHub_Checklist_Add.php
+++ b/commands/GitHub_Checklist_Add.php
@@ -71,7 +71,7 @@ final class GitHub_Checklist_Add extends Command {
 		),
 		'site-redesign' => array(
 			'question'    => 'Is this a redesign of a site that has an existing/prior T51 repo?',
-			'description' => 'This site already has a Team 51 GitHub code repository',
+			'description' => 'This site already has a Team 51 GitHub code repository.',
 		),
 	);
 

--- a/commands/GitHub_Checklist_Add.php
+++ b/commands/GitHub_Checklist_Add.php
@@ -70,7 +70,7 @@ final class GitHub_Checklist_Add extends Command {
 			'description' => 'The site has previously been hosted on WordPress.com or WordPress VIP.',
 		),
 		'site-redesign' => array(
-			'question'    => 'Is this a redesign of a site that has an existing T51 repo?',
+			'question'    => 'Is this a redesign of a site that has an existing/prior T51 repo?',
 			'description' => 'This site already has a Team 51 GitHub code repository',
 		),
 	);


### PR DESCRIPTION
Adds a `site-redesign` prompt to the `github:add-checklist` command that can then be used to parse launch checklists found in the `special-projects-checklists` repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "site-redesign" checklist option for identifying site redesigns with existing Team 51 GitHub repositories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->