### PR TITLE
Add wp-subdomain conditional tag

### DIFF
--- a/commands/GitHub_Checklist_Add.php
+++ b/commands/GitHub_Checklist_Add.php
@@ -69,6 +69,10 @@ final class GitHub_Checklist_Add extends Command {
 			'question'    => 'Has the site previously been hosted on WordPress.com or WordPress VIP?',
 			'description' => 'The site has previously been hosted on WordPress.com or WordPress VIP.',
 		),
+		'wp-subdomain' => array(
+			'question'    => 'Will the final URL be a subdomain of WordPress.com or WordPress.org?',
+			'description' => 'The site uses a subdomain of WordPress.com or WordPress.org.',
+		),
 	);
 
 	/**


### PR DESCRIPTION
Adds a `wp-subdomain` prompt to the `github:add-checklist` command that can then be used to parse launch checklists found in the `special-projects-checklists` repo.

Specifically, we want to avoid adding or testing for a `www` sub-subdomain in the `launch-site.md` [checklist](https://github.com/a8cteam51/special-projects-checklists/blob/trunk/checklists/launch/launch-site.md), since doing so is an unsupported anti-pattern: pMz3w-lWV-p2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new checklist condition for WordPress.com/WordPress.org subdomains.
  * During setup, you may be asked if the final URL will use a WordPress.com or WordPress.org subdomain.
  * Checklist sections will automatically show or hide based on your answer, tailoring guidance to your site’s configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->