### PR TITLE
Reorder command arguments in Pressable_Site_WP_CLI_Command_Run class

### DIFF
--- a/commands/Pressable_Site_WP_CLI_Command_Run.php
+++ b/commands/Pressable_Site_WP_CLI_Command_Run.php
@@ -61,8 +61,8 @@ final class Pressable_Site_WP_CLI_Command_Run extends Command {
 		$this->setDescription( 'Runs a given WP-CLI command on a given Pressable site.' )
 			->setHelp( 'This command allows you to run an arbitrary WP-CLI command on a Pressable site.' );
 
-		$this->addArgument( 'wp-cli-command', InputArgument::REQUIRED, 'The WP-CLI command to run.' )
-			->addArgument( 'site', InputArgument::OPTIONAL, 'The domain or numeric Pressable ID of the site to open the shell to.' );
+		$this->addArgument( 'site', InputArgument::REQUIRED, 'The domain or numeric Pressable ID of the site to open the shell to.' )
+			->addArgument( 'wp-cli-command', InputArgument::REQUIRED, 'The WP-CLI command to run.' );
 
 		$this->addOption( 'multiple', null, InputOption::VALUE_REQUIRED, 'Determines whether the `site` argument is optional or not. Accepted values are `all` or a comma-separated list of site IDs or domains.' )
 			->addOption( 'skip-output', null, InputOption::VALUE_NONE, 'Skip outputting the response to the console.' );


### PR DESCRIPTION
### Changes proposed
- Swapped the order of 'site' and 'wp-cli-command' arguments for clarity.
- This order makes more sense and also matches a similar command for WPCOM `wpcom:run-site-wp-cli-command`
- Also made Site a mandatory value, instead of optional

### How to reproduce issue

- Open the Terminal
- Run `team51 pressable:run-site-wp-cli-command "https://mishtalk.com" "wp plugin list"`
- Notice how URL is first arguent and the WP command is the second argument
- Expected: the WP is successfully executed on that site URL
- Actual: OpsOasis receives the command `wp+plugin+list` as the Site ID: `❌ API error (404 https://opsoasis.wpspecialprojects.com/wp-json/wpcomsp/pressable/v1/sites/wp+plugin+list): {"code":"rest_no_route","message":"No route was found matching the URL and request method.","data":{"status":404}}`

The command for WPCOM, `wpcom:run-site-wp-cli-command`, does take as the first argument the Site URL.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated CLI command usage: now requires two arguments in this order—site (domain or ID) followed by the WP-CLI command.
  * Previously, the WP-CLI command came first and the site was optional.
  * Scripts or aliases using the old order will fail; update your usage to the new format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->