### PR TITLE
Created the site:remove-atlantis-legacy-modules command

### DIFF
--- a/commands/GitHub_Repository_Audit.php
+++ b/commands/GitHub_Repository_Audit.php
@@ -1,0 +1,282 @@
+<?php
+
+namespace WPCOMSpecialProjects\CLI\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Audits a8cteam51 GitHub repositories for legacy modules.
+ *
+ * Examples:
+ *   # Check for trunk/master/main branches (default) and scan for legacy modules
+ *   team51 github:audit-repositories --export=repos-audit.csv
+ *
+ *   # Check for develop branch only (original behavior)
+ *   team51 github:audit-repositories --branches=develop --export=repos-develop.csv
+ *
+ *   # Check for specific branches
+ *   team51 github:audit-repositories --branches=trunk,main --export=repos-audit.csv
+ */
+#[AsCommand( name: 'github:audit-repositories' )]
+final class GitHub_Repository_Audit extends Command {
+
+	// region FIELDS AND CONSTANTS
+
+	/**
+	 * The list of GitHub repositories to process.
+	 *
+	 * @var stdClass[]|null
+	 */
+	private ?array $repositories = null;
+
+	/**
+	 * The branches to check for on each repository.
+	 *
+	 * @var string[]
+	 */
+	private array $branches = array( 'trunk', 'master', 'main' );
+
+	/**
+	 * The terms to search for in directory listings.
+	 *
+	 * @var string[]
+	 */
+	private array $search_terms = array(
+		'colophon',
+		'team51-tracking',
+		'plugin-autoupdate-filter',
+	);
+
+	/**
+	 * The directories to scan for legacy modules.
+	 *
+	 * @var string[]
+	 */
+	private array $search_dirs = array(
+		'plugins',
+		'mu-plugins',
+		'modules',
+	);
+
+	/**
+	 * File handle for CSV export.
+	 *
+	 * @var resource|null
+	 */
+	private $stream = null;
+
+	// endregion
+
+	// region INHERITED METHODS
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function configure(): void {
+		$this->setDescription( 'Audits a8cteam51 GitHub repositories for legacy modules.' )
+			->setHelp( 'Lists all repositories, checks for specified branches, and scans for legacy modules (colophon, team51-tracking, plugin-autoupdate-filter) in plugins, mu-plugins, and modules directories.' );
+
+		$this->addOption( 'export', null, InputOption::VALUE_REQUIRED, 'Path to export CSV results to.' )
+			->addOption( 'branches', null, InputOption::VALUE_REQUIRED, 'Comma-separated list of branches to check for (default: trunk,master,main).' )
+			->addOption( 'terms', null, InputOption::VALUE_REQUIRED, 'Comma-separated list of terms to search for (default: colophon,team51-tracking,plugin-autoupdate-filter).' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function initialize( InputInterface $input, OutputInterface $output ): void {
+		// Override branches if provided.
+		$branches = $input->getOption( 'branches' );
+		if ( ! empty( $branches ) ) {
+			$this->branches = array_map( 'trim', explode( ',', $branches ) );
+		}
+
+		// Override search terms if provided.
+		$terms = $input->getOption( 'terms' );
+		if ( ! empty( $terms ) ) {
+			$this->search_terms = array_map( 'trim', explode( ',', $terms ) );
+		}
+
+		// Fetch all repositories.
+		$output->writeln( '<comment>Fetching all a8cteam51 repositories...</comment>' );
+		$this->repositories = get_github_repositories();
+		if ( empty( $this->repositories ) ) {
+			$output->writeln( '<error>No repositories found.</error>' );
+			return;
+		}
+		$output->writeln( '<info>Found ' . count( $this->repositories ) . ' repositories.</info>' );
+
+		// Build branch column headers.
+		$branch_headers = array_map( fn( $b ) => "Has {$b}", $this->branches );
+
+		// Open export file if requested and write headers immediately.
+		$export_path = $input->getOption( 'export' );
+		if ( ! empty( $export_path ) ) {
+			$this->stream = get_file_handle( $export_path, 'csv' );
+			$headers      = array_merge( array( 'Repository' ), $branch_headers, $this->search_terms );
+			\fputcsv( $this->stream, $headers );
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( InputInterface $input, OutputInterface $output ): int {
+		if ( empty( $this->repositories ) ) {
+			return Command::FAILURE;
+		}
+
+		$output->writeln( '<fg=magenta;options=bold>Auditing repositories for legacy modules...</>' );
+
+		$results = array();
+		$total   = count( $this->repositories );
+
+		$progress_bar = new ProgressBar( $output, $total );
+		$progress_bar->setFormat( ' %current%/%max% [%bar%] %percent:3s%% %message%' );
+		$progress_bar->setMessage( 'Starting...' );
+		$progress_bar->start();
+
+		foreach ( $this->repositories as $repo ) {
+			$progress_bar->setMessage( $repo->name );
+			$progress_bar->advance();
+
+			// Check which branches exist.
+			$repo_branches  = $this->get_repo_branch_names( $repo->name );
+			$scan_branch    = null;
+
+			$row = array( 'Repository' => $repo->name );
+
+			foreach ( $this->branches as $branch ) {
+				$has_branch          = \in_array( $branch, $repo_branches, true );
+				$row[ "Has {$branch}" ] = $has_branch ? 'Yes' : 'No';
+
+				// Use the first matching branch for module scanning.
+				if ( $has_branch && null === $scan_branch ) {
+					$scan_branch = $branch;
+				}
+			}
+
+			if ( null !== $scan_branch ) {
+				$found_modules = $this->scan_repo_for_modules( $repo->name, $scan_branch );
+				foreach ( $this->search_terms as $term ) {
+					$row[ $term ] = $found_modules[ $term ] ?? '';
+				}
+			} else {
+				foreach ( $this->search_terms as $term ) {
+					$row[ $term ] = '';
+				}
+			}
+
+			$results[] = $row;
+
+			// Write row to CSV immediately so results are available during the run.
+			if ( null !== $this->stream ) {
+				\fputcsv( $this->stream, array_values( $row ) );
+				\fflush( $this->stream );
+			}
+		}
+
+		$progress_bar->finish();
+		$output->writeln( '' );
+
+		// Build branch column headers.
+		$branch_headers = array_map( fn( $b ) => "Has {$b}", $this->branches );
+
+		// Output console table.
+		$headers = array_merge( array( 'Repository' ), $branch_headers, $this->search_terms );
+		output_table( $output, array_map( 'array_values', $results ), $headers, 'Repository Audit - Legacy Modules' );
+
+		// Summary statistics.
+		$output->writeln( '' );
+		$output->writeln( "<info>Total repositories: {$total}</info>" );
+
+		foreach ( $this->branches as $branch ) {
+			$count = count( array_filter( $results, fn( $r ) => 'Yes' === $r[ "Has {$branch}" ] ) );
+			$output->writeln( "<info>Repositories with '{$branch}' branch: {$count}</info>" );
+		}
+
+		$repos_with_modules = count(
+			array_filter(
+				$results,
+				function ( $r ) {
+					foreach ( $this->search_terms as $term ) {
+						if ( ! empty( $r[ $term ] ) ) {
+							return true;
+						}
+					}
+					return false;
+				}
+			)
+		);
+		$output->writeln( "<info>Repositories with legacy modules: {$repos_with_modules}</info>" );
+
+		// Close CSV file.
+		if ( null !== $this->stream ) {
+			\fclose( $this->stream );
+
+			$export_path = $input->getOption( 'export' );
+			$output->writeln( "<info>Results exported to {$export_path}</info>" );
+		}
+
+		return Command::SUCCESS;
+	}
+
+	// endregion
+
+	// region HELPERS
+
+	/**
+	 * Returns the list of branch names for a repository.
+	 *
+	 * @param   string $repository The name of the repository.
+	 *
+	 * @return  string[]
+	 */
+	private function get_repo_branch_names( string $repository ): array {
+		$branches = get_github_repository_branches( $repository );
+		if ( empty( $branches ) ) {
+			return array();
+		}
+
+		return array_column( $branches, 'name' );
+	}
+
+	/**
+	 * Scans a repo's branch for legacy modules in plugins/mu-plugins/modules directories.
+	 *
+	 * @param   string $repository The name of the repository.
+	 * @param   string $ref        The branch to scan.
+	 *
+	 * @return  array Associative array: term => location path(s).
+	 */
+	private function scan_repo_for_modules( string $repository, string $ref ): array {
+		$found = array();
+
+		foreach ( $this->search_dirs as $dir ) {
+			$contents = get_github_repository_contents( $repository, $dir, $ref );
+			if ( empty( $contents ) ) {
+				continue;
+			}
+
+			foreach ( $contents as $item ) {
+				foreach ( $this->search_terms as $term ) {
+					if ( $item->name === $term || str_starts_with( $item->name, $term . '-' ) ) {
+						$location      = $dir . '/' . $item->name;
+						$found[ $term ] = isset( $found[ $term ] )
+							? $found[ $term ] . ', ' . $location
+							: $location;
+					}
+				}
+			}
+		}
+
+		return $found;
+	}
+
+	// endregion
+}

--- a/commands/GitHub_Repository_Secret_Update.php
+++ b/commands/GitHub_Repository_Secret_Update.php
@@ -114,11 +114,11 @@ final class GitHub_Repository_Secret_Update extends Command {
 			$output->writeln( "<fg=magenta;options=bold>Setting the GitHub repository secret $this->secret_name on `$repository->name`.</>" );
 
 			// Check that the secrets exist before proceeding.
-			$secrets = get_github_repository_secrets( $repository->name );
-			if ( ! \in_array( $this->secret_name, \array_column( $secrets ?? array(), 'name' ), true ) ) {
-				$output->writeln( "<comment>Secret $this->secret_name not found on `$repository->name`. Skipping...</comment>" );
-				continue;
-			}
+			// $secrets = get_github_repository_secrets( $repository->name );
+			// if ( ! \in_array( $this->secret_name, \array_column( $secrets ?? array(), 'name' ), true ) ) {
+			// 	$output->writeln( "<comment>Secret $this->secret_name not found on `$repository->name`. Skipping...</comment>" );
+			// 	continue;
+			// }
 
 			$result = set_github_repository_secret( $repository->name, $this->secret_name, $this->secret_value );
 			if ( \is_null( $result ) ) {
@@ -127,6 +127,7 @@ final class GitHub_Repository_Secret_Update extends Command {
 			}
 
 			$output->writeln( "<fg=green;options=bold>Successfully updated secret $this->secret_name on `$repository->name`.</>" );
+			sleep( 15 );
 		}
 
 		return Command::SUCCESS;

--- a/commands/Jetpack_Site_Connection_Triage.php
+++ b/commands/Jetpack_Site_Connection_Triage.php
@@ -180,7 +180,7 @@ EOT
 			);
 			$context     = stream_context_create( $options );
 			$result      = @file_get_contents( $site_url, false, $context );
-			$headers     = parse_http_headers( $http_response_header );
+			$headers     = parse_http_headers( http_get_last_response_headers() );
 			$status_code = $headers['http_code'];
 
 			if ( 410 === $status_code && $this->is_staging_domain( $site_url ) ) {
@@ -201,7 +201,8 @@ EOT
 				// Check WPCOM API for site information
 				$wpcom_api_url = 'https://public-api.wordpress.com/rest/v1.1/sites/' . rawurlencode( $domain );
 				$wpcom_result  = @file_get_contents( $wpcom_api_url, false, $context );
-				$wpcom_status  = $http_response_header ? parse_http_headers( $http_response_header )['http_code'] : '';
+				$wpcom_headers = http_get_last_response_headers();
+				$wpcom_status  = $wpcom_headers ? parse_http_headers( $wpcom_headers )['http_code'] : '';
 
 				if ( '400' === $wpcom_status ) {
 					$notes = 'Site is not connected to WordPress.com. If site loads, it may have moved hosts.';

--- a/commands/Site_Atlantis_Readiness_Audit.php
+++ b/commands/Site_Atlantis_Readiness_Audit.php
@@ -1,0 +1,1040 @@
+<?php
+
+namespace WPCOMSpecialProjects\CLI\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use WPCOMSpecialProjects\CLI\Helper\AutocompleteTrait;
+
+/**
+ * Audits sites for Atlantis installation readiness from a CSV file.
+ *
+ * This is a read-only command that evaluates each site's readiness for Atlantis
+ * installation without making any changes. Checks include: site existence, SSH
+ * access, PHP version, Atlantis installation status, legacy plugins on the site,
+ * linked GitHub repository, and legacy plugins in the repository.
+ *
+ * Examples:
+ *   # Audit sites from a CSV file
+ *   team51 site:atlantis-readiness-audit --sites=my-sites.csv
+ *
+ *   # Audit with custom export path
+ *   team51 site:atlantis-readiness-audit --sites=my-sites.csv --export=results.csv
+ *
+ * CSV File Format:
+ *   The input CSV file should have at minimum the following columns: Site/Site Name, URL/Domain, Host
+ *   Example:
+ *     "Site Name",Domain,"Site ID",Host
+ *     "Example Site",https://example.mystagingwebsite.com,123456,Pressable
+ */
+#[AsCommand( name: 'site:atlantis-readiness-audit' )]
+final class Site_Atlantis_Readiness_Audit extends Command {
+	use AutocompleteTrait;
+
+	// region FIELDS AND CONSTANTS
+
+	/**
+	 * Path to the input CSV file.
+	 *
+	 * @var string|null
+	 */
+	private ?string $sites_csv_path = null;
+
+	/**
+	 * Path to the export CSV file.
+	 *
+	 * @var string|null
+	 */
+	private ?string $export_csv_path = null;
+
+	/**
+	 * File handle for CSV export.
+	 *
+	 * @var resource|null
+	 */
+	private $export_stream = null;
+
+	/**
+	 * Legacy plugin prefixes to check.
+	 *
+	 * @var array
+	 */
+	private array $legacy_plugins = array(
+		'colophon',
+		'plugin-autoupdate-filter',
+		'team51-tracking',
+	);
+
+	/**
+	 * Branch priority for repository checks.
+	 *
+	 * @var array
+	 */
+	private array $branch_priority = array( 'trunk', 'master', 'main' );
+
+	/**
+	 * Minimum PHP version for Atlantis.
+	 *
+	 * @var string
+	 */
+	private string $min_php_version = '8.3';
+
+	/**
+	 * Output CSV column headers.
+	 *
+	 * @var array
+	 */
+	private array $csv_headers = array(
+		'Site',
+		'URL',
+		'Host (CSV)',
+		'Host (Resolved)',
+		'Site Exists',
+		'SSH Access',
+		'PHP Version',
+		'PHP Ready',
+		'Atlantis Status',
+		'Legacy Plugins (Site)',
+		'Repository',
+		'Repo Branch',
+		'Legacy Plugins (Repo)',
+		'Notes',
+	);
+
+	/**
+	 * Collected audit results for the summary table.
+	 *
+	 * @var array
+	 */
+	private array $results = array();
+
+	// endregion
+
+	// region INHERITED METHODS
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function configure(): void {
+		$this->setDescription( 'Audits sites for Atlantis installation readiness from a CSV file.' )
+			->setHelp( 'Reads a CSV file of sites and performs read-only checks to determine each site\'s readiness for Atlantis installation. No modifications are made.' );
+
+		$this->addOption( 'sites', null, InputOption::VALUE_REQUIRED, 'Path to the input CSV file (required). Format: Site,URL,Host columns.' )
+			->addOption( 'export', null, InputOption::VALUE_REQUIRED, 'Path to the output CSV file. Defaults to atlantis-readiness-audit-{timestamp}.csv.' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function initialize( InputInterface $input, OutputInterface $output ): void {
+		$this->sites_csv_path = $input->getOption( 'sites' );
+		if ( empty( $this->sites_csv_path ) ) {
+			$output->writeln( '<error>The --sites option is required. Provide a path to a CSV file.</error>' );
+			exit( 1 );
+		}
+
+		if ( ! file_exists( $this->sites_csv_path ) ) {
+			$output->writeln( "<error>CSV file not found: {$this->sites_csv_path}</error>" );
+			exit( 1 );
+		}
+
+		$export_option = $input->getOption( 'export' );
+		if ( empty( $export_option ) ) {
+			$this->export_csv_path = 'atlantis-readiness-audit-' . gmdate( 'Y-m-d-His' ) . '.csv';
+		} else {
+			$this->export_csv_path = $export_option;
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( InputInterface $input, OutputInterface $output ): int {
+		$output->writeln( '<fg=magenta;options=bold>Atlantis Readiness Audit</>' );
+		$output->writeln( '' );
+
+		// Read the input CSV.
+		$csv_data = $this->read_csv( $this->sites_csv_path );
+		if ( empty( $csv_data ) ) {
+			$output->writeln( '<error>No valid sites found in CSV file.</error>' );
+			return Command::FAILURE;
+		}
+
+		// Validate required columns.
+		$first_row = reset( $csv_data );
+		foreach ( array( 'Site', 'URL', 'Host' ) as $column ) {
+			if ( ! isset( $first_row[ $column ] ) ) {
+				$output->writeln( "<error>CSV file is missing required column: {$column}</error>" );
+				return Command::FAILURE;
+			}
+		}
+
+		// Check for existing export CSV to enable resume.
+		$already_processed = array();
+		$resuming          = false;
+		if ( file_exists( $this->export_csv_path ) ) {
+			$existing_handle = fopen( $this->export_csv_path, 'r' );
+			if ( false !== $existing_handle ) {
+				$existing_headers = fgetcsv( $existing_handle );
+				if ( false !== $existing_headers ) {
+					$url_index = array_search( 'URL', $existing_headers, true );
+					if ( false !== $url_index ) {
+						while ( ( $existing_row = fgetcsv( $existing_handle ) ) !== false ) {
+							if ( isset( $existing_row[ $url_index ] ) && ! empty( $existing_row[ $url_index ] ) ) {
+								$already_processed[ $existing_row[ $url_index ] ] = true;
+							}
+						}
+					}
+				}
+				fclose( $existing_handle );
+			}
+
+			if ( ! empty( $already_processed ) ) {
+				$resuming = true;
+				$output->writeln( "<info>Resuming: found " . count( $already_processed ) . " already-processed sites in {$this->export_csv_path}</info>" );
+				$output->writeln( '' );
+			}
+		}
+
+		// Open export CSV - append if resuming, otherwise write headers.
+		if ( $resuming ) {
+			$this->export_stream = fopen( $this->export_csv_path, 'a' );
+		} else {
+			$this->export_stream = get_file_handle( $this->export_csv_path, 'csv' );
+			fputcsv( $this->export_stream, $this->csv_headers );
+		}
+
+		$total   = count( $csv_data );
+		$counter = 0;
+		$skipped = 0;
+
+		foreach ( $csv_data as $site_data ) {
+			++$counter;
+			$site_name = $site_data['Site'] ?? 'Unknown';
+			$site_url  = $site_data['URL'] ?? '';
+			$csv_host  = strtolower( trim( $site_data['Host'] ?? '' ) );
+
+			// Skip "other" hosts entirely.
+			if ( 'other' === $csv_host ) {
+				$output->writeln( "<comment>[{$counter}/{$total}] Skipping: {$site_name} (host: other)</comment>" );
+				++$skipped;
+				continue;
+			}
+
+			// Validate required fields.
+			if ( empty( $site_url ) || empty( $csv_host ) ) {
+				$output->writeln( "<comment>[{$counter}/{$total}] Skipping: {$site_name} (missing URL or Host)</comment>" );
+				++$skipped;
+				continue;
+			}
+
+			// Skip already-processed sites when resuming.
+			if ( isset( $already_processed[ $site_url ] ) ) {
+				$output->writeln( "<comment>[{$counter}/{$total}] Already processed: {$site_name} ({$site_url})</comment>" );
+				++$skipped;
+				continue;
+			}
+
+			$output->writeln( "<info>[{$counter}/{$total}] Auditing: {$site_name} ({$site_url}) [{$csv_host}]</info>" );
+
+			// Initialize result row with defaults.
+			$row = array(
+				'Site'                  => $site_name,
+				'URL'                   => $site_url,
+				'Host (CSV)'            => $csv_host,
+				'Host (Resolved)'       => $csv_host,
+				'Site Exists'           => 'No',
+				'SSH Access'            => 'No',
+				'PHP Version'           => '',
+				'PHP Ready'             => '',
+				'Atlantis Status'       => '',
+				'Legacy Plugins (Site)' => '',
+				'Repository'            => '',
+				'Repo Branch'           => '',
+				'Legacy Plugins (Repo)' => '',
+				'Notes'                 => '',
+			);
+
+			// Resolve the actual host type.
+			$host = $csv_host;
+			if ( 'simple' === $csv_host ) {
+				$resolution           = $this->resolve_simple_host( $site_url, $output );
+				$host                 = $resolution['host'];
+				$row['Host (Resolved)'] = $host;
+
+				if ( ! empty( $resolution['redirect_url'] ) ) {
+					$row['Notes'] = 'Redirect: ' . $resolution['redirect_url'];
+				}
+
+				if ( 'simple' === $host ) {
+					$row['Notes'] = trim( ( $row['Notes'] ? $row['Notes'] . '; ' : '' ) . 'Confirmed Simple site (actionbar found)' );
+					$this->write_result_row( $row, $output );
+					continue;
+				}
+			}
+
+			if ( ! in_array( $host, array( 'pressable', 'atomic' ), true ) ) {
+				$row['Notes'] = "Unresolvable host: {$host}";
+				$this->write_result_row( $row, $output );
+				continue;
+			}
+
+			// Use redirect URL for lookups if host was reclassified from Simple.
+			$lookup_url = $site_url;
+			if ( 'simple' === $csv_host && isset( $resolution ) && ! empty( $resolution['redirect_url'] ) ) {
+				$lookup_url = $resolution['redirect_url'];
+			}
+
+			// Run all checks.
+			$this->audit_site( $row, $host, $lookup_url, $output );
+
+			// Write result row.
+			$this->write_result_row( $row, $output );
+		}
+
+		if ( $skipped > 0 ) {
+			$skip_reason = $resuming ? 'other host, missing data, or already processed' : 'other host or missing data';
+			$output->writeln( "<comment>Skipped {$skipped} sites ({$skip_reason})</comment>" );
+		}
+
+		// Close export CSV.
+		fclose( $this->export_stream );
+		$output->writeln( '' );
+		$output->writeln( "<info>Results exported to: {$this->export_csv_path}</info>" );
+
+		// Output summary.
+		$this->output_summary( $output );
+
+		return Command::SUCCESS;
+	}
+
+	// endregion
+
+	// region AUDIT CHECKS
+
+	/**
+	 * Orchestrates all audit checks for a single site.
+	 *
+	 * @param   array           $row      The result row (passed by reference).
+	 * @param   string          $host     The hosting provider.
+	 * @param   string          $site_url The site URL.
+	 * @param   OutputInterface $output   The output object.
+	 *
+	 * @return  void
+	 */
+	private function audit_site( array &$row, string $host, string $site_url, OutputInterface $output ): void {
+		// Preserve any existing notes (e.g., redirect URL from host resolution).
+		$notes = array();
+		if ( ! empty( $row['Notes'] ) ) {
+			$notes[] = $row['Notes'];
+		}
+
+		// --- Check 1: Site Exists ---
+		$site = null;
+		try {
+			$site = $this->check_site_exists( $host, $site_url );
+			$row['Site Exists'] = $site ? 'Yes' : 'No';
+			if ( ! $site ) {
+				$notes[] = 'Site not found via API';
+			}
+		} catch ( \Exception $e ) {
+			$row['Site Exists'] = 'Error';
+			$notes[] = 'Site check error: ' . $e->getMessage();
+		}
+
+		if ( ! $site ) {
+			$row['Notes'] = implode( '; ', $notes );
+			return;
+		}
+
+		// --- Host verification: Ensure "atomic" sites are truly Atomic before WP-CLI calls ---
+		if ( 'atomic' === $host && empty( $site->is_wpcom_atomic ) ) {
+			$output->writeln( '  <comment>Site is not actually Atomic (is_wpcom_atomic=false), trying Pressable...</comment>' );
+
+			$domain         = $this->extract_domain( $site_url );
+			$pressable_site = get_pressable_site( $domain );
+
+			if ( $pressable_site ) {
+				$host                   = 'pressable';
+				$site                   = $pressable_site;
+				$row['Host (Resolved)'] = 'pressable';
+				$notes[]                = 'Reclassified: listed as atomic, actually pressable';
+				$output->writeln( '  <info>Resolved as Pressable</info>' );
+			} else {
+				$notes[]                = 'Listed as atomic but is_wpcom_atomic=false and not found on Pressable';
+				$row['Notes']           = implode( '; ', $notes );
+				$row['SSH Access']      = 'N/A';
+				$row['PHP Version']     = 'Unknown';
+				$row['PHP Ready']       = 'Unknown';
+				$row['Atlantis Status'] = 'N/A';
+				$output->writeln( '  <error>Cannot determine actual host, skipping SSH-dependent checks</error>' );
+				// Still try repo checks below, so don't return yet.
+			}
+		}
+
+		// Only run SSH-dependent checks if we have a valid host type.
+		$skip_ssh_checks = ! in_array( $host, array( 'pressable', 'atomic' ), true );
+
+		$site_identifier = $skip_ssh_checks ? '' : ( ( 'atomic' === $host ) ? $site->ID : $site->id );
+
+		// --- Check 2: SSH Access ---
+		if ( ! $skip_ssh_checks ) {
+			try {
+				$ssh_ok = $this->check_ssh_access( $host, $site_identifier );
+				$row['SSH Access'] = $ssh_ok ? 'Yes' : 'No';
+				if ( ! $ssh_ok ) {
+					$notes[] = 'SSH access failed';
+				}
+			} catch ( \Exception $e ) {
+				$row['SSH Access'] = 'Error';
+				$notes[] = 'SSH check error: ' . $e->getMessage();
+			}
+		}
+
+		// --- Check 3: PHP Version ---
+		if ( ! $skip_ssh_checks ) {
+			try {
+				$php_version = $this->check_php_version( $host, $site, $site_identifier );
+				$row['PHP Version'] = $php_version ?? 'Unknown';
+				if ( $php_version ) {
+					$row['PHP Ready'] = version_compare( $php_version, $this->min_php_version, '>=' ) ? 'Yes' : 'No';
+				} else {
+					$row['PHP Ready'] = 'Unknown';
+				}
+			} catch ( \Exception $e ) {
+				$row['PHP Version'] = 'Error';
+				$row['PHP Ready']   = 'Error';
+				$notes[]            = 'PHP version check error: ' . $e->getMessage();
+			}
+		}
+
+		// --- Checks 4 & 5: Atlantis Status and Legacy Plugins on Site ---
+		if ( ! $skip_ssh_checks && 'Yes' === $row['SSH Access'] ) {
+			try {
+				$plugins = $this->get_site_plugin_list( $host, $site_identifier );
+
+				if ( null !== $plugins ) {
+					$row['Atlantis Status']       = $this->check_atlantis_status( $plugins );
+					$row['Legacy Plugins (Site)'] = $this->check_legacy_plugins_on_site( $plugins );
+				} else {
+					$row['Atlantis Status'] = 'Error (could not get plugin list)';
+					$notes[]                = 'Could not retrieve plugin list';
+				}
+			} catch ( \Exception $e ) {
+				$row['Atlantis Status'] = 'Error';
+				$notes[]                = 'Plugin list error: ' . $e->getMessage();
+			}
+		} elseif ( ! $skip_ssh_checks ) {
+			$row['Atlantis Status']       = 'N/A (no SSH)';
+			$row['Legacy Plugins (Site)'] = 'N/A (no SSH)';
+		}
+
+		// --- Check 6: Linked GitHub Repository ---
+		$repo_name = null;
+		try {
+			$repo_name        = $this->check_linked_repository( $host, $site );
+			$row['Repository'] = $repo_name ?? 'none';
+		} catch ( \Exception $e ) {
+			$row['Repository'] = 'Error';
+			$notes[]           = 'Repo check error: ' . $e->getMessage();
+		}
+
+		// --- Check 7: Legacy Plugins in Repository ---
+		if ( $repo_name ) {
+			try {
+				$repo_check                  = $this->check_legacy_plugins_in_repo( $repo_name );
+				$row['Repo Branch']           = $repo_check['branch'] ?? 'none found';
+				$row['Legacy Plugins (Repo)'] = $repo_check['plugins'] ?? '';
+			} catch ( \Exception $e ) {
+				$row['Repo Branch']           = 'Error';
+				$row['Legacy Plugins (Repo)'] = 'Error';
+				$notes[]                      = 'Repo plugin check error: ' . $e->getMessage();
+			}
+		}
+
+		$row['Notes'] = implode( '; ', $notes );
+	}
+
+	/**
+	 * Check if the site exists via the platform API.
+	 *
+	 * @param   string $host     The hosting provider.
+	 * @param   string $site_url The site URL.
+	 *
+	 * @return  \stdClass|null The site object, or null if not found.
+	 */
+	private function check_site_exists( string $host, string $site_url ): ?\stdClass {
+		$domain = $this->extract_domain( $site_url );
+
+		if ( 'pressable' === $host ) {
+			return get_pressable_site( $domain );
+		}
+
+		return get_wpcom_site( $domain );
+	}
+
+	/**
+	 * Check if SSH access is available by running a simple WP-CLI command.
+	 *
+	 * @param   string $host            The hosting provider.
+	 * @param   string $site_identifier The site ID.
+	 *
+	 * @return  bool True if SSH access works.
+	 */
+	private function check_ssh_access( string $host, string $site_identifier ): bool {
+		$command = "eval 'echo \"ok\";'";
+
+		if ( 'pressable' === $host ) {
+			$result = run_pressable_site_wp_cli_command( $site_identifier, $command, true );
+		} else {
+			$result = run_wpcom_site_wp_cli_command( $site_identifier, $command, true );
+		}
+
+		$wp_cli_output = $GLOBALS['wp_cli_output'] ?? '';
+
+		if ( str_contains( $wp_cli_output, 'Fatal error:' ) || str_contains( $wp_cli_output, 'critical error on this website' ) ) {
+			return false;
+		}
+
+		return Command::SUCCESS === $result && str_contains( $wp_cli_output, 'ok' );
+	}
+
+	/**
+	 * Check the PHP version of the site.
+	 *
+	 * @param   string    $host            The hosting provider.
+	 * @param   \stdClass $site            The site object.
+	 * @param   string    $site_identifier The site ID.
+	 *
+	 * @return  string|null The PHP version string, or null if unknown.
+	 */
+	private function check_php_version( string $host, \stdClass $site, string $site_identifier ): ?string {
+		// For Pressable, try the API property first.
+		if ( 'pressable' === $host && isset( $site->phpVersion ) ) {
+			return $site->phpVersion;
+		}
+
+		$command = "eval 'echo phpversion();'";
+
+		if ( 'pressable' === $host ) {
+			run_pressable_site_wp_cli_command( $site_identifier, $command, true );
+		} else {
+			run_wpcom_site_wp_cli_command( $site_identifier, $command, true );
+		}
+
+		$wp_cli_output = $GLOBALS['wp_cli_output'] ?? '';
+		if ( preg_match( '/(\d+\.\d+(\.\d+)?)/', $wp_cli_output, $matches ) ) {
+			return $matches[1];
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get the list of installed plugins from the site via WP-CLI.
+	 *
+	 * @param   string $host            The hosting provider.
+	 * @param   string $site_identifier The site ID.
+	 *
+	 * @return  array|null Array of plugin data, or null on error.
+	 */
+	private function get_site_plugin_list( string $host, string $site_identifier ): ?array {
+		$command = 'plugin list --format=json';
+
+		if ( 'pressable' === $host ) {
+			run_pressable_site_wp_cli_command( $site_identifier, $command, true );
+		} else {
+			run_wpcom_site_wp_cli_command( $site_identifier, $command, true );
+		}
+
+		$wp_cli_output = $GLOBALS['wp_cli_output'] ?? '';
+
+		if ( str_contains( $wp_cli_output, 'Fatal error:' ) || str_contains( $wp_cli_output, 'critical error on this website' ) ) {
+			return null;
+		}
+
+		if ( preg_match( '/\[.*\]/s', $wp_cli_output, $matches ) ) {
+			$plugins = json_decode( $matches[0], true );
+			return is_array( $plugins ) ? $plugins : null;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Check the Atlantis plugin status from a plugin list.
+	 *
+	 * @param   array $plugins The plugin list from WP-CLI.
+	 *
+	 * @return  string The Atlantis status (active, inactive, must-use, not-installed, etc.).
+	 */
+	private function check_atlantis_status( array $plugins ): string {
+		foreach ( $plugins as $plugin ) {
+			if ( isset( $plugin['name'] ) && 'a8csp-atlantis' === $plugin['name'] ) {
+				return $plugin['status'] ?? 'unknown';
+			}
+		}
+
+		return 'not-installed';
+	}
+
+	/**
+	 * Check for legacy plugins on the site from a plugin list.
+	 *
+	 * @param   array $plugins The plugin list from WP-CLI.
+	 *
+	 * @return  string Comma-separated list of found legacy plugins with status, or empty string.
+	 */
+	private function check_legacy_plugins_on_site( array $plugins ): string {
+		$found = array();
+
+		foreach ( $plugins as $plugin ) {
+			if ( ! isset( $plugin['name'] ) ) {
+				continue;
+			}
+
+			$plugin_name_lower = strtolower( $plugin['name'] );
+
+			foreach ( $this->legacy_plugins as $legacy_prefix ) {
+				if ( $plugin_name_lower === $legacy_prefix || str_starts_with( $plugin_name_lower, $legacy_prefix . '-' ) ) {
+					$status  = $plugin['status'] ?? 'unknown';
+					$found[] = "{$plugin['name']} ({$status})";
+					break;
+				}
+			}
+		}
+
+		return implode( ', ', $found );
+	}
+
+	/**
+	 * Check for a linked GitHub repository.
+	 *
+	 * @param   string    $host The hosting provider.
+	 * @param   \stdClass $site The site object.
+	 *
+	 * @return  string|null The repository name, or null if none found.
+	 */
+	private function check_linked_repository( string $host, \stdClass $site ): ?string {
+		if ( 'pressable' === $host ) {
+			$deployhq_config = get_pressable_site_deployhq_config( $site->id );
+			if ( ! $deployhq_config || ! isset( $deployhq_config->project ) ) {
+				return null;
+			}
+
+			$gh_repo = get_github_repository_from_deployhq_project( $deployhq_config->project->permalink );
+			return $gh_repo->name ?? null;
+		}
+
+		// Atomic: WPCOM Code Deployments.
+		$code_deployments = get_wpcom_site_code_deployments( $site->ID );
+		if ( empty( $code_deployments ) ) {
+			return null;
+		}
+
+		$repository_name = $code_deployments[0]->repository_name ?? null;
+		if ( ! $repository_name ) {
+			return null;
+		}
+
+		// Extract repo slug from "owner/repo" format.
+		$parts     = explode( '/', $repository_name );
+		$repo_slug = $parts[1] ?? $parts[0];
+
+		$gh_repo = get_github_repository( $repo_slug );
+		return $gh_repo->name ?? null;
+	}
+
+	/**
+	 * Check for legacy plugins in a GitHub repository.
+	 *
+	 * Tries branches in priority order (trunk, master, main) and checks
+	 * plugins/ and mu-plugins/ directories via the GitHub API.
+	 *
+	 * @param   string $repo_name The repository name.
+	 *
+	 * @return  array Array with 'branch' and 'plugins' keys.
+	 */
+	private function check_legacy_plugins_in_repo( string $repo_name ): array {
+		// Find the first available branch from priority list.
+		$branches     = get_github_repository_branches( $repo_name );
+		$branch_names = is_array( $branches ) ? array_column( $branches, 'name' ) : array();
+		$used_branch  = null;
+
+		foreach ( $this->branch_priority as $candidate ) {
+			if ( in_array( $candidate, $branch_names, true ) ) {
+				$used_branch = $candidate;
+				break;
+			}
+		}
+
+		if ( null === $used_branch ) {
+			return array(
+				'branch'  => 'none found (tried: ' . implode( ', ', $this->branch_priority ) . ')',
+				'plugins' => '',
+			);
+		}
+
+		// Check for legacy plugins in plugins/ and mu-plugins/ directories.
+		$found       = array();
+		$search_dirs = array( 'plugins', 'mu-plugins' );
+
+		foreach ( $search_dirs as $dir ) {
+			$contents = get_github_repository_contents( $repo_name, $dir, $used_branch );
+			if ( empty( $contents ) ) {
+				continue;
+			}
+
+			foreach ( $contents as $item ) {
+				foreach ( $this->legacy_plugins as $prefix ) {
+					if ( $item->name === $prefix || str_starts_with( $item->name, $prefix . '-' ) ) {
+						$found[] = $dir . '/' . $item->name;
+						break;
+					}
+				}
+			}
+		}
+
+		return array(
+			'branch'  => $used_branch,
+			'plugins' => implode( ', ', $found ),
+		);
+	}
+
+	// endregion
+
+	// region HOST RESOLUTION
+
+	/**
+	 * Resolve a "Simple" host by checking the page for the WordPress.com actionbar
+	 * and using redirect URL heuristics and API properties.
+	 *
+	 * @param   string          $site_url The site URL.
+	 * @param   OutputInterface $output   The output object.
+	 *
+	 * @return  array Array with 'host' (string) and 'redirect_url' (string|null) keys.
+	 */
+	private function resolve_simple_host( string $site_url, OutputInterface $output ): array {
+		$output->writeln( '  <comment>Host listed as Simple, verifying...</comment>' );
+
+		// Fetch the page and capture both actionbar presence and redirect URL.
+		$page_info = $this->fetch_page_info( $site_url );
+
+		if ( $page_info['redirect_url'] ) {
+			$output->writeln( "  <comment>Redirected to: {$page_info['redirect_url']}</comment>" );
+		}
+
+		// If actionbar is found, it's confirmed Simple.
+		if ( $page_info['has_actionbar'] ) {
+			$output->writeln( '  <comment>Actionbar found - confirmed Simple site</comment>' );
+			return array(
+				'host'         => 'simple',
+				'redirect_url' => $page_info['redirect_url'],
+			);
+		}
+
+		$output->writeln( '  <comment>No actionbar found, resolving host type...</comment>' );
+
+		// Use redirect URL heuristics to determine host.
+		$redirect_url = $page_info['redirect_url'] ?? '';
+		$url_to_check = strtolower( $redirect_url ?: $site_url );
+
+		if ( str_contains( $url_to_check, 'mystagingwebsite' ) ) {
+			// "mystagingwebsite" URLs are Pressable.
+			$output->writeln( '  <info>Resolved as Pressable (mystagingwebsite in URL)</info>' );
+			return array(
+				'host'         => 'pressable',
+				'redirect_url' => $page_info['redirect_url'],
+			);
+		}
+
+		if ( str_contains( $url_to_check, 'wpcomstaging' ) ) {
+			// "wpcomstaging" URLs are Atomic.
+			$output->writeln( '  <info>Resolved as Atomic (wpcomstaging in URL)</info>' );
+			return array(
+				'host'         => 'atomic',
+				'redirect_url' => $page_info['redirect_url'],
+			);
+		}
+
+		// No redirect hint - use API lookups to determine host type.
+		$domain = $this->extract_domain( $redirect_url ?: $site_url );
+
+		// Check WPCOM API for is_wpcom_atomic property (safe, no SSH).
+		try {
+			$site = get_wpcom_site( $domain );
+			if ( $site && ! empty( $site->is_wpcom_atomic ) ) {
+				$output->writeln( '  <info>Resolved as Atomic (is_wpcom_atomic flag)</info>' );
+				return array(
+					'host'         => 'atomic',
+					'redirect_url' => $page_info['redirect_url'],
+				);
+			}
+		} catch ( \Exception $e ) {
+			// Ignore and try Pressable.
+		}
+
+		// Try Pressable API.
+		try {
+			$site = get_pressable_site( $domain );
+			if ( $site ) {
+				$output->writeln( '  <info>Resolved as Pressable (found via API)</info>' );
+				return array(
+					'host'         => 'pressable',
+					'redirect_url' => $page_info['redirect_url'],
+				);
+			}
+		} catch ( \Exception $e ) {
+			// Ignore.
+		}
+
+		$output->writeln( '  <comment>Could not resolve to Atomic or Pressable, treating as Simple</comment>' );
+		return array(
+			'host'         => 'simple',
+			'redirect_url' => $page_info['redirect_url'],
+		);
+	}
+
+	/**
+	 * Fetch a page and return info about actionbar presence and redirect URL.
+	 *
+	 * @param   string $url The URL to fetch.
+	 *
+	 * @return  array Array with 'has_actionbar' (bool) and 'redirect_url' (string|null) keys.
+	 */
+	private function fetch_page_info( string $url ): array {
+		// Ensure URL has a scheme.
+		if ( ! preg_match( '#^https?://#i', $url ) ) {
+			$url = 'https://' . $url;
+		}
+
+		$context = stream_context_create(
+			array(
+				'http' => array(
+					'method'          => 'GET',
+					'timeout'         => 15,
+					'follow_location' => true,
+					'ignore_errors'   => true,
+					'header'          => 'User-Agent: Mozilla/5.0 (team51-cli audit)',
+				),
+				'ssl'  => array(
+					'verify_peer' => false,
+				),
+			)
+		);
+
+		$html = @file_get_contents( $url, false, $context );
+
+		// Extract redirect URL from response headers.
+		$redirect_url     = null;
+		$response_headers = http_get_last_response_headers();
+		if ( ! empty( $response_headers ) ) {
+			foreach ( $response_headers as $header ) {
+				if ( preg_match( '/^Location:\s*(.+)/i', $header, $matches ) ) {
+					$redirect_url = trim( $matches[1] );
+				}
+			}
+		}
+
+		// Only report redirect if it differs from the original URL.
+		if ( $redirect_url && $this->extract_domain( $redirect_url ) === $this->extract_domain( $url ) ) {
+			$redirect_url = null;
+		}
+
+		return array(
+			'has_actionbar' => false !== $html && str_contains( $html, 'id="actionbar"' ),
+			'redirect_url'  => $redirect_url,
+		);
+	}
+
+	// endregion
+
+	// region HELPERS
+
+	/**
+	 * Extract domain from URL (remove protocol, path, etc.).
+	 *
+	 * @param   string $url The URL to parse.
+	 *
+	 * @return  string The domain only.
+	 */
+	private function extract_domain( string $url ): string {
+		if ( empty( $url ) ) {
+			return '';
+		}
+
+		$domain = preg_replace( '#^https?://#i', '', $url );
+		$domain = preg_replace( '~[/?#].*$~', '', $domain );
+		$domain = rtrim( $domain ?? '', '/' );
+
+		return $domain;
+	}
+
+	/**
+	 * Write a result row to the export CSV and store for summary.
+	 *
+	 * @param   array           $row    The result row.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  void
+	 */
+	private function write_result_row( array $row, OutputInterface $output ): void {
+		fputcsv( $this->export_stream, array_values( $row ) );
+		fflush( $this->export_stream );
+
+		$this->results[] = $row;
+
+		$status = $this->get_status_indicator( $row );
+		$output->writeln( "  {$status}" );
+	}
+
+	/**
+	 * Get a brief console status indicator for a site.
+	 *
+	 * @param   array $row The result row.
+	 *
+	 * @return  string Formatted status string.
+	 */
+	private function get_status_indicator( array $row ): string {
+		if ( 'No' === $row['Site Exists'] || 'Error' === $row['Site Exists'] ) {
+			return '<error>Site not found</error>';
+		}
+		if ( 'No' === $row['SSH Access'] ) {
+			return '<comment>No SSH access</comment>';
+		}
+		if ( 'No' === $row['PHP Ready'] ) {
+			return "<comment>PHP {$row['PHP Version']} (needs >= {$this->min_php_version})</comment>";
+		}
+		if ( 'active' === $row['Atlantis Status'] ) {
+			return '<info>Atlantis already active</info>';
+		}
+		if ( ! empty( $row['Notes'] ) ) {
+			return "<comment>{$row['Notes']}</comment>";
+		}
+
+		return '<info>Check complete</info>';
+	}
+
+	/**
+	 * Output the summary table and statistics.
+	 *
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  void
+	 */
+	private function output_summary( OutputInterface $output ): void {
+		$table_rows = array();
+		foreach ( $this->results as $row ) {
+			$host_display = $row['Host (Resolved)'];
+			if ( $row['Host (CSV)'] !== $row['Host (Resolved)'] ) {
+				$host_display = $row['Host (Resolved)'] . ' (was ' . $row['Host (CSV)'] . ')';
+			}
+
+			$table_rows[] = array(
+				$row['Site'],
+				$host_display,
+				$row['Site Exists'],
+				$row['SSH Access'],
+				$row['PHP Version'],
+				$row['PHP Ready'],
+				$row['Atlantis Status'],
+				$row['Repository'] ?: 'none',
+			);
+		}
+
+		$summary_headers = array( 'Site', 'Host', 'Exists', 'SSH', 'PHP', 'PHP Ready', 'Atlantis', 'Repository' );
+		output_table( $output, $table_rows, $summary_headers, 'Atlantis Readiness Audit Summary' );
+
+		// Statistics.
+		$total                  = count( $this->results );
+		$confirmed_simple       = count( array_filter( $this->results, fn( $r ) => 'simple' === $r['Host (Resolved)'] ) );
+		$reclassified           = count( array_filter( $this->results, fn( $r ) => $r['Host (CSV)'] !== $r['Host (Resolved)'] && 'simple' !== $r['Host (Resolved)'] ) );
+		$exists                 = count( array_filter( $this->results, fn( $r ) => 'Yes' === $r['Site Exists'] ) );
+		$ssh_ok                 = count( array_filter( $this->results, fn( $r ) => 'Yes' === $r['SSH Access'] ) );
+		$php_ready              = count( array_filter( $this->results, fn( $r ) => 'Yes' === $r['PHP Ready'] ) );
+		$atlantis_active        = count( array_filter( $this->results, fn( $r ) => 'active' === $r['Atlantis Status'] ) );
+		$atlantis_not_installed = count( array_filter( $this->results, fn( $r ) => 'not-installed' === $r['Atlantis Status'] ) );
+		$has_repo               = count( array_filter( $this->results, fn( $r ) => ! empty( $r['Repository'] ) && 'none' !== $r['Repository'] && 'Error' !== $r['Repository'] ) );
+		$has_legacy_site        = count( array_filter( $this->results, fn( $r ) => ! empty( $r['Legacy Plugins (Site)'] ) && 'N/A (no SSH)' !== $r['Legacy Plugins (Site)'] ) );
+		$has_legacy_repo        = count( array_filter( $this->results, fn( $r ) => ! empty( $r['Legacy Plugins (Repo)'] ) ) );
+
+		$output->writeln( '' );
+		$output->writeln( '<fg=cyan;options=bold>=== Audit Statistics ===' );
+		$output->writeln( "<info>Total sites in report: {$total}</info>" );
+		$output->writeln( "<comment>Confirmed Simple (skipped): {$confirmed_simple}</comment>" );
+		if ( $reclassified > 0 ) {
+			$output->writeln( "<comment>Reclassified from Simple: {$reclassified}</comment>" );
+		}
+		$output->writeln( "<info>Sites found: {$exists}</info>" );
+		$output->writeln( "<info>SSH accessible: {$ssh_ok}</info>" );
+		$output->writeln( "<info>PHP >= {$this->min_php_version}: {$php_ready}</info>" );
+		$output->writeln( "<info>Atlantis active: {$atlantis_active}</info>" );
+		$output->writeln( "<info>Atlantis not installed: {$atlantis_not_installed}</info>" );
+		$output->writeln( "<info>Linked repositories: {$has_repo}</info>" );
+		$output->writeln( "<info>Sites with legacy plugins (WP): {$has_legacy_site}</info>" );
+		$output->writeln( "<info>Repos with legacy plugins: {$has_legacy_repo}</info>" );
+	}
+
+	/**
+	 * Read CSV file and return array of site data.
+	 *
+	 * @param   string $csv_path Path to CSV file.
+	 *
+	 * @return  array
+	 */
+	private function read_csv( string $csv_path ): array {
+		$csv_data = array();
+		$handle   = fopen( $csv_path, 'r' );
+
+		if ( false === $handle ) {
+			return $csv_data;
+		}
+
+		$headers = fgetcsv( $handle );
+		if ( false === $headers ) {
+			fclose( $handle );
+			return $csv_data;
+		}
+
+		// Normalize column names to support multiple CSV formats.
+		$column_map = array(
+			'Site Name' => 'Site',
+			'Domain'    => 'URL',
+		);
+		$headers = array_map(
+			fn( $h ) => $column_map[ $h ] ?? $h,
+			$headers
+		);
+
+		while ( ( $row = fgetcsv( $handle ) ) !== false ) {
+			if ( empty( array_filter( $row ) ) ) {
+				continue;
+			}
+
+			if ( count( $row ) !== count( $headers ) ) {
+				$row = array_pad( array_slice( $row, 0, count( $headers ) ), count( $headers ), '' );
+			}
+
+			$site_data = array_combine( $headers, $row );
+			if ( ! $site_data ) {
+				continue;
+			}
+
+			// Skip summary/non-data rows (e.g., rows without a valid Host value).
+			$host = strtolower( trim( $site_data['Host'] ?? '' ) );
+			if ( ! in_array( $host, array( 'pressable', 'atomic', 'simple', 'other' ), true ) ) {
+				continue;
+			}
+
+			$csv_data[] = $site_data;
+		}
+
+		fclose( $handle );
+		return $csv_data;
+	}
+
+	// endregion
+}

--- a/commands/Site_Remove_Atlantis_Legacy_Modules.php
+++ b/commands/Site_Remove_Atlantis_Legacy_Modules.php
@@ -182,26 +182,26 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 	protected function initialize( InputInterface $input, OutputInterface $output ): void {
 		// Check if processing multiple sites from CSV.
 		$this->sites_csv_path = $input->getOption( 'sites' );
-		
+
 		if ( $this->sites_csv_path ) {
 			// Get options for CSV processing.
-			$this->quiet            = (bool) $input->getOption( 'no-output' );
-			$this->merge_pr         = (bool) $input->getOption( 'merge-pr' );
+			$this->quiet             = (bool) $input->getOption( 'no-output' );
+			$this->merge_pr          = (bool) $input->getOption( 'merge-pr' );
 			$this->uninstall_plugins = (bool) $input->getOption( 'uninstall' );
-			
+
 			// Validate CSV file exists.
 			if ( ! file_exists( $this->sites_csv_path ) ) {
 				$output->writeln( "<error>CSV file not found: {$this->sites_csv_path}</error>" );
 				exit( 1 );
 			}
-			
+
 			// Skip individual site initialization.
 			return;
 		}
 
 		// Get no-output, merge-pr, and uninstall options.
-		$this->quiet            = (bool) $input->getOption( 'no-output' );
-		$this->merge_pr         = (bool) $input->getOption( 'merge-pr' );
+		$this->quiet             = (bool) $input->getOption( 'no-output' );
+		$this->merge_pr          = (bool) $input->getOption( 'merge-pr' );
 		$this->uninstall_plugins = (bool) $input->getOption( 'uninstall' );
 
 		// Get the site argument. If not provided, prompt for it (unless in quiet mode).
@@ -222,12 +222,12 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 		// Initialize site.
 		try {
 			$this->initialize_site_from_url( $site_input, $this->host );
-			
+
 			// For WPCOM sites, normalize the URL property.
 			if ( 'atomic' === $this->host && isset( $this->site->URL ) ) {
 				$this->site->url = $this->site->URL;
 			}
-			
+
 			$input->setArgument( 'site', $this->site );
 		} catch ( \Exception $e ) {
 			$output->writeln( "<error>Failed to find the site with input: $site_input</error>" );
@@ -237,7 +237,7 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 		// Initialize repository.
 		try {
 			$this->initialize_repository( $input, $output );
-			
+
 			// Show DeployHQ info for Pressable sites.
 			if ( 'pressable' === $this->host && $this->deployhq_project ) {
 				$output->writeln( "<comment>Found DeployHQ project {$this->deployhq_project->name} (permalink {$this->deployhq_project->permalink}) for the given site.</comment>", OutputInterface::VERBOSITY_VERBOSE );
@@ -311,7 +311,7 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 		}
 
 		// Validate required columns exist in first row.
-		$first_row = reset( $csv_data );
+		$first_row        = reset( $csv_data );
 		$required_columns = array( 'Site', 'URL', 'Host' );
 		foreach ( $required_columns as $column ) {
 			if ( ! isset( $first_row[ $column ] ) ) {
@@ -320,10 +320,10 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 			}
 		}
 
-		$total_sites    = count( $csv_data );
-		$processed      = 0;
-		$skipped        = 0;
-		$failed         = 0;
+		$total_sites = count( $csv_data );
+		$processed   = 0;
+		$skipped     = 0;
+		$failed      = 0;
 
 		foreach ( $csv_data as $index => $site_data ) {
 			$site_name = $site_data['Site'] ?? 'Unknown';
@@ -335,7 +335,7 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 				$note = 'Missing required fields (URL or Host)';
 				$this->update_csv_row( $index, '', '', $note );
 				$output->writeln( "<error>[$index/$total_sites] Skipping {$site_name} - {$note}</error>" );
-				$skipped++;
+				++$skipped;
 				continue;
 			}
 
@@ -344,7 +344,7 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 				$note = "Invalid host value: {$host} (must be 'pressable' or 'atomic')";
 				$this->update_csv_row( $index, '', '', $note );
 				$output->writeln( "<error>[$index/$total_sites] Skipping {$site_name} - {$note}</error>" );
-				$skipped++;
+				++$skipped;
 				continue;
 			}
 
@@ -353,7 +353,7 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 				$note = 'Already processed (has PR or marked as Merged)';
 				$this->update_csv_row( $index, $site_data['PR'] ?? '', $site_data['Merged'] ?? '', $note );
 				$output->writeln( "<comment>[$index/$total_sites] Skipping {$site_name} - already processed</comment>" );
-				$skipped++;
+				++$skipped;
 				continue;
 			}
 
@@ -370,7 +370,7 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 
 				// Initialize site.
 				$this->initialize_site_from_url( $site_url, $host );
-				
+
 				// Initialize repository (handle WPCOM GitHub Deployments error gracefully).
 				try {
 					$this->initialize_repository( $input, $output );
@@ -380,13 +380,13 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 						$note = 'Unable to find a WPCOM GitHub Deployment for the site';
 						$this->update_csv_row( $index, '', '', $note );
 						$output->writeln( "<comment>⚠ {$site_name}: {$note}</comment>" );
-						$skipped++;
+						++$skipped;
 						continue;
 					}
 					// Re-throw if it's a different error.
 					throw $e;
 				}
-				
+
 				$this->initialize_paths_and_branch( $input );
 
 				// Determine environment and base branch.
@@ -405,22 +405,22 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 						$merged_status = $this->merge_pr ? 'Y' : '';
 						$this->update_csv_row( $index, $this->pr_url, $merged_status );
 						$output->writeln( "<info>✓ {$site_name} completed successfully</info>" );
-						$processed++;
+						++$processed;
 					} else {
 						// No PR created (likely no modules found).
 						$note = 'No legacy modules found in repository';
 						$this->update_csv_row( $index, '', '', $note );
 						$output->writeln( "<comment>⚠ {$site_name}: {$note}</comment>" );
-						$skipped++;
+						++$skipped;
 					}
 				} else {
-					$failed++;
+					++$failed;
 					$output->writeln( "<error>✗ {$site_name} failed</error>" );
 				}
 			} catch ( \Exception $e ) {
 				$note = 'Error: ' . $e->getMessage();
 				$this->update_csv_row( $index, '', '', $note );
-				$failed++;
+				++$failed;
 				$output->writeln( "<error>✗ {$site_name} failed: {$e->getMessage()}</error>" );
 			}
 
@@ -463,9 +463,21 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 		$this->write_output( $output, '' );
 		$this->write_output( $output, '<fg=cyan;options=bold>Searching for legacy modules to remove...</>' );
 
+		// First, find which legacy modules exist.
+		$found_modules = array();
 		foreach ( $this->legacy_modules as $plugin_name ) {
 			$plugin_info = $this->find_plugin( $plugin_name, $output );
 			if ( null !== $plugin_info ) {
+				$found_modules[ $plugin_name ] = $plugin_info;
+			}
+		}
+
+		// Only install the Atlantis plugin if we found legacy modules to replace.
+		if ( ! empty( $found_modules ) ) {
+			$this->install_atlantis_plugin( $output );
+
+			// Now delete the found modules.
+			foreach ( $found_modules as $plugin_name => $plugin_info ) {
 				$this->delete_plugin( $plugin_name, $plugin_info['location'], $plugin_info['path'], $output );
 			}
 		}
@@ -495,7 +507,7 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 				\run_system_command( array( 'rm', '-rf', $this->repo_dir ), $this->repo_dir, false );
 				$this->write_output( $output, "<info>Deleted repository folder: {$this->repo_dir}</info>" );
 			} else {
-				$this->write_output( $output, "<error>Safety check failed: repository path is not within repos directory. Skipping deletion.</error>" );
+				$this->write_output( $output, '<error>Safety check failed: repository path is not within repos directory. Skipping deletion.</error>' );
 			}
 		}
 
@@ -528,21 +540,21 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 	 *
 	 * @return  string The domain only.
 	 */
-	private function extract_domain_from_url(string $url): string {
-		if (empty($url)) {
+	private function extract_domain_from_url( string $url ): string {
+		if ( empty( $url ) ) {
 			return '';
 		}
-	
+
 		// Remove protocol (http://, https://)
-		$domain = preg_replace('#^https?://#i', '', $url);
-	
+		$domain = preg_replace( '#^https?://#i', '', $url );
+
 		// Remove path, query string, and fragment
 		// Use a different delimiter (e.g., ~) to avoid conflicts with '#'
-		$domain = preg_replace('~[/?#].*$~', '', $domain);
-	
+		$domain = preg_replace( '~[/?#].*$~', '', $domain );
+
 		// Remove trailing slash if any
-		$domain = rtrim($domain ?? '', '/');
-	
+		$domain = rtrim( $domain ?? '', '/' );
+
 		return $domain;
 	}
 
@@ -558,7 +570,7 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 	private function initialize_site_from_url( string $site_url, string $host ): void {
 		// Extract domain only (remove protocol, path, etc.).
 		$domain = $this->extract_domain_from_url( $site_url );
-		
+
 		if ( 'pressable' === $host ) {
 			$this->site = get_pressable_site( $domain );
 		} else {
@@ -585,19 +597,19 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 			$deployhq_config = get_pressable_site_deployhq_config( $this->site->id );
 			if ( $deployhq_config ) {
 				$this->deployhq_project = $deployhq_config->project;
-				$this->gh_repository = get_github_repository_from_deployhq_project( $this->deployhq_project->permalink );
+				$this->gh_repository    = get_github_repository_from_deployhq_project( $this->deployhq_project->permalink );
 			}
 		} else {
 			// Get WPCOM repository.
 			// Check for WPCOM GitHub Deployments first.
 			$wpcom_gh_repositories = get_wpcom_site_code_deployments( $this->site->ID );
-			
+
 			if ( empty( $wpcom_gh_repositories ) ) {
 				// In CSV processing mode, throw exception instead of asking.
 				if ( $this->sites_csv_path ) {
 					throw new \Exception( 'Unable to find a WPCOM GitHub Deployments for the site.' );
 				}
-				
+
 				// In interactive mode, ask user.
 				$output->writeln( '<error>Unable to find a WPCOM GitHub Deployments for the site.</error>' );
 				$question = new ConfirmationQuestion( '<question>Do you want to continue anyway? [y/N]</question> ', false );
@@ -607,7 +619,7 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 				}
 				return; // Exit early if user chooses to continue without repository.
 			}
-			
+
 			// Continue with normal WPCOM repository initialization.
 			$this->get_wpcom_repository( $input, $output );
 		}
@@ -629,7 +641,7 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 		// Set up repository paths.
 		$this->repos_dir = getcwd() . '/repos';
 		$this->repo_dir  = $this->repos_dir . '/' . $this->gh_repository->name;
-		
+
 		// Set default branch.
 		$this->gh_repo_branch = 'develop';
 		$input->setOption( 'branch', $this->gh_repo_branch );
@@ -844,26 +856,33 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 		// Create PR from remove/atlantis-legacy-modules to the base branch.
 		// Always show PR creation output, even in silent mode.
 		$this->write_output( $output, "<info>Creating PR to merge remove/atlantis-legacy-modules into {$this->git_base_branch}...</info>", OutputInterface::VERBOSITY_QUIET );
-		
+
 		// Try to create the PR. If it already exists, gh will output the existing PR URL.
-		$process = \run_system_command( 
-			array( 
-				'gh', 'pr', 'create', 
-				'--title', 'Atlantis Rollout - Remove legacy modules', 
-				'--body', 'This PR was automatically generated by a script. Please review the changes and merge if they look good.', 
-				'--base', $this->git_base_branch, 
-				'--head', 'remove/atlantis-legacy-modules', 
-				'--repo', 'a8cteam51/' . $this->gh_repository->name 
+		$process = \run_system_command(
+			array(
+				'gh',
+				'pr',
+				'create',
+				'--title',
+				'Atlantis Rollout - Remove legacy modules',
+				'--body',
+				'This PR was automatically generated by a script. Please review the changes and merge if they look good.',
+				'--base',
+				$this->git_base_branch,
+				'--head',
+				'remove/atlantis-legacy-modules',
+				'--repo',
+				'a8cteam51/' . $this->gh_repository->name,
 			),
 			$this->repo_dir,
 			false // Don't exit on error - the PR might already exist.
 		);
-		
+
 		// Output the result (either new PR URL or error message).
 		$pr_output = trim( $process->getOutput() . $process->getErrorOutput() );
 		if ( ! empty( $pr_output ) ) {
 			$output->writeln( $pr_output, OutputInterface::VERBOSITY_QUIET );
-			
+
 			// Extract and save PR URL for CSV processing.
 			// The output typically contains the PR URL (e.g., https://github.com/a8cteam51/repo/pull/123).
 			if ( preg_match( '#https://github\.com/[^/]+/[^/]+/pull/\d+#', $pr_output, $matches ) ) {
@@ -886,17 +905,21 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 		if ( $should_merge ) {
 			// Merge the PR - always show output, even in silent mode.
 			$output->writeln( '<info>Merging PR...</info>', OutputInterface::VERBOSITY_QUIET );
-			
+
 			// Try with --auto first (for PRs that need to wait for checks).
 			// Use Process directly to avoid printing the error when it's expected.
 			$process = new \Symfony\Component\Process\Process(
-				array( 
-					'gh', 'pr', 'merge', 'remove/atlantis-legacy-modules', 
+				array(
+					'gh',
+					'pr',
+					'merge',
+					'remove/atlantis-legacy-modules',
 					'--squash',  // Squash all commits into one
 					'--auto',    // Auto-merge when requirements are met
 					'--delete-branch',  // Delete the branch after merge
-					'--repo', 'a8cteam51/' . $this->gh_repository->name 
-				), 
+					'--repo',
+					'a8cteam51/' . $this->gh_repository->name,
+				),
 				$this->repo_dir
 			);
 			$process->run();
@@ -905,14 +928,18 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 			if ( 0 !== $process->getExitCode() && str_contains( $process->getErrorOutput(), 'is in clean status' ) ) {
 				// PR is ready to merge immediately, try without --auto.
 				$output->writeln( '<comment>PR is ready, merging immediately...</comment>', OutputInterface::VERBOSITY_QUIET );
-				$process = \run_system_command( 
-					array( 
-						'gh', 'pr', 'merge', 'remove/atlantis-legacy-modules', 
+				$process = \run_system_command(
+					array(
+						'gh',
+						'pr',
+						'merge',
+						'remove/atlantis-legacy-modules',
 						'--squash',
 						'--delete-branch',
-						'--repo', 'a8cteam51/' . $this->gh_repository->name 
-					), 
-					$this->repo_dir 
+						'--repo',
+						'a8cteam51/' . $this->gh_repository->name,
+					),
+					$this->repo_dir
 				);
 			} elseif ( 0 !== $process->getExitCode() ) {
 				// Some other error occurred, output it and exit.
@@ -1026,6 +1053,51 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 	}
 
 	/**
+	 * Installs and activates the Atlantis plugin from GitHub.
+	 *
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  void
+	 */
+	private function install_atlantis_plugin( OutputInterface $output ): void {
+		$plugin_url      = 'https://github.com/a8cteam51/a8csp-atlantis/releases/download/v1.0.2/a8csp-atlantis.zip';
+		$site_identifier = 'atomic' === $this->host ? $this->site->ID : $this->site->id;
+
+		$this->write_output( $output, '' );
+		$this->write_output( $output, '<fg=cyan;options=bold>Installing Atlantis plugin from GitHub...</>' );
+
+		try {
+			// Install the plugin.
+			$install_command = "plugin install {$plugin_url} --force";
+			$this->write_output( $output, "  Running: wp {$install_command}" );
+
+			if ( 'pressable' === $this->host ) {
+				run_pressable_site_wp_cli_command( $site_identifier, $install_command, $this->quiet );
+			} else {
+				run_wpcom_site_wp_cli_command( $site_identifier, $install_command, $this->quiet );
+			}
+
+			$this->write_output( $output, '  <info>✓ Plugin installed successfully</info>' );
+
+			// Activate the plugin.
+			$activate_command = 'plugin activate a8csp-atlantis';
+			$this->write_output( $output, "  Running: wp {$activate_command}" );
+
+			if ( 'pressable' === $this->host ) {
+				run_pressable_site_wp_cli_command( $site_identifier, $activate_command, $this->quiet );
+			} else {
+				run_wpcom_site_wp_cli_command( $site_identifier, $activate_command, $this->quiet );
+			}
+
+			$this->write_output( $output, '  <info>✓ Plugin activated successfully</info>' );
+
+		} catch ( \Exception $e ) {
+			$this->write_output( $output, "  <error>Failed to install/activate Atlantis plugin: {$e->getMessage()}</error>" );
+			$this->write_output( $output, '  <comment>Continuing with legacy module removal...</comment>' );
+		}
+	}
+
+	/**
 	 * Uninstalls all legacy plugins from WordPress in a single command.
 	 *
 	 * @param   OutputInterface $output The output object.
@@ -1051,7 +1123,7 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 				run_wpcom_site_wp_cli_command( $site_identifier, $command, $this->quiet );
 			}
 
-			$this->write_output( $output, "  <info>✓ Plugins deactivated and uninstalled from WordPress</info>" );
+			$this->write_output( $output, '  <info>✓ Plugins deactivated and uninstalled from WordPress</info>' );
 		} catch ( \Exception $e ) {
 			$this->write_output( $output, "  <error>Failed to uninstall plugins from WordPress: {$e->getMessage()}</error>" );
 			$this->write_output( $output, '  <comment>This is usually fine if the plugins were not installed on the site.</comment>' );
@@ -1083,19 +1155,19 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 		// Read data rows.
 		$row_index = 1; // Start at 1 (0 is header).
 		while ( ( $row = fgetcsv( $handle ) ) !== false ) {
-			$row_index++;
-			
+			++$row_index;
+
 			// Skip empty rows.
 			if ( empty( array_filter( $row ) ) ) {
 				continue;
 			}
-			
+
 			// Ensure row has same number of columns as headers.
 			if ( count( $row ) !== count( $headers ) ) {
 				// Pad or truncate row to match header count.
 				$row = array_pad( array_slice( $row, 0, count( $headers ) ), count( $headers ), '' );
 			}
-			
+
 			$site_data = array_combine( $headers, $row );
 			if ( $site_data ) {
 				$csv_data[ $row_index ] = $site_data;
@@ -1144,7 +1216,7 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 		// If Notes column doesn't exist, we'll add it.
 		$needs_notes_column = false === $notes_index;
 		if ( $needs_notes_column ) {
-			$headers[] = 'Notes';
+			$headers[]   = 'Notes';
 			$notes_index = count( $headers ) - 1;
 		}
 
@@ -1152,7 +1224,7 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 
 		$current_row = 1; // Start at 1 (header is row 0).
 		while ( ( $row = fgetcsv( $handle ) ) !== false ) {
-			$current_row++;
+			++$current_row;
 
 			// Update the target row.
 			if ( $current_row === $row_index ) {
@@ -1210,13 +1282,13 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 	 * @return  void
 	 */
 	private function reset_site_state(): void {
-		$this->site              = null;
-		$this->deployhq_project  = null;
-		$this->gh_repository     = null;
-		$this->gh_repo_branch    = null;
-		$this->repo_dir          = null;
-		$this->removed_modules   = array();
-		$this->git_base_branch   = 'develop';
+		$this->site             = null;
+		$this->deployhq_project = null;
+		$this->gh_repository    = null;
+		$this->gh_repo_branch   = null;
+		$this->repo_dir         = null;
+		$this->removed_modules  = array();
+		$this->git_base_branch  = 'develop';
 	}
 
 	// endregion

--- a/commands/Site_Remove_Atlantis_Legacy_Modules.php
+++ b/commands/Site_Remove_Atlantis_Legacy_Modules.php
@@ -1,0 +1,1223 @@
+<?php
+
+namespace WPCOMSpecialProjects\CLI\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Question\Question;
+use WPCOMSpecialProjects\CLI\Helper\AutocompleteTrait;
+
+/**
+ * Removes Atlantis legacy modules from a Pressable or Atomic site.
+ *
+ * Examples:
+ *   # Interactive mode - process a single site
+ *   team51 site:remove-atlantis-legacy-modules example.com --host=pressable
+ *
+ *   # Process a single site with automatic PR merge
+ *   team51 site:remove-atlantis-legacy-modules example.com --host=pressable --merge-pr
+ *
+ *   # Process a single site silently (no confirmations, minimal output)
+ *   team51 site:remove-atlantis-legacy-modules example.com --host=pressable --no-output --merge-pr
+ *
+ *   # Process a single site and uninstall plugins from WordPress
+ *   team51 site:remove-atlantis-legacy-modules example.com --host=pressable --uninstall
+ *
+ *   # Process multiple sites from CSV file
+ *   team51 site:remove-atlantis-legacy-modules --sites=atlantis-sites.csv --no-output --merge-pr
+ *
+ *   # Process multiple sites from CSV with plugin uninstallation
+ *   team51 site:remove-atlantis-legacy-modules --sites=atlantis-sites.csv --no-output --merge-pr --uninstall
+ *
+ *
+ * CSV File Format:
+ *   The CSV file should have the following columns: Site, URL, Host, Merged, PR, Notes
+ *   Example:
+ *     Site,URL,Host,Merged,PR,Notes
+ *     "Example Site",https://example.mystagingwebsite.com,Pressable,,"",""
+ */
+#[AsCommand( name: 'site:remove-atlantis-legacy-modules' )]
+final class Site_Remove_Atlantis_Legacy_Modules extends Command {
+	use AutocompleteTrait;
+
+	// region FIELDS AND CONSTANTS
+
+	/**
+	 * The site to remove Atlantis legacy modules from.
+	 *
+	 * @var \stdClass|null
+	 */
+	private ?\stdClass $site = null;
+
+	/**
+	 * The DeployHQ project for the given site.
+	 *
+	 * @var \stdClass|null
+	 */
+	private ?\stdClass $deployhq_project = null;
+
+	/**
+	 * The GitHub repository connected to the DeployHQ project or WPCOM site.
+	 *
+	 * @var \stdClass|null
+	 */
+	private ?\stdClass $gh_repository = null;
+
+	/**
+	 * The GitHub repository branch.
+	 *
+	 * @var string|null
+	 */
+	private ?string $gh_repo_branch = null;
+
+	/**
+	 * The repos directory path.
+	 *
+	 * @var string|null
+	 */
+	private ?string $repos_dir = null;
+
+	/**
+	 * The repository directory path.
+	 *
+	 * @var string|null
+	 */
+	private ?string $repo_dir = null;
+
+	/**
+	 * The hosting provider (pressable or atomic).
+	 *
+	 * @var string|null
+	 */
+	private ?string $host = null;
+
+	/**
+	 * Legacy modules/plugins to be removed from the repository.
+	 *
+	 * @var array
+	 */
+	private array $legacy_modules = array(
+		'colophon',
+		'plugin-autoupdate-filter',
+	);
+
+	/**
+	 * Removed modules/plugins from the repository.
+	 *
+	 * @var array
+	 */
+	private array $removed_modules = array();
+
+	/**
+	 * The base branch to checkout from.
+	 *
+	 * @var string
+	 */
+	private string $git_base_branch = 'develop';
+
+	/**
+	 * Whether to skip confirmations and minimize output (quiet mode).
+	 *
+	 * @var bool
+	 */
+	private bool $quiet = false;
+
+	/**
+	 * Whether to automatically merge PRs.
+	 *
+	 * @var bool
+	 */
+	private bool $merge_pr = false;
+
+	/**
+	 * Whether to uninstall plugins from WordPress.
+	 *
+	 * @var bool
+	 */
+	private bool $uninstall_plugins = false;
+
+	/**
+	 * Path to the CSV file with sites to process.
+	 *
+	 * @var string|null
+	 */
+	private ?string $sites_csv_path = null;
+
+	/**
+	 * The URL of the created PR (captured during execution).
+	 *
+	 * @var string|null
+	 */
+	private ?string $pr_url = null;
+
+	// endregion
+
+	// region INHERITED METHODS
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function configure(): void {
+		$this->setDescription( 'Removes Atlantis legacy modules from a Pressable or Atomic site.' )
+			->setHelp( 'Use this command to remove Atlantis legacy modules from a given Pressable or Atomic site, or from multiple sites using a CSV file.' );
+
+		$this->addArgument( 'site', InputArgument::OPTIONAL, 'The site to get repository information for.' )
+			->addOption( 'host', null, InputOption::VALUE_REQUIRED, 'The hosting provider (pressable or atomic).' )
+			->addOption( 'branch', null, InputOption::VALUE_REQUIRED, 'The branch to deploy from.', 'develop' )
+			->addOption( 'no-output', null, InputOption::VALUE_NONE, 'Skip confirmations and minimize output (except PR creation).' )
+			->addOption( 'merge-pr', null, InputOption::VALUE_NONE, 'Automatically merge the PR without asking for confirmation.' )
+			->addOption( 'uninstall', null, InputOption::VALUE_NONE, 'Uninstall plugins from WordPress in addition to removing them from the repository.' )
+			->addOption( 'sites', null, InputOption::VALUE_REQUIRED, 'Path to a CSV file containing sites to process (Site,URL,Host,Merged,PR).' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function initialize( InputInterface $input, OutputInterface $output ): void {
+		// Check if processing multiple sites from CSV.
+		$this->sites_csv_path = $input->getOption( 'sites' );
+		
+		if ( $this->sites_csv_path ) {
+			// Get options for CSV processing.
+			$this->quiet            = (bool) $input->getOption( 'no-output' );
+			$this->merge_pr         = (bool) $input->getOption( 'merge-pr' );
+			$this->uninstall_plugins = (bool) $input->getOption( 'uninstall' );
+			
+			// Validate CSV file exists.
+			if ( ! file_exists( $this->sites_csv_path ) ) {
+				$output->writeln( "<error>CSV file not found: {$this->sites_csv_path}</error>" );
+				exit( 1 );
+			}
+			
+			// Skip individual site initialization.
+			return;
+		}
+
+		// Get no-output, merge-pr, and uninstall options.
+		$this->quiet            = (bool) $input->getOption( 'no-output' );
+		$this->merge_pr         = (bool) $input->getOption( 'merge-pr' );
+		$this->uninstall_plugins = (bool) $input->getOption( 'uninstall' );
+
+		// Get the site argument. If not provided, prompt for it (unless in quiet mode).
+		$site_input = $input->getArgument( 'site' );
+		if ( empty( $site_input ) ) {
+			if ( $this->quiet ) {
+				$output->writeln( '<error>Site argument is required in quiet mode.</error>' );
+				exit( 1 );
+			}
+			$site_input = $this->prompt_site_input( $input, $output );
+			$input->setArgument( 'site', $site_input );
+		}
+
+		// Get and validate the host option.
+		$this->host = get_enum_input( $input, 'host', array( 'pressable', 'atomic' ), fn() => $this->prompt_host_input( $input, $output ) );
+		$input->setOption( 'host', $this->host );
+
+		// Initialize site.
+		try {
+			$this->initialize_site_from_url( $site_input, $this->host );
+			
+			// For WPCOM sites, normalize the URL property.
+			if ( 'atomic' === $this->host && isset( $this->site->URL ) ) {
+				$this->site->url = $this->site->URL;
+			}
+			
+			$input->setArgument( 'site', $this->site );
+		} catch ( \Exception $e ) {
+			$output->writeln( "<error>Failed to find the site with input: $site_input</error>" );
+			exit( 1 );
+		}
+
+		// Initialize repository.
+		try {
+			$this->initialize_repository( $input, $output );
+			
+			// Show DeployHQ info for Pressable sites.
+			if ( 'pressable' === $this->host && $this->deployhq_project ) {
+				$output->writeln( "<comment>Found DeployHQ project {$this->deployhq_project->name} (permalink {$this->deployhq_project->permalink}) for the given site.</comment>", OutputInterface::VERBOSITY_VERBOSE );
+			}
+		} catch ( \Exception $e ) {
+			$output->writeln( '<error>Failed to get the GitHub repository connected to the project or invalid connected repository.</error>' );
+			exit( 1 );
+		}
+
+		// Initialize repository paths.
+		$this->repos_dir = getcwd() . '/repos';
+		$this->repo_dir  = $this->repos_dir . '/' . $this->gh_repository->name;
+
+		// Check if the site is a staging site and set the base branch accordingly.
+		$environment = $this->get_site_environment( $output );
+		if ( 'production' === $environment ) {
+			$this->git_base_branch = 'trunk';
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function interact( InputInterface $input, OutputInterface $output ): void {
+		// Skip interaction if quiet mode is enabled or processing CSV.
+		if ( $this->quiet || $this->sites_csv_path ) {
+			return;
+		}
+
+		$question = new ConfirmationQuestion( "<question>Are you sure you want to remove legacy modules from the repository for {$this->site->url} [{$this->host}] (repository: {$this->gh_repository->name} [{$this->git_base_branch}])? [y/N]</question> ", false );
+		if ( true !== $this->getHelper( 'question' )->ask( $input, $output, $question ) ) {
+			$output->writeln( '<comment>Command aborted by user.</comment>' );
+			exit( 2 );
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( InputInterface $input, OutputInterface $output ): int {
+		// If CSV file provided, process multiple sites.
+		if ( $this->sites_csv_path ) {
+			return $this->process_csv( $input, $output );
+		}
+
+		// Otherwise, process single site.
+		return $this->process_single_site( $input, $output );
+	}
+
+	// endregion
+
+	// region CSV PROCESSING
+
+	/**
+	 * Process multiple sites from a CSV file.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  int
+	 */
+	private function process_csv( InputInterface $input, OutputInterface $output ): int {
+		$output->writeln( '<info>Processing sites from CSV file...</info>' );
+		$output->writeln( '' );
+
+		// Read CSV file.
+		$csv_data = $this->read_csv( $this->sites_csv_path );
+		if ( empty( $csv_data ) ) {
+			$output->writeln( '<error>No valid sites found in CSV file.</error>' );
+			return Command::FAILURE;
+		}
+
+		// Validate required columns exist in first row.
+		$first_row = reset( $csv_data );
+		$required_columns = array( 'Site', 'URL', 'Host' );
+		foreach ( $required_columns as $column ) {
+			if ( ! isset( $first_row[ $column ] ) ) {
+				$output->writeln( "<error>CSV file is missing required column: {$column}</error>" );
+				return Command::FAILURE;
+			}
+		}
+
+		$total_sites    = count( $csv_data );
+		$processed      = 0;
+		$skipped        = 0;
+		$failed         = 0;
+
+		foreach ( $csv_data as $index => $site_data ) {
+			$site_name = $site_data['Site'] ?? 'Unknown';
+			$site_url  = $site_data['URL'] ?? '';
+			$host      = strtolower( $site_data['Host'] ?? '' );
+
+			// Validate required fields.
+			if ( empty( $site_url ) || empty( $host ) ) {
+				$note = 'Missing required fields (URL or Host)';
+				$this->update_csv_row( $index, '', '', $note );
+				$output->writeln( "<error>[$index/$total_sites] Skipping {$site_name} - {$note}</error>" );
+				$skipped++;
+				continue;
+			}
+
+			// Validate host value.
+			if ( ! in_array( $host, array( 'pressable', 'atomic' ), true ) ) {
+				$note = "Invalid host value: {$host} (must be 'pressable' or 'atomic')";
+				$this->update_csv_row( $index, '', '', $note );
+				$output->writeln( "<error>[$index/$total_sites] Skipping {$site_name} - {$note}</error>" );
+				$skipped++;
+				continue;
+			}
+
+			// Skip if already processed (has PR URL or is marked as Merged).
+			if ( ! empty( $site_data['PR'] ?? '' ) || 'Y' === strtoupper( $site_data['Merged'] ?? '' ) ) {
+				$note = 'Already processed (has PR or marked as Merged)';
+				$this->update_csv_row( $index, $site_data['PR'] ?? '', $site_data['Merged'] ?? '', $note );
+				$output->writeln( "<comment>[$index/$total_sites] Skipping {$site_name} - already processed</comment>" );
+				$skipped++;
+				continue;
+			}
+
+			$output->writeln( "<info>[$index/$total_sites] Processing: {$site_name} ({$site_url})</info>" );
+
+			try {
+				// Reset state for this site.
+				$this->reset_site_state();
+				$this->pr_url = null;
+
+				// Initialize site data.
+				$this->host = $host;
+				$input->setOption( 'host', $host );
+
+				// Initialize site.
+				$this->initialize_site_from_url( $site_url, $host );
+				
+				// Initialize repository (handle WPCOM GitHub Deployments error gracefully).
+				try {
+					$this->initialize_repository( $input, $output );
+				} catch ( \Exception $e ) {
+					// Check if it's the WPCOM GitHub Deployments error.
+					if ( str_contains( $e->getMessage(), 'WPCOM GitHub Deployments' ) || str_contains( $e->getMessage(), 'GitHub repository' ) ) {
+						$note = 'Unable to find a WPCOM GitHub Deployment for the site';
+						$this->update_csv_row( $index, '', '', $note );
+						$output->writeln( "<comment>⚠ {$site_name}: {$note}</comment>" );
+						$skipped++;
+						continue;
+					}
+					// Re-throw if it's a different error.
+					throw $e;
+				}
+				
+				$this->initialize_paths_and_branch( $input );
+
+				// Determine environment and base branch.
+				$environment = $this->get_site_environment( $output );
+				if ( 'production' === $environment ) {
+					$this->git_base_branch = 'trunk';
+				}
+
+				// Process the site.
+				$result = $this->process_single_site( $input, $output );
+
+				if ( Command::SUCCESS === $result ) {
+					if ( $this->pr_url ) {
+						// Update CSV with PR URL and Merged status.
+						// Mark as 'Y' only if --merge-pr was used.
+						$merged_status = $this->merge_pr ? 'Y' : '';
+						$this->update_csv_row( $index, $this->pr_url, $merged_status );
+						$output->writeln( "<info>✓ {$site_name} completed successfully</info>" );
+						$processed++;
+					} else {
+						// No PR created (likely no modules found).
+						$note = 'No legacy modules found in repository';
+						$this->update_csv_row( $index, '', '', $note );
+						$output->writeln( "<comment>⚠ {$site_name}: {$note}</comment>" );
+						$skipped++;
+					}
+				} else {
+					$failed++;
+					$output->writeln( "<error>✗ {$site_name} failed</error>" );
+				}
+			} catch ( \Exception $e ) {
+				$note = 'Error: ' . $e->getMessage();
+				$this->update_csv_row( $index, '', '', $note );
+				$failed++;
+				$output->writeln( "<error>✗ {$site_name} failed: {$e->getMessage()}</error>" );
+			}
+
+			$output->writeln( '' );
+		}
+
+		// Summary.
+		$output->writeln( '' );
+		$output->writeln( '<fg=cyan;options=bold>=== Processing Summary ===' );
+		$output->writeln( "<info>Total sites: {$total_sites}</info>" );
+		$output->writeln( "<info>Processed: {$processed}</info>" );
+		$output->writeln( "<comment>Skipped: {$skipped}</comment>" );
+		if ( $failed > 0 ) {
+			$output->writeln( "<error>Failed: {$failed}</error>" );
+		}
+
+		return Command::SUCCESS;
+	}
+
+	/**
+	 * Process a single site.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  int
+	 */
+	private function process_single_site( InputInterface $input, OutputInterface $output ): int {
+		$this->write_output( $output, "<fg=magenta;options=bold>Processing repository for site {$this->site->url} (base branch: {$this->git_base_branch}).</>" );
+
+		$this->clone_repo( $output );
+
+		// Checkout the base branch.
+		\run_system_command( array( 'git', 'checkout', $this->git_base_branch ), $this->repo_dir );
+
+		// Checkout the branch 'remove/atlantis-legacy-modules'.
+		$this->git_checkout_branch( 'remove/atlantis-legacy-modules', $output );
+
+		// Check for legacy modules and delete them if they exist.
+		$this->write_output( $output, '' );
+		$this->write_output( $output, '<fg=cyan;options=bold>Searching for legacy modules to remove...</>' );
+
+		foreach ( $this->legacy_modules as $plugin_name ) {
+			$plugin_info = $this->find_plugin( $plugin_name, $output );
+			if ( null !== $plugin_info ) {
+				$this->delete_plugin( $plugin_name, $plugin_info['location'], $plugin_info['path'], $output );
+			}
+		}
+
+		// Uninstall plugins from WordPress if --uninstall option is provided.
+		if ( $this->uninstall_plugins && count( $this->legacy_modules ) > 0 ) {
+			// In quiet mode, automatically uninstall plugins.
+			if ( $this->quiet ) {
+				$this->uninstall_plugins_from_wordpress( $output );
+			} else {
+				$output->writeln( '' );
+				$plugins_list = implode( ', ', $this->legacy_modules );
+				$question     = new ConfirmationQuestion( "<question>Do you want to deactivate and uninstall these plugins from WordPress ({$plugins_list})? [y/N]</question> ", false );
+				if ( true === $this->getHelper( 'question' )->ask( $input, $output, $question ) ) {
+					$this->uninstall_plugins_from_wordpress( $output );
+				} else {
+					$output->writeln( '<comment>Skipping WordPress plugin uninstallation.</comment>' );
+				}
+			}
+		}
+
+		if ( count( $this->removed_modules ) > 0 ) {
+			$this->stage_commit_push_pr_and_merge( $input, $output );
+
+			// Delete the repository folder (with safety check).
+			if ( $this->repo_dir && $this->repos_dir && str_starts_with( $this->repo_dir, $this->repos_dir ) ) {
+				\run_system_command( array( 'rm', '-rf', $this->repo_dir ), $this->repo_dir, false );
+				$this->write_output( $output, "<info>Deleted repository folder: {$this->repo_dir}</info>" );
+			} else {
+				$this->write_output( $output, "<error>Safety check failed: repository path is not within repos directory. Skipping deletion.</error>" );
+			}
+		}
+
+		return Command::SUCCESS;
+	}
+
+	// endregion
+
+	// region HELPERS
+
+	/**
+	 * Writes output to the console unless in quiet mode.
+	 *
+	 * @param   OutputInterface    $output  The output object.
+	 * @param   string|array       $message The message(s) to write.
+	 * @param   int                $options Output options.
+	 *
+	 * @return  void
+	 */
+	private function write_output( OutputInterface $output, $message, int $options = 0 ): void {
+		if ( ! $this->quiet ) {
+			$output->writeln( $message, $options );
+		}
+	}
+
+	/**
+	 * Extract domain from URL (remove protocol, path, etc.).
+	 *
+	 * @param   string $url The URL to parse.
+	 *
+	 * @return  string The domain only.
+	 */
+	private function extract_domain_from_url(string $url): string {
+		if (empty($url)) {
+			return '';
+		}
+	
+		// Remove protocol (http://, https://)
+		$domain = preg_replace('#^https?://#i', '', $url);
+	
+		// Remove path, query string, and fragment
+		// Use a different delimiter (e.g., ~) to avoid conflicts with '#'
+		$domain = preg_replace('~[/?#].*$~', '', $domain);
+	
+		// Remove trailing slash if any
+		$domain = rtrim($domain ?? '', '/');
+	
+		return $domain;
+	}
+
+	/**
+	 * Initialize site from URL and host.
+	 *
+	 * @param   string $site_url The site URL.
+	 * @param   string $host     The hosting provider ('pressable' or 'atomic').
+	 *
+	 * @throws  \Exception If site cannot be found.
+	 * @return  void
+	 */
+	private function initialize_site_from_url( string $site_url, string $host ): void {
+		// Extract domain only (remove protocol, path, etc.).
+		$domain = $this->extract_domain_from_url( $site_url );
+		
+		if ( 'pressable' === $host ) {
+			$this->site = get_pressable_site( $domain );
+		} else {
+			$this->site = get_wpcom_site( $domain );
+		}
+
+		if ( ! $this->site ) {
+			throw new \Exception( "Could not find site: {$domain}" );
+		}
+	}
+
+	/**
+	 * Initialize GitHub repository based on host.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @throws  \Exception If repository cannot be found.
+	 * @return  void
+	 */
+	private function initialize_repository( InputInterface $input, OutputInterface $output ): void {
+		if ( 'pressable' === $this->host ) {
+			// Get Pressable DeployHQ config and GitHub repository.
+			$deployhq_config = get_pressable_site_deployhq_config( $this->site->id );
+			if ( $deployhq_config ) {
+				$this->deployhq_project = $deployhq_config->project;
+				$this->gh_repository = get_github_repository_from_deployhq_project( $this->deployhq_project->permalink );
+			}
+		} else {
+			// Get WPCOM repository.
+			// Check for WPCOM GitHub Deployments first.
+			$wpcom_gh_repositories = get_wpcom_site_code_deployments( $this->site->ID );
+			
+			if ( empty( $wpcom_gh_repositories ) ) {
+				// In CSV processing mode, throw exception instead of asking.
+				if ( $this->sites_csv_path ) {
+					throw new \Exception( 'Unable to find a WPCOM GitHub Deployments for the site.' );
+				}
+				
+				// In interactive mode, ask user.
+				$output->writeln( '<error>Unable to find a WPCOM GitHub Deployments for the site.</error>' );
+				$question = new ConfirmationQuestion( '<question>Do you want to continue anyway? [y/N]</question> ', false );
+				if ( true !== $this->getHelper( 'question' )->ask( $input, $output, $question ) ) {
+					$output->writeln( '<comment>Command aborted by user.</comment>' );
+					exit( 1 );
+				}
+				return; // Exit early if user chooses to continue without repository.
+			}
+			
+			// Continue with normal WPCOM repository initialization.
+			$this->get_wpcom_repository( $input, $output );
+		}
+
+		// Validate repository was found.
+		if ( ! $this->gh_repository || ! $this->gh_repository->name ) {
+			throw new \Exception( 'Could not find GitHub repository for site: ' . ( $this->site->url ?? 'unknown' ) );
+		}
+	}
+
+	/**
+	 * Initialize repository paths and branch.
+	 *
+	 * @param   InputInterface $input The input object.
+	 *
+	 * @return  void
+	 */
+	private function initialize_paths_and_branch( InputInterface $input ): void {
+		// Set up repository paths.
+		$this->repos_dir = getcwd() . '/repos';
+		$this->repo_dir  = $this->repos_dir . '/' . $this->gh_repository->name;
+		
+		// Set default branch.
+		$this->gh_repo_branch = 'develop';
+		$input->setOption( 'branch', $this->gh_repo_branch );
+	}
+
+	/**
+	 * Prompts the user for a hosting provider.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  string|null
+	 */
+	private function prompt_host_input( InputInterface $input, OutputInterface $output ): ?string {
+		$choices = array(
+			'pressable' => 'Pressable',
+			'atomic'    => 'Atomic',
+		);
+
+		$question = new ChoiceQuestion( '<question>Please select the hosting provider:</question> ', $choices, 'pressable' );
+		$question->setValidator( fn( $value ) => validate_user_choice( $value, $choices ) );
+		return $this->getHelper( 'question' )->ask( $input, $output, $question );
+	}
+
+	/**
+	 * Prompts the user for a site.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  string|null
+	 */
+	private function prompt_site_input( InputInterface $input, OutputInterface $output ): ?string {
+		$question = new Question( '<question>Enter the domain or site ID:</question> ' );
+		return $this->getHelper( 'question' )->ask( $input, $output, $question );
+	}
+
+	/**
+	 * Prompts the user for a branch name.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  string|null
+	 */
+	private function prompt_branch_input( InputInterface $input, OutputInterface $output ): ?string {
+		$question = new Question( '<question>Enter the branch to deploy from [develop]:</question> ', 'develop' );
+		if ( ! $input->getOption( 'no-autocomplete' ) ) {
+			$question->setAutocompleterValues( array_column( get_github_repository_branches( $this->gh_repository->name ) ?? array(), 'name' ) );
+		}
+
+		return $this->getHelper( 'question' )->ask( $input, $output, $question );
+	}
+
+	/**
+	 * Gets the repository slug from the owner/repo-slug name.
+	 *
+	 * @param   string $repository_name The repository name.
+	 *
+	 * @return  string|null
+	 */
+	private function get_repository_slug_from_repository_name( string $repository_name ): ?string {
+		$repository_parts = explode( '/', $repository_name );
+
+		return $repository_parts[1] ?? null;
+	}
+
+	/**
+	 * Gets the site environment.
+	 *
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  string
+	 */
+	private function get_site_environment( OutputInterface $output ): string {
+		// If the site URL contains 'mystagingwebsite' or 'wpcomstaging' it's a staging site. Otherwise it's a production site.
+		if ( str_contains( $this->site->url, 'mystagingwebsite' ) || str_contains( $this->site->url, 'wpcomstaging' ) ) {
+			$this->write_output( $output, '<info>Site is a staging site.</info>' );
+			return 'staging';
+		}
+		$this->write_output( $output, '<info>Site is a production site.</info>' );
+		return 'production';
+	}
+
+	/**
+	 * Clones the GitHub repository.
+	 *
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  void
+	 */
+	private function clone_repo( OutputInterface $output ): void {
+		// Create a folder named "repos" in the current working directory if it doesn't exist.
+		if ( ! file_exists( $this->repos_dir ) ) {
+			mkdir( $this->repos_dir, 0755, true );
+		}
+
+		// Create a folder named the repository name in the repos folder if it doesn't exist.
+		if ( ! file_exists( $this->repo_dir ) ) {
+			mkdir( $this->repo_dir, 0755, true );
+			$this->write_output( $output, "<info>Created folder: {$this->repo_dir}</info>" );
+
+			// Clone the repository.
+			\run_system_command( array( 'git', 'clone', $this->gh_repository->clone_url, $this->repo_dir ) );
+			$this->write_output( $output, "<info>Cloned repository: {$this->gh_repository->name} ({$this->gh_repository->clone_url}) into {$this->repo_dir}</info>" );
+		}
+	}
+
+	/**
+	 * Gets the WPCOM repository.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  void
+	 */
+	private function get_wpcom_repository( InputInterface $input, OutputInterface $output ): void {
+		$wpcom_gh_repositories = get_wpcom_site_code_deployments( $this->site->ID );
+		$gh_repository_name    = null;
+
+		if ( empty( $wpcom_gh_repositories ) ) {
+			$output->writeln( '<error>Unable to find a WPCOM GitHub Deployments for the site.</error>' );
+
+			$question = new ConfirmationQuestion( '<question>Do you want to continue anyway? [y/N]</question> ', false );
+			if ( true !== $this->getHelper( 'question' )->ask( $input, $output, $question ) ) {
+				$output->writeln( '<comment>Command aborted by user.</comment>' );
+				exit( 1 );
+			}
+		}
+
+		if ( $wpcom_gh_repositories && 1 < count( $wpcom_gh_repositories ) ) {
+			$output->writeln( '<comment>Found multiple WPCOM GitHub Deployments for the site.</comment>' );
+
+			$question = new ChoiceQuestion(
+				'<question>Choose from which repository you want to use:</question> ',
+				\array_column( $wpcom_gh_repositories, 'repository_name' ),
+				0
+			);
+			$question->setErrorMessage( 'Repository %s is invalid.' );
+
+			$gh_repository_name = $this->get_repository_slug_from_repository_name( $this->getHelper( 'question' )->ask( $input, $output, $question ) );
+		} elseif ( $wpcom_gh_repositories && 1 === count( $wpcom_gh_repositories ) ) {
+			$gh_repository_name = $this->get_repository_slug_from_repository_name( $wpcom_gh_repositories[0]->repository_name );
+		}
+
+		if ( $gh_repository_name ) {
+			$this->gh_repo_branch = get_string_input( $input, 'branch', fn() => $this->prompt_branch_input( $input, $output ) );
+			$input->setOption( 'branch', $this->gh_repo_branch );
+
+			$this->gh_repository = get_github_repository( $gh_repository_name );
+		}
+	}
+
+	/**
+	 * Checks out the provided branch in the repository.
+	 * Creates the branch if it doesn't exist, otherwise checks out the existing branch.
+	 *
+	 * @param   string          $branch The branch to checkout.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  void
+	 */
+	private function git_checkout_branch( string $branch, OutputInterface $output ): void {
+		// First, check if the branch exists locally using git show-ref.
+		$check_process = new \Symfony\Component\Process\Process(
+			array( 'git', 'show-ref', '--verify', '--quiet', "refs/heads/{$branch}" ),
+			$this->repo_dir
+		);
+		$check_process->run();
+
+		if ( 0 === $check_process->getExitCode() ) {
+			// Branch exists, just checkout.
+			$this->write_output( $output, "  <comment>Branch {$branch} exists. Checking out...</comment>" );
+			\run_system_command( array( 'git', 'checkout', $branch ), $this->repo_dir );
+			$this->write_output( $output, "<info>Checked out existing branch: {$branch}</info>" );
+		} else {
+			// Branch doesn't exist, create it from current HEAD.
+			$this->write_output( $output, "  <comment>Branch {$branch} doesn't exist. Creating from {$this->git_base_branch}...</comment>" );
+			$process = \run_system_command( array( 'git', 'checkout', '-b', $branch ), $this->repo_dir );
+
+			if ( $process->getExitCode() !== 0 ) {
+				$output->writeln( "<error>Failed to create and checkout branch: {$branch}</error>" );
+				exit( 1 );
+			}
+			$this->write_output( $output, "<info>Created and checked out branch: {$branch}</info>" );
+		}
+	}
+
+	/**
+	 * Stages, commits, pushes, creates a PR and merges the changes.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  void
+	 */
+	private function stage_commit_push_pr_and_merge( InputInterface $input, OutputInterface $output ): void {
+		// Stage file changes.
+		\run_system_command( array( 'git', 'add', '.' ), $this->repo_dir, false );
+		$this->write_output( $output, '<info>Staged file changes.</info>' );
+
+		// Commit file changes.
+		\run_system_command( array( 'git', 'commit', '-m', 'Remove legacy modules' ), $this->repo_dir, false );
+		$this->write_output( $output, '<info>Committed file changes.</info>' );
+
+		// Push the branch with changes to remote.
+		// Use --force-with-lease to handle the case where the branch already exists from a previous run.
+		// This is safe because it's a temporary branch that will be deleted after merge.
+		\run_system_command( array( 'git', 'push', '--force-with-lease', '--set-upstream', 'origin', 'remove/atlantis-legacy-modules' ), $this->repo_dir, false );
+		$this->write_output( $output, "<info>Pushed branch 'remove/atlantis-legacy-modules' to remote.</info>" );
+
+		// Create PR from remove/atlantis-legacy-modules to the base branch.
+		// Always show PR creation output, even in silent mode.
+		$this->write_output( $output, "<info>Creating PR to merge remove/atlantis-legacy-modules into {$this->git_base_branch}...</info>", OutputInterface::VERBOSITY_QUIET );
+		
+		// Try to create the PR. If it already exists, gh will output the existing PR URL.
+		$process = \run_system_command( 
+			array( 
+				'gh', 'pr', 'create', 
+				'--title', 'Atlantis Rollout - Remove legacy modules', 
+				'--body', 'This PR was automatically generated by a script. Please review the changes and merge if they look good.', 
+				'--base', $this->git_base_branch, 
+				'--head', 'remove/atlantis-legacy-modules', 
+				'--repo', 'a8cteam51/' . $this->gh_repository->name 
+			),
+			$this->repo_dir,
+			false // Don't exit on error - the PR might already exist.
+		);
+		
+		// Output the result (either new PR URL or error message).
+		$pr_output = trim( $process->getOutput() . $process->getErrorOutput() );
+		if ( ! empty( $pr_output ) ) {
+			$output->writeln( $pr_output, OutputInterface::VERBOSITY_QUIET );
+			
+			// Extract and save PR URL for CSV processing.
+			// The output typically contains the PR URL (e.g., https://github.com/a8cteam51/repo/pull/123).
+			if ( preg_match( '#https://github\.com/[^/]+/[^/]+/pull/\d+#', $pr_output, $matches ) ) {
+				$this->pr_url = $matches[0];
+			}
+		}
+
+		// Ask for confirmation before merging PR and deleting branches (unless merge-pr or quiet flag is set).
+		$should_merge = $this->merge_pr;
+		if ( ! $this->quiet ) {
+			$output->writeln( '' );
+			$question = new ConfirmationQuestion( '<question>Do you want to merge the PR and delete the branches? [y/N]</question> ', false );
+			if ( true !== $this->getHelper( 'question' )->ask( $input, $output, $question ) ) {
+				$output->writeln( '<comment>Skipping PR merge and branch deletion.</comment>' );
+				return;
+			}
+			$should_merge = true;
+		}
+
+		if ( $should_merge ) {
+			// Merge the PR - always show output, even in silent mode.
+			$output->writeln( '<info>Merging PR...</info>', OutputInterface::VERBOSITY_QUIET );
+			
+			// Try with --auto first (for PRs that need to wait for checks).
+			// Use Process directly to avoid printing the error when it's expected.
+			$process = new \Symfony\Component\Process\Process(
+				array( 
+					'gh', 'pr', 'merge', 'remove/atlantis-legacy-modules', 
+					'--squash',  // Squash all commits into one
+					'--auto',    // Auto-merge when requirements are met
+					'--delete-branch',  // Delete the branch after merge
+					'--repo', 'a8cteam51/' . $this->gh_repository->name 
+				), 
+				$this->repo_dir
+			);
+			$process->run();
+
+			// Check if auto-merge failed because PR is already in clean status.
+			if ( 0 !== $process->getExitCode() && str_contains( $process->getErrorOutput(), 'is in clean status' ) ) {
+				// PR is ready to merge immediately, try without --auto.
+				$output->writeln( '<comment>PR is ready, merging immediately...</comment>', OutputInterface::VERBOSITY_QUIET );
+				$process = \run_system_command( 
+					array( 
+						'gh', 'pr', 'merge', 'remove/atlantis-legacy-modules', 
+						'--squash',
+						'--delete-branch',
+						'--repo', 'a8cteam51/' . $this->gh_repository->name 
+					), 
+					$this->repo_dir 
+				);
+			} elseif ( 0 !== $process->getExitCode() ) {
+				// Some other error occurred, output it and exit.
+				$output->writeln( '<error>Failed to merge PR:</error>', OutputInterface::VERBOSITY_QUIET );
+				$output->writeln( $process->getErrorOutput(), OutputInterface::VERBOSITY_QUIET );
+				exit( 1 );
+			}
+
+			// Output the merge result (only if successful).
+			if ( 0 === $process->getExitCode() ) {
+				$merge_output = trim( $process->getOutput() . $process->getErrorOutput() );
+				if ( ! empty( $merge_output ) ) {
+					$output->writeln( $merge_output, OutputInterface::VERBOSITY_QUIET );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Finds a plugin folder in the repository.
+	 * Checks mu-plugins first, then plugins.
+	 *
+	 * @param   string          $plugin_name The plugin folder name to search for.
+	 * @param   OutputInterface $output      The output object.
+	 *
+	 * @return  array|null Array with 'location' and 'path' keys, or null if not found.
+	 */
+	private function find_plugin( string $plugin_name, OutputInterface $output ): ?array {
+		// Check in mu-plugins folder first.
+		$mu_plugins_path = $this->repo_dir . '/mu-plugins/' . $plugin_name;
+		if ( file_exists( $mu_plugins_path ) ) {
+			$this->write_output( $output, "<comment>{$plugin_name} found in mu-plugins</comment>" );
+			return array(
+				'location' => 'mu-plugins',
+				'path'     => $mu_plugins_path,
+			);
+		}
+
+		// Check in plugins folder.
+		$plugins_path = $this->repo_dir . '/plugins/' . $plugin_name;
+		if ( file_exists( $plugins_path ) ) {
+			$this->write_output( $output, "<comment>{$plugin_name} found in plugins</comment>" );
+			return array(
+				'location' => 'plugins',
+				'path'     => $plugins_path,
+			);
+		}
+
+		$this->write_output( $output, "<info>{$plugin_name} not found in mu-plugins or plugins directories.</info>" );
+		return null;
+	}
+
+	/**
+	 * Deletes a plugin folder from the repository.
+	 *
+	 * @param   string          $plugin_name The plugin name.
+	 * @param   string          $location    The location type ('mu-plugins' or 'plugins').
+	 * @param   string          $plugin_path The path to the plugin folder.
+	 * @param   OutputInterface $output      The output object.
+	 *
+	 * @return  void
+	 */
+	private function delete_plugin( string $plugin_name, string $location, string $plugin_path, OutputInterface $output ): void {
+		if ( ! file_exists( $plugin_path ) ) {
+			return;
+		}
+
+		$this->write_output( $output, "<fg=yellow>Removing {$plugin_name} from {$location}...</>" );
+
+		// Check if .gitmodules exists and contains the plugin as a submodule.
+		$gitmodules_path = $this->repo_dir . '/.gitmodules';
+		$submodule_path  = $location . '/' . $plugin_name;
+		$is_submodule    = false;
+
+		if ( file_exists( $gitmodules_path ) ) {
+			$gitmodules_content = file_get_contents( $gitmodules_path );
+
+			// Check if the plugin submodule exists in .gitmodules for this location.
+			if ( false !== $gitmodules_content && str_contains( $gitmodules_content, $submodule_path ) ) {
+				$is_submodule = true;
+			}
+		}
+
+		if ( $is_submodule ) {
+			$this->write_output( $output, "  <comment>→ {$plugin_name} is a git submodule. Removing...</comment>" );
+
+			// Use git commands to properly remove the submodule.
+			// 1. Deinitialize the submodule.
+			$this->write_output( $output, '  1. Deinitializing submodule...' );
+			\run_system_command( array( 'git', 'submodule', 'deinit', '-f', $submodule_path ), $this->repo_dir, false );
+
+			// 2. Remove the submodule from git index.
+			$this->write_output( $output, '  2. Removing submodule from git index...' );
+			\run_system_command( array( 'git', 'rm', '-f', $submodule_path ), $this->repo_dir, false );
+
+			// 3. Remove the submodule's .git directory.
+			$submodule_git_dir = $this->repo_dir . '/.git/modules/' . $submodule_path;
+			if ( file_exists( $submodule_git_dir ) ) {
+				$this->write_output( $output, '  3. Cleaning up .git/modules directory...' );
+				\run_system_command( array( 'rm', '-rf', $submodule_git_dir ) );
+			}
+
+			$this->write_output( $output, "  <info>✓ {$plugin_name} submodule successfully removed from {$location}</info>" );
+		} else {
+			$this->write_output( $output, "  <comment>→ {$plugin_name} is a regular directory. Removing...</comment>" );
+			\run_system_command( array( 'rm', '-rf', $plugin_path ) );
+			$this->write_output( $output, "  <info>✓ {$plugin_name} directory successfully removed from {$location}</info>" );
+		}
+
+		$this->removed_modules[] = $plugin_name;
+	}
+
+	/**
+	 * Uninstalls all legacy plugins from WordPress in a single command.
+	 *
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  void
+	 */
+	private function uninstall_plugins_from_wordpress( OutputInterface $output ): void {
+		$site_identifier = 'atomic' === $this->host ? $this->site->ID : $this->site->id;
+		$plugins_list    = implode( ' ', $this->legacy_modules );
+
+		$this->write_output( $output, '' );
+		$this->write_output( $output, '<fg=cyan;options=bold>Deactivating and uninstalling plugins from WordPress...</>' );
+
+		try {
+			// Run single command to deactivate and uninstall all plugins.
+			// The --uninstall flag will also deactivate if needed.
+			$command = "plugin uninstall {$plugins_list} --deactivate";
+
+			// Skip output in silent mode.
+			if ( 'pressable' === $this->host ) {
+				run_pressable_site_wp_cli_command( $site_identifier, $command, $this->quiet );
+			} else {
+				run_wpcom_site_wp_cli_command( $site_identifier, $command, $this->quiet );
+			}
+
+			$this->write_output( $output, "  <info>✓ Plugins deactivated and uninstalled from WordPress</info>" );
+		} catch ( \Exception $e ) {
+			$this->write_output( $output, "  <error>Failed to uninstall plugins from WordPress: {$e->getMessage()}</error>" );
+			$this->write_output( $output, '  <comment>This is usually fine if the plugins were not installed on the site.</comment>' );
+		}
+	}
+
+	/**
+	 * Read CSV file and return array of site data.
+	 *
+	 * @param   string $csv_path Path to CSV file.
+	 *
+	 * @return  array
+	 */
+	private function read_csv( string $csv_path ): array {
+		$csv_data = array();
+		$handle   = fopen( $csv_path, 'r' );
+
+		if ( false === $handle ) {
+			return $csv_data;
+		}
+
+		// Read header row.
+		$headers = fgetcsv( $handle );
+		if ( false === $headers ) {
+			fclose( $handle );
+			return $csv_data;
+		}
+
+		// Read data rows.
+		$row_index = 1; // Start at 1 (0 is header).
+		while ( ( $row = fgetcsv( $handle ) ) !== false ) {
+			$row_index++;
+			
+			// Skip empty rows.
+			if ( empty( array_filter( $row ) ) ) {
+				continue;
+			}
+			
+			// Ensure row has same number of columns as headers.
+			if ( count( $row ) !== count( $headers ) ) {
+				// Pad or truncate row to match header count.
+				$row = array_pad( array_slice( $row, 0, count( $headers ) ), count( $headers ), '' );
+			}
+			
+			$site_data = array_combine( $headers, $row );
+			if ( $site_data ) {
+				$csv_data[ $row_index ] = $site_data;
+			}
+		}
+
+		fclose( $handle );
+		return $csv_data;
+	}
+
+	/**
+	 * Update a specific row in the CSV file.
+	 *
+	 * @param   int    $row_index  The row index to update (1-based, accounting for header).
+	 * @param   string $pr_url     The PR URL to set.
+	 * @param   string $merged     The Merged status ('Y' or '').
+	 * @param   string $note       Optional note to add.
+	 *
+	 * @return  void
+	 */
+	private function update_csv_row( int $row_index, string $pr_url, string $merged, string $note = '' ): void {
+		if ( ! $this->sites_csv_path || ! file_exists( $this->sites_csv_path ) ) {
+			return;
+		}
+
+		// Read all rows.
+		$rows   = array();
+		$handle = fopen( $this->sites_csv_path, 'r' );
+
+		if ( false === $handle ) {
+			return;
+		}
+
+		// Read header to find column indices.
+		$headers = fgetcsv( $handle );
+		if ( false === $headers ) {
+			fclose( $handle );
+			return;
+		}
+
+		// Find column indices (use strict comparison since array_search can return 0).
+		$pr_index     = array_search( 'PR', $headers, true );
+		$merged_index = array_search( 'Merged', $headers, true );
+		$notes_index  = array_search( 'Notes', $headers, true );
+
+		// If Notes column doesn't exist, we'll add it.
+		$needs_notes_column = false === $notes_index;
+		if ( $needs_notes_column ) {
+			$headers[] = 'Notes';
+			$notes_index = count( $headers ) - 1;
+		}
+
+		$rows[] = $headers; // Add header row.
+
+		$current_row = 1; // Start at 1 (header is row 0).
+		while ( ( $row = fgetcsv( $handle ) ) !== false ) {
+			$current_row++;
+
+			// Update the target row.
+			if ( $current_row === $row_index ) {
+				// Ensure row has enough columns.
+				while ( count( $row ) < count( $headers ) ) {
+					$row[] = '';
+				}
+
+				// Update PR column.
+				if ( false !== $pr_index ) {
+					$row[ $pr_index ] = $pr_url;
+				}
+
+				// Update Merged column.
+				if ( false !== $merged_index ) {
+					$row[ $merged_index ] = $merged;
+				}
+
+				// Update or add Notes column.
+				if ( $needs_notes_column ) {
+					// Add Notes column to existing rows that don't have it.
+					while ( count( $row ) <= $notes_index ) {
+						$row[] = '';
+					}
+				}
+				$row[ $notes_index ] = $note;
+			} elseif ( $needs_notes_column ) {
+				// Add empty Notes column to other rows.
+				while ( count( $row ) < count( $headers ) ) {
+					$row[] = '';
+				}
+			}
+
+			$rows[] = $row;
+		}
+
+		fclose( $handle );
+
+		// Write back to file.
+		$handle = fopen( $this->sites_csv_path, 'w' );
+		if ( false === $handle ) {
+			return;
+		}
+
+		foreach ( $rows as $row ) {
+			fputcsv( $handle, $row );
+		}
+
+		fclose( $handle );
+	}
+
+	/**
+	 * Reset site state between processing multiple sites.
+	 *
+	 * @return  void
+	 */
+	private function reset_site_state(): void {
+		$this->site              = null;
+		$this->deployhq_project  = null;
+		$this->gh_repository     = null;
+		$this->gh_repo_branch    = null;
+		$this->repo_dir          = null;
+		$this->removed_modules   = array();
+		$this->git_base_branch   = 'develop';
+	}
+
+	// endregion
+}

--- a/commands/Site_Remove_Atlantis_Legacy_Modules.php
+++ b/commands/Site_Remove_Atlantis_Legacy_Modules.php
@@ -157,6 +157,34 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 	 */
 	private ?string $pr_url = null;
 
+	/**
+	 * The PHP version of the current site.
+	 *
+	 * @var string|null
+	 */
+	private ?string $php_version = null;
+
+	/**
+	 * Minimum required PHP version for Atlantis plugin.
+	 *
+	 * @var string
+	 */
+	private string $min_php_version = '8.3';
+
+	/**
+	 * Note explaining why a site was skipped (for CSV processing).
+	 *
+	 * @var string|null
+	 */
+	private ?string $skip_note = null;
+
+	/**
+	 * The CSV URL for environment detection (more reliable than API URL).
+	 *
+	 * @var string|null
+	 */
+	private ?string $csv_url = null;
+
 	// endregion
 
 	// region INHERITED METHODS
@@ -325,8 +353,10 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 		$processed   = 0;
 		$skipped     = 0;
 		$failed      = 0;
+		$counter     = 0;
 
 		foreach ( $csv_data as $index => $site_data ) {
+			++$counter;
 			$site_name = $site_data['Site'] ?? 'Unknown';
 			$site_url  = $site_data['URL'] ?? '';
 			$host      = strtolower( $site_data['Host'] ?? '' );
@@ -335,7 +365,7 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 			if ( empty( $site_url ) || empty( $host ) ) {
 				$note = 'Missing required fields (URL or Host)';
 				$this->update_csv_row( $index, '', '', $note );
-				$output->writeln( "<error>[$index/$total_sites] Skipping {$site_name} - {$note}</error>" );
+				$output->writeln( "<error>[{$counter}/{$total_sites}] Skipping {$site_name} - {$note}</error>" );
 				++$skipped;
 				continue;
 			}
@@ -344,7 +374,7 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 			if ( ! in_array( $host, array( 'pressable', 'atomic' ), true ) ) {
 				$note = "Invalid host value: {$host} (must be 'pressable' or 'atomic')";
 				$this->update_csv_row( $index, '', '', $note );
-				$output->writeln( "<error>[$index/$total_sites] Skipping {$site_name} - {$note}</error>" );
+				$output->writeln( "<error>[{$counter}/{$total_sites}] Skipping {$site_name} - {$note}</error>" );
 				++$skipped;
 				continue;
 			}
@@ -353,12 +383,12 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 			if ( ! empty( $site_data['PR'] ?? '' ) || 'Y' === strtoupper( $site_data['Merged'] ?? '' ) ) {
 				$note = 'Already processed (has PR or marked as Merged)';
 				$this->update_csv_row( $index, $site_data['PR'] ?? '', $site_data['Merged'] ?? '', $note );
-				$output->writeln( "<comment>[$index/$total_sites] Skipping {$site_name} - already processed</comment>" );
+				$output->writeln( "<comment>[{$counter}/{$total_sites}] Skipping {$site_name} - already processed</comment>" );
 				++$skipped;
 				continue;
 			}
 
-			$output->writeln( "<info>[$index/$total_sites] Processing: {$site_name} ({$site_url})</info>" );
+			$output->writeln( "<info>[{$counter}/{$total_sites}] Processing: {$site_name} ({$site_url})</info>" );
 
 			try {
 				// Reset state for this site.
@@ -372,13 +402,38 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 				// Initialize site.
 				$this->initialize_site_from_url( $site_url, $host );
 
-				// Initialize repository (handle WPCOM GitHub Deployments error gracefully).
+				// Normalize URL property for WPCOM sites (they use uppercase URL).
+				if ( 'atomic' === $host && isset( $this->site->URL ) ) {
+					$this->site->url = $this->site->URL;
+				}
+
+				// Safety check: Compare CSV URL with API URL (applies to both Atomic AND Pressable).
+				$csv_domain = $this->extract_domain_from_url( $site_url );
+				$api_domain = $this->extract_domain_from_url( $this->site->url ?? '' );
+
+				if ( $csv_domain !== $api_domain ) {
+					$note = "API URL differs from CSV: {$this->site->url}";
+					$this->update_csv_row( $index, '', '', $note );
+					$output->writeln( "<comment>⚠ {$site_name}: {$note}</comment>" );
+					++$skipped;
+					continue;
+				}
+
+				// Store CSV URL for environment detection (more reliable than API URL).
+				$this->csv_url = $site_url;
+
+				// Initialize repository (handle deployment configuration errors gracefully).
 				try {
 					$this->initialize_repository( $input, $output );
 				} catch ( \Exception $e ) {
-					// Check if it's the WPCOM GitHub Deployments error.
-					if ( str_contains( $e->getMessage(), 'WPCOM GitHub Deployments' ) || str_contains( $e->getMessage(), 'GitHub repository' ) ) {
-						$note = 'Unable to find a WPCOM GitHub Deployment for the site';
+					// Check if it's a deployment configuration error (DeployHQ for Pressable, WPCOM GitHub Deployments for Atomic).
+					$is_deployment_error = str_contains( $e->getMessage(), 'WPCOM GitHub Deployments' )
+						|| str_contains( $e->getMessage(), 'GitHub repository' )
+						|| str_contains( $e->getMessage(), 'DeployHQ' );
+
+					if ( $is_deployment_error ) {
+						$deployment_type = ( 'pressable' === $site_host ) ? 'DeployHQ' : 'WPCOM GitHub';
+						$note            = "Unable to find a {$deployment_type} deployment for the site";
 						$this->update_csv_row( $index, '', '', $note );
 						$output->writeln( "<comment>⚠ {$site_name}: {$note}</comment>" );
 						++$skipped;
@@ -396,24 +451,46 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 					$this->git_base_branch = 'trunk';
 				}
 
+				// Safety check: If CSV URL indicates staging, never use trunk/master.
+				// This prevents accidentally processing production when staging was intended.
+				$csv_url_lower  = strtolower( $site_url );
+				$is_staging_url = str_contains( $csv_url_lower, 'staging' ) ||
+					str_contains( $csv_url_lower, 'mystagingwebsite' ) ||
+					str_contains( $csv_url_lower, 'wpcomstaging' ) ||
+					str_contains( $csv_url_lower, '-dev' ) ||
+					str_contains( $csv_url_lower, '-development' );
+
+				if ( $is_staging_url && in_array( $this->git_base_branch, array( 'trunk', 'master' ), true ) ) {
+					$note = "Staging URL but would use {$this->git_base_branch} branch - skipping for safety";
+					$this->update_csv_row( $index, '', '', $note );
+					$output->writeln( "<error>⚠ {$site_name}: {$note}</error>" );
+					++$skipped;
+					continue;
+				}
+
 				// Process the site.
 				$result = $this->process_single_site( $input, $output );
 
-				if ( Command::SUCCESS === $result ) {
+				if ( Command::INVALID === $result ) {
+					// Site was skipped due to PHP version or branch issue.
+					$note = $this->skip_note ?? 'Site skipped (unknown reason)';
+					$this->update_csv_row( $index, '', '', $note );
+					$output->writeln( "<comment>⚠ {$site_name}: {$note}</comment>" );
+					++$skipped;
+				} elseif ( Command::SUCCESS === $result ) {
 					if ( $this->pr_url ) {
 						// Update CSV with PR URL and Merged status.
 						// Mark as 'Y' only if --merge-pr was used.
 						$merged_status = $this->merge_pr ? 'Y' : '';
 						$this->update_csv_row( $index, $this->pr_url, $merged_status );
 						$output->writeln( "<info>✓ {$site_name} completed successfully</info>" );
-						++$processed;
 					} else {
-						// No PR created (likely no modules found).
-						$note = 'No legacy modules found in repository';
-						$this->update_csv_row( $index, '', '', $note );
-						$output->writeln( "<comment>⚠ {$site_name}: {$note}</comment>" );
-						++$skipped;
+						// No PR created - plugin installed, no repo changes needed (no legacy modules in repo).
+						// This is still a successful completion.
+						$this->update_csv_row( $index, '', 'Y', 'Plugin installed (no repo changes needed)' );
+						$output->writeln( "<info>✓ {$site_name} completed successfully (no repo changes needed)</info>" );
 					}
+					++$processed;
 				} else {
 					++$failed;
 					$output->writeln( "<error>✗ {$site_name} failed</error>" );
@@ -452,10 +529,29 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 	private function process_single_site( InputInterface $input, OutputInterface $output ): int {
 		$this->write_output( $output, "<fg=magenta;options=bold>Processing repository for site {$this->site->url} (base branch: {$this->git_base_branch}).</>" );
 
+		// Check PHP version first - Atlantis plugin requires PHP 8.3+.
+		$this->check_php_version( $output );
+		if ( ! $this->meets_php_requirement() ) {
+			$this->skip_note = "PHP version {$this->php_version} < {$this->min_php_version} required";
+			$this->write_output( $output, "<error>{$this->skip_note}. Skipping Atlantis plugin installation.</error>" );
+			// Return a special status to indicate PHP version issue (caller will handle CSV update).
+			return Command::INVALID;
+		}
+
 		$this->clone_repo( $output );
 
-		// Checkout the base branch.
-		\run_system_command( array( 'git', 'checkout', $this->git_base_branch ), $this->repo_dir );
+		// Checkout the base branch - handle failure gracefully.
+		$checkout_process = \run_system_command( array( 'git', 'checkout', $this->git_base_branch ), $this->repo_dir, false );
+		if ( ! $checkout_process->isSuccessful() ) {
+			$this->skip_note = "Branch '{$this->git_base_branch}' not found";
+			$this->write_output( $output, "<error>{$this->skip_note}. Skipping site.</error>" );
+			// Clean up the cloned repo folder.
+			if ( $this->repo_dir && $this->repos_dir && str_starts_with( $this->repo_dir, $this->repos_dir ) ) {
+				\run_system_command( array( 'rm', '-rf', $this->repo_dir ), $this->repo_dir, false );
+			}
+			// Return a special status to indicate branch issue (caller will handle CSV update).
+			return Command::INVALID;
+		}
 
 		// Checkout the branch 'remove/atlantis-legacy-modules'.
 		$this->git_checkout_branch( 'remove/atlantis-legacy-modules', $output );
@@ -473,34 +569,25 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 			}
 		}
 
-		// Only install the Atlantis plugin if we found legacy modules to replace.
-		if ( ! empty( $found_modules ) ) {
-			$this->install_atlantis_plugin( $output );
+		// Check autoupdate filter status BEFORE installing Atlantis.
+		// This must happen first so the database option is set before Atlantis activates.
+		$this->check_autoupdate_filter_status( $output );
 
-			// Check if plugin-autoupdate-filter exists but is deactivated, and disable Atlantis module if so.
-			$this->check_autoupdate_filter_status( $output );
+		// Always install the Atlantis plugin.
+		$plugin_installed = $this->install_atlantis_plugin( $output );
 
-			// Now delete the found modules.
+		if ( $plugin_installed && ! empty( $found_modules ) ) {
+			// Delete the found modules from the repository.
 			foreach ( $found_modules as $plugin_name => $plugin_info ) {
 				$this->delete_plugin( $plugin_name, $plugin_info['location'], $plugin_info['path'], $output );
 			}
 		}
 
 		// Uninstall plugins from WordPress if --uninstall option is provided.
-		if ( $this->uninstall_plugins && count( $this->legacy_modules ) > 0 ) {
-			// In quiet mode, automatically uninstall plugins.
-			if ( $this->quiet ) {
-				$this->uninstall_plugins_from_wordpress( $output );
-			} else {
-				$output->writeln( '' );
-				$plugins_list = implode( ', ', $this->legacy_modules );
-				$question     = new ConfirmationQuestion( "<question>Do you want to deactivate and uninstall these plugins from WordPress ({$plugins_list})? [y/N]</question> ", false );
-				if ( true === $this->getHelper( 'question' )->ask( $input, $output, $question ) ) {
-					$this->uninstall_plugins_from_wordpress( $output );
-				} else {
-					$output->writeln( '<comment>Skipping WordPress plugin uninstallation.</comment>' );
-				}
-			}
+		// No confirmation needed - just proceed automatically.
+		$legacy_modules_count = count( $this->legacy_modules );
+		if ( $this->uninstall_plugins && $legacy_modules_count > 0 ) {
+			$this->uninstall_plugins_from_wordpress( $output );
 		}
 
 		if ( count( $this->removed_modules ) > 0 ) {
@@ -721,8 +808,11 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 	 * @return  string
 	 */
 	private function get_site_environment( OutputInterface $output ): string {
-		// If the site URL contains 'mystagingwebsite' or 'wpcomstaging' it's a staging site. Otherwise it's a production site.
-		if ( str_contains( $this->site->url, 'mystagingwebsite' ) || str_contains( $this->site->url, 'wpcomstaging' ) ) {
+		// Use stored CSV URL if available (more reliable for staging detection).
+		$url_to_check = $this->csv_url ?? $this->site->url ?? '';
+
+		// If the URL contains 'mystagingwebsite' or 'wpcomstaging' it's a staging site. Otherwise it's a production site.
+		if ( str_contains( $url_to_check, 'mystagingwebsite' ) || str_contains( $url_to_check, 'wpcomstaging' ) ) {
 			$this->write_output( $output, '<info>Site is a staging site.</info>' );
 			return 'staging';
 		}
@@ -896,7 +986,7 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 
 		// Ask for confirmation before merging PR and deleting branches (unless merge-pr or quiet flag is set).
 		$should_merge = $this->merge_pr;
-		if ( ! $this->quiet ) {
+		if ( ! $this->quiet && ! $this->merge_pr ) {
 			$output->writeln( '' );
 			$question = new ConfirmationQuestion( '<question>Do you want to merge the PR and delete the branches? [y/N]</question> ', false );
 			if ( true !== $this->getHelper( 'question' )->ask( $input, $output, $question ) ) {
@@ -928,10 +1018,18 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 			);
 			$process->run();
 
-			// Check if auto-merge failed because PR is already in clean status.
-			if ( 0 !== $process->getExitCode() && str_contains( $process->getErrorOutput(), 'is in clean status' ) ) {
-				// PR is ready to merge immediately, try without --auto.
-				$output->writeln( '<comment>PR is ready, merging immediately...</comment>', OutputInterface::VERBOSITY_QUIET );
+			// Check if auto-merge failed and we should retry without --auto.
+			// This happens when:
+			// - PR is already in clean status (ready to merge immediately)
+			// - Branch protection rules not configured (auto-merge not available)
+			$error_output = $process->getErrorOutput();
+			$should_retry = str_contains( $error_output, 'is in clean status' ) ||
+				str_contains( $error_output, 'Protected branch rules not configured' ) ||
+				str_contains( $error_output, 'enablePullRequestAutoMerge' );
+
+			if ( 0 !== $process->getExitCode() && $should_retry ) {
+				// Retry without --auto flag.
+				$output->writeln( '<comment>Auto-merge not available, merging directly...</comment>', OutputInterface::VERBOSITY_QUIET );
 				$process = \run_system_command(
 					array(
 						'gh',
@@ -943,12 +1041,13 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 						'--repo',
 						'a8cteam51/' . $this->gh_repository->name,
 					),
-					$this->repo_dir
+					$this->repo_dir,
+					false
 				);
 			} elseif ( 0 !== $process->getExitCode() ) {
 				// Some other error occurred, output it and exit.
 				$output->writeln( '<error>Failed to merge PR:</error>', OutputInterface::VERBOSITY_QUIET );
-				$output->writeln( $process->getErrorOutput(), OutputInterface::VERBOSITY_QUIET );
+				$output->writeln( $error_output, OutputInterface::VERBOSITY_QUIET );
 				exit( 1 );
 			}
 
@@ -1061,9 +1160,9 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 	 *
 	 * @param   OutputInterface $output The output object.
 	 *
-	 * @return  void
+	 * @return  bool True if plugin was installed and activated successfully, false otherwise.
 	 */
-	private function install_atlantis_plugin( OutputInterface $output ): void {
+	private function install_atlantis_plugin( OutputInterface $output ): bool {
 		$plugin_url      = 'https://github.com/a8cteam51/a8csp-atlantis/releases/download/v1.0.2/a8csp-atlantis.zip';
 		$site_identifier = 'atomic' === $this->host ? $this->site->ID : $this->site->id;
 
@@ -1076,9 +1175,15 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 			$this->write_output( $output, "  Running: wp {$install_command}" );
 
 			if ( 'pressable' === $this->host ) {
-				run_pressable_site_wp_cli_command( $site_identifier, $install_command, $this->quiet );
+				$install_result = run_pressable_site_wp_cli_command( $site_identifier, $install_command, $this->quiet );
 			} else {
-				run_wpcom_site_wp_cli_command( $site_identifier, $install_command, $this->quiet );
+				$install_result = run_wpcom_site_wp_cli_command( $site_identifier, $install_command, $this->quiet );
+			}
+
+			// Check if installation was successful.
+			if ( Command::SUCCESS !== $install_result ) {
+				$this->write_output( $output, '  <error>Plugin installation failed.</error>' );
+				return false;
 			}
 
 			$this->write_output( $output, '  <info>✓ Plugin installed successfully</info>' );
@@ -1088,16 +1193,23 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 			$this->write_output( $output, "  Running: wp {$activate_command}" );
 
 			if ( 'pressable' === $this->host ) {
-				run_pressable_site_wp_cli_command( $site_identifier, $activate_command, $this->quiet );
+				$activate_result = run_pressable_site_wp_cli_command( $site_identifier, $activate_command, $this->quiet );
 			} else {
-				run_wpcom_site_wp_cli_command( $site_identifier, $activate_command, $this->quiet );
+				$activate_result = run_wpcom_site_wp_cli_command( $site_identifier, $activate_command, $this->quiet );
+			}
+
+			// Check if activation was successful.
+			if ( Command::SUCCESS !== $activate_result ) {
+				$this->write_output( $output, '  <error>Plugin activation failed.</error>' );
+				return false;
 			}
 
 			$this->write_output( $output, '  <info>✓ Plugin activated successfully</info>' );
+			return true;
 
 		} catch ( \Exception $e ) {
 			$this->write_output( $output, "  <error>Failed to install/activate Atlantis plugin: {$e->getMessage()}</error>" );
-			$this->write_output( $output, '  <comment>Continuing with legacy module removal...</comment>' );
+			return false;
 		}
 	}
 
@@ -1126,13 +1238,20 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 			$list_command = 'plugin list --format=json';
 
 			if ( 'pressable' === $this->host ) {
-				$result = run_pressable_site_wp_cli_command( $site_identifier, $list_command, true );
+				run_pressable_site_wp_cli_command( $site_identifier, $list_command, true );
 			} else {
-				$result = run_wpcom_site_wp_cli_command( $site_identifier, $list_command, true );
+				run_wpcom_site_wp_cli_command( $site_identifier, $list_command, true );
 			}
 
-			// Parse the JSON output.
-			$plugins = json_decode( $result, true );
+			// Get the output from the global variable.
+			$wp_cli_output = $GLOBALS['wp_cli_output'] ?? '';
+
+			// Extract JSON array from output (may contain warnings before JSON).
+			$plugins = null;
+			if ( preg_match( '/\[.*\]/s', $wp_cli_output, $matches ) ) {
+				$plugins = json_decode( $matches[0], true );
+			}
+
 			if ( ! is_array( $plugins ) ) {
 				$this->write_output( $output, '  <comment>Could not parse plugin list.</comment>' );
 				return;
@@ -1166,8 +1285,8 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 			if ( ! $any_active ) {
 				$this->write_output( $output, '  <comment>Plugin found but not active. Disabling Atlantis autoupdates module...</comment>' );
 
-				// Set option to disable the autoupdates module: a:1:{s:7:"enabled";s:1:"0";}
-				$option_command = "option update a8csp_module_autoupdates 'a:1:{s:7:\"enabled\";s:1:\"0\";}'";
+				// Use wp eval to set the option as an array directly (avoids shell escaping issues).
+				$option_command = 'eval "update_option( \'a8csp_module_autoupdates\', array( \'enabled\' => \'0\' ) );"';
 
 				if ( 'pressable' === $this->host ) {
 					run_pressable_site_wp_cli_command( $site_identifier, $option_command, $this->quiet );
@@ -1216,6 +1335,67 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 			$this->write_output( $output, "  <error>Failed to uninstall plugins from WordPress: {$e->getMessage()}</error>" );
 			$this->write_output( $output, '  <comment>This is usually fine if the plugins were not installed on the site.</comment>' );
 		}
+	}
+
+	/**
+	 * Check the PHP version of the current site.
+	 *
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  string|null The PHP version string, or null on error.
+	 */
+	private function check_php_version( OutputInterface $output ): ?string {
+		$this->write_output( $output, '' );
+		$this->write_output( $output, '<fg=cyan;options=bold>Checking PHP version...</>' );
+
+		// For Pressable sites, try to get PHP version from the API response first.
+		if ( 'pressable' === $this->host && isset( $this->site->phpVersion ) ) {
+			$this->php_version = $this->site->phpVersion;
+			$this->write_output( $output, "  <info>PHP version: {$this->php_version} (from API)</info>" );
+			return $this->php_version;
+		}
+
+		// Fall back to WP-CLI for Atomic sites or if API doesn't have PHP version.
+		$site_identifier = 'atomic' === $this->host ? $this->site->ID : $this->site->id;
+
+		try {
+			$command = "eval 'echo phpversion();'";
+
+			if ( 'pressable' === $this->host ) {
+				run_pressable_site_wp_cli_command( $site_identifier, $command, true );
+			} else {
+				run_wpcom_site_wp_cli_command( $site_identifier, $command, true );
+			}
+
+			// Get the output from the global variable.
+			$wp_cli_output = $GLOBALS['wp_cli_output'] ?? '';
+
+			// Parse the version from output (should be something like "8.3.0" or "8.2.30").
+			if ( preg_match( '/(\d+\.\d+(\.\d+)?)/', $wp_cli_output, $matches ) ) {
+				$this->php_version = $matches[1];
+				$this->write_output( $output, "  <info>PHP version: {$this->php_version}</info>" );
+				return $this->php_version;
+			}
+
+			$this->write_output( $output, '  <comment>Could not determine PHP version from output.</comment>' );
+			return null;
+		} catch ( \Exception $e ) {
+			$this->write_output( $output, "  <error>Failed to check PHP version: {$e->getMessage()}</error>" );
+			return null;
+		}
+	}
+
+	/**
+	 * Check if the site meets the minimum PHP version requirement.
+	 *
+	 * @return  bool True if PHP version is sufficient, false otherwise.
+	 */
+	private function meets_php_requirement(): bool {
+		if ( null === $this->php_version ) {
+			return false;
+		}
+
+		return version_compare( $this->php_version, $this->min_php_version, '>=' );
 	}
 
 	/**
@@ -1377,6 +1557,9 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 		$this->repo_dir         = null;
 		$this->removed_modules  = array();
 		$this->git_base_branch  = 'develop';
+		$this->php_version      = null;
+		$this->skip_note        = null;
+		$this->csv_url          = null;
 	}
 
 	// endregion

--- a/commands/Site_Remove_Atlantis_Legacy_Modules.php
+++ b/commands/Site_Remove_Atlantis_Legacy_Modules.php
@@ -35,6 +35,15 @@ use WPCOMSpecialProjects\CLI\Helper\AutocompleteTrait;
  *   # Process multiple sites from CSV with plugin uninstallation
  *   team51 site:remove-atlantis-legacy-modules --sites=atlantis-sites.csv --no-output --merge-pr --uninstall
  *
+ *   # Site-only mode: verify Atlantis is active and uninstall legacy plugins (no repository operations)
+ *   team51 site:remove-atlantis-legacy-modules example.com --host=pressable --site-only
+ *
+ *   # Site-only batch mode: process multiple sites without repository operations
+ *   team51 site:remove-atlantis-legacy-modules --sites=atlantis-sites.csv --no-output --site-only
+ *
+ *   # Dry run: check all sites without making any changes
+ *   team51 site:remove-atlantis-legacy-modules --sites=atlantis-sites.csv --dry-run
+ *
  *
  * CSV File Format:
  *   The CSV file should have the following columns: Site, URL, Host, Merged, PR, Notes
@@ -106,6 +115,7 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 		'colophon',
 		'plugin-autoupdate-filter',
 		'team51-tracking',
+		'wc-usage-tracking-auto-opt-in',
 	);
 
 	/**
@@ -121,6 +131,14 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 	 * @var string
 	 */
 	private string $git_base_branch = 'develop';
+
+	/**
+	 * The working branch name for removing legacy modules.
+	 * Derived from the base branch (e.g. remove/atlantis-legacy-modules-trunk).
+	 *
+	 * @var string
+	 */
+	private string $working_branch = 'remove/atlantis-legacy-modules-develop';
 
 	/**
 	 * Whether to skip confirmations and minimize output (quiet mode).
@@ -149,6 +167,21 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 	 * @var bool
 	 */
 	private bool $skip_repository = false;
+
+	/**
+	 * Whether --site-only was explicitly passed on the CLI.
+	 * Preserved across CSV iterations (not reset by reset_site_state()).
+	 *
+	 * @var bool
+	 */
+	private bool $site_only_option = false;
+
+	/**
+	 * Whether to run in dry-run mode (read-only, no changes made).
+	 *
+	 * @var bool
+	 */
+	private bool $dry_run = false;
 
 	/**
 	 * Whether the current site had no deployment found (used to gracefully
@@ -184,7 +217,7 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 	 *
 	 * @var string
 	 */
-	private string $min_php_version = '8.3';
+	private string $min_php_version = '8.2';
 
 	/**
 	 * Note explaining why a site was skipped (for CSV processing).
@@ -217,7 +250,9 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 			->addOption( 'no-output', null, InputOption::VALUE_NONE, 'Skip confirmations and minimize output (except PR creation).' )
 			->addOption( 'merge-pr', null, InputOption::VALUE_NONE, 'Automatically merge the PR without asking for confirmation.' )
 			->addOption( 'uninstall', null, InputOption::VALUE_NONE, 'Uninstall plugins from WordPress in addition to removing them from the repository.' )
-			->addOption( 'sites', null, InputOption::VALUE_REQUIRED, 'Path to a CSV file containing sites to process (Site,URL,Host,Merged,PR).' );
+			->addOption( 'sites', null, InputOption::VALUE_REQUIRED, 'Path to a CSV file containing sites to process (Site,URL,Host,Merged,PR).' )
+			->addOption( 'site-only', null, InputOption::VALUE_NONE, 'Skip repository operations; only verify Atlantis is active and uninstall legacy plugins from WordPress.' )
+			->addOption( 'dry-run', null, InputOption::VALUE_NONE, 'Run all checks without making any changes (no plugin install/uninstall, no repo modifications, no CSV updates).' );
 	}
 
 	/**
@@ -232,6 +267,14 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 			$this->quiet             = (bool) $input->getOption( 'no-output' );
 			$this->merge_pr          = (bool) $input->getOption( 'merge-pr' );
 			$this->uninstall_plugins = (bool) $input->getOption( 'uninstall' );
+			$this->site_only_option  = (bool) $input->getOption( 'site-only' );
+			$this->skip_repository   = $this->site_only_option;
+			$this->dry_run           = (bool) $input->getOption( 'dry-run' );
+
+			// When --site-only is set, uninstalling plugins is implied.
+			if ( $this->skip_repository ) {
+				$this->uninstall_plugins = true;
+			}
 
 			// Validate CSV file exists.
 			if ( ! file_exists( $this->sites_csv_path ) ) {
@@ -247,6 +290,14 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 		$this->quiet             = (bool) $input->getOption( 'no-output' );
 		$this->merge_pr          = (bool) $input->getOption( 'merge-pr' );
 		$this->uninstall_plugins = (bool) $input->getOption( 'uninstall' );
+		$this->site_only_option  = (bool) $input->getOption( 'site-only' );
+		$this->skip_repository   = $this->site_only_option;
+		$this->dry_run           = (bool) $input->getOption( 'dry-run' );
+
+		// When --site-only is set, uninstalling plugins is implied.
+		if ( $this->skip_repository ) {
+			$this->uninstall_plugins = true;
+		}
 
 		// Get the site argument. If not provided, prompt for it (unless in quiet mode).
 		$site_input = $input->getArgument( 'site' );
@@ -278,27 +329,31 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 			exit( 1 );
 		}
 
-		// Initialize repository.
-		try {
-			$this->initialize_repository( $input, $output );
+		// Skip repository operations when --site-only is set.
+		if ( ! $this->skip_repository ) {
+			// Initialize repository.
+			try {
+				$this->initialize_repository( $input, $output );
 
-			// Show DeployHQ info for Pressable sites.
-			if ( 'pressable' === $this->host && $this->deployhq_project ) {
-				$output->writeln( "<comment>Found DeployHQ project {$this->deployhq_project->name} (permalink {$this->deployhq_project->permalink}) for the given site.</comment>", OutputInterface::VERBOSITY_VERBOSE );
+				// Show DeployHQ info for Pressable sites.
+				if ( 'pressable' === $this->host && $this->deployhq_project ) {
+					$output->writeln( "<comment>Found DeployHQ project {$this->deployhq_project->name} (permalink {$this->deployhq_project->permalink}) for the given site.</comment>", OutputInterface::VERBOSITY_VERBOSE );
+				}
+			} catch ( \Exception $e ) {
+				$output->writeln( '<error>Failed to get the GitHub repository connected to the project or invalid connected repository.</error>' );
+				exit( 1 );
 			}
-		} catch ( \Exception $e ) {
-			$output->writeln( '<error>Failed to get the GitHub repository connected to the project or invalid connected repository.</error>' );
-			exit( 1 );
-		}
 
-		// Initialize repository paths.
-		$this->repos_dir = getcwd() . '/repos';
-		$this->repo_dir  = $this->repos_dir . '/' . $this->gh_repository->name;
+			// Initialize repository paths.
+			$this->repos_dir = getcwd() . '/repos';
+			$this->repo_dir  = $this->repos_dir . '/' . $this->gh_repository->name;
 
-		// Check if the site is a staging site and set the base branch accordingly.
-		$environment = $this->get_site_environment( $output );
-		if ( 'production' === $environment ) {
-			$this->git_base_branch = 'trunk';
+			// Check if the site is a staging site and set the base branch accordingly.
+			$environment = $this->get_site_environment( $output );
+			if ( 'production' === $environment ) {
+				$this->git_base_branch = 'trunk';
+				$this->working_branch  = 'remove/atlantis-legacy-modules-trunk';
+			}
 		}
 	}
 
@@ -311,7 +366,11 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 			return;
 		}
 
-		$question = new ConfirmationQuestion( "<question>Are you sure you want to remove legacy modules from the repository for {$this->site->url} [{$this->host}] (repository: {$this->gh_repository->name} [{$this->git_base_branch}])? [y/N]</question> ", false );
+		if ( $this->skip_repository ) {
+			$question = new ConfirmationQuestion( "<question>Are you sure you want to verify Atlantis and remove legacy plugins from {$this->site->url} [{$this->host}]? [y/N]</question> ", false );
+		} else {
+			$question = new ConfirmationQuestion( "<question>Are you sure you want to remove legacy modules from the repository for {$this->site->url} [{$this->host}] (repository: {$this->gh_repository->name} [{$this->git_base_branch}])? [y/N]</question> ", false );
+		}
 		if ( true !== $this->getHelper( 'question' )->ask( $input, $output, $question ) ) {
 			$output->writeln( '<comment>Command aborted by user.</comment>' );
 			exit( 2 );
@@ -322,6 +381,11 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 	 * {@inheritDoc}
 	 */
 	protected function execute( InputInterface $input, OutputInterface $output ): int {
+		if ( $this->dry_run ) {
+			$output->writeln( '<fg=yellow;options=bold>--- DRY RUN MODE: No changes will be made ---</>' );
+			$output->writeln( '' );
+		}
+
 		// If CSV file provided, process multiple sites.
 		if ( $this->sites_csv_path ) {
 			return $this->process_csv( $input, $output );
@@ -364,11 +428,12 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 			}
 		}
 
-		$total_sites = count( $csv_data );
-		$processed   = 0;
-		$skipped     = 0;
-		$failed      = 0;
-		$counter     = 0;
+		$total_sites     = count( $csv_data );
+		$processed       = 0;
+		$skipped         = 0;
+		$failed          = 0;
+		$counter         = 0;
+		$processed_sites = array();
 
 		foreach ( $csv_data as $index => $site_data ) {
 			++$counter;
@@ -434,85 +499,100 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 					continue;
 				}
 
+				// Host verification: Ensure "atomic" sites are truly Atomic before proceeding.
+				if ( 'atomic' === $host && empty( $this->site->is_wpcom_atomic ) ) {
+					$pressable_site = get_pressable_site( $this->extract_domain_from_url( $site_url ) );
+					$actual_host    = $pressable_site ? 'Pressable' : 'unknown';
+					$note           = "Listed as Atomic but is_wpcom_atomic=false (actually {$actual_host}) - requires manual verification";
+					$this->update_csv_row( $index, '', '', $note );
+					$output->writeln( "<error>⚠ {$site_name}: {$note}</error>" );
+					++$skipped;
+					continue;
+				}
+
 				// Store CSV URL for environment detection (more reliable than API URL).
 				$this->csv_url = $site_url;
 
-				// Initialize repository (handle deployment configuration errors gracefully).
-				try {
-					$this->initialize_repository( $input, $output );
-				} catch ( \Exception $e ) {
-					// Check if it's a deployment configuration error (DeployHQ for Pressable, WPCOM GitHub Deployments for Atomic).
-					$is_deployment_error = str_contains( $e->getMessage(), 'WPCOM GitHub Deployments' )
-						|| str_contains( $e->getMessage(), 'GitHub repository' )
-						|| str_contains( $e->getMessage(), 'DeployHQ' );
+				// Skip repository operations when --site-only is set globally.
+				if ( ! $this->skip_repository ) {
+					// Initialize repository (handle deployment configuration errors gracefully).
+					try {
+						$this->initialize_repository( $input, $output );
+					} catch ( \Exception $e ) {
+						// Check if it's a deployment configuration error (DeployHQ for Pressable, WPCOM GitHub Deployments for Atomic).
+						$is_deployment_error = str_contains( $e->getMessage(), 'WPCOM GitHub Deployments' )
+							|| str_contains( $e->getMessage(), 'GitHub repository' )
+							|| str_contains( $e->getMessage(), 'DeployHQ' );
 
-					if ( ! $is_deployment_error ) {
-						// Re-throw if it's a different error.
-						throw $e;
-					}
+						if ( ! $is_deployment_error ) {
+							// Re-throw if it's a different error.
+							throw $e;
+						}
 
-					$deployment_type = ( 'pressable' === $host ) ? 'DeployHQ' : 'WPCOM GitHub';
-					$output->writeln( "<comment>⚠ {$site_name}: Unable to find a {$deployment_type} deployment for the site.</comment>" );
+						$deployment_type = ( 'pressable' === $host ) ? 'DeployHQ' : 'WPCOM GitHub';
+						$output->writeln( "<comment>⚠ {$site_name}: Unable to find a {$deployment_type} deployment for the site.</comment>" );
 
-					// Present the user with choices for how to proceed.
-					$choices = array(
-						'enter_repo' => 'Enter a repository URL or slug manually',
-						'site_only'  => 'Skip repository, process site only (install Atlantis, handle plugins)',
-						'skip'       => 'Skip this site entirely',
-					);
+						// Present the user with choices for how to proceed.
+						$choices = array(
+							'enter_repo' => 'Enter a repository URL or slug manually',
+							'site_only'  => 'Skip repository, process site only (install Atlantis, handle plugins)',
+							'skip'       => 'Skip this site entirely',
+						);
 
-					$question          = new ChoiceQuestion( '<question>How would you like to proceed?</question> ', $choices, 'skip' );
-					$deployment_choice = $this->getHelper( 'question' )->ask( $input, $output, $question );
+						$question          = new ChoiceQuestion( '<question>How would you like to proceed?</question> ', $choices, 'skip' );
+						$deployment_choice = $this->getHelper( 'question' )->ask( $input, $output, $question );
 
-					if ( 'skip' === $deployment_choice ) {
-						$note = "No {$deployment_type} deployment for the site - skipped by user";
-						$this->update_csv_row( $index, '', '', $note );
-						$output->writeln( "<comment>⚠ {$site_name}: {$note}</comment>" );
-						++$skipped;
-						continue;
-					}
-
-					$this->deployment_not_found = true;
-
-					if ( 'enter_repo' === $deployment_choice ) {
-						$repo = $this->prompt_and_resolve_repository( $input, $output );
-						if ( null === $repo ) {
-							$note = "No {$deployment_type} deployment - manual repo entry failed";
+						if ( 'skip' === $deployment_choice ) {
+							$note = "No {$deployment_type} deployment for the site - skipped by user";
 							$this->update_csv_row( $index, '', '', $note );
 							$output->writeln( "<comment>⚠ {$site_name}: {$note}</comment>" );
 							++$skipped;
 							continue;
 						}
-						$this->gh_repository = $repo;
-					} elseif ( 'site_only' === $deployment_choice ) {
-						$this->skip_repository = true;
+
+						$this->deployment_not_found = true;
+
+						if ( 'enter_repo' === $deployment_choice ) {
+							$repo = $this->prompt_and_resolve_repository( $input, $output );
+							if ( null === $repo ) {
+								$note = "No {$deployment_type} deployment - manual repo entry failed";
+								$this->update_csv_row( $index, '', '', $note );
+								$output->writeln( "<comment>⚠ {$site_name}: {$note}</comment>" );
+								++$skipped;
+								continue;
+							}
+							$this->gh_repository = $repo;
+						} elseif ( 'site_only' === $deployment_choice ) {
+							$this->skip_repository = true;
+						}
 					}
-				}
 
-				if ( ! $this->skip_repository ) {
-					$this->initialize_paths_and_branch( $input );
+					if ( ! $this->skip_repository ) {
+						$this->initialize_paths_and_branch( $input );
 
-					// Determine environment and base branch.
-					$environment = $this->get_site_environment( $output );
-					if ( 'production' === $environment ) {
-						$this->git_base_branch = 'trunk';
-					}
+						// Determine environment and base branch.
+						$environment = $this->get_site_environment( $output );
+						if ( 'production' === $environment ) {
+							$this->git_base_branch = 'trunk';
+							$this->working_branch  = 'remove/atlantis-legacy-modules-trunk';
+						}
 
-					// Safety check: If CSV URL indicates staging, never use trunk/master.
-					// This prevents accidentally processing production when staging was intended.
-					$csv_url_lower  = strtolower( $site_url );
-					$is_staging_url = str_contains( $csv_url_lower, 'staging' ) ||
-						str_contains( $csv_url_lower, 'mystagingwebsite' ) ||
-						str_contains( $csv_url_lower, 'wpcomstaging' ) ||
-						str_contains( $csv_url_lower, '-dev' ) ||
-						str_contains( $csv_url_lower, '-development' );
+						// Safety check: If CSV URL indicates staging, never use trunk/master.
+						// This prevents accidentally processing production when staging was intended.
+						$csv_url_lower  = strtolower( $site_url );
+						$is_staging_url = str_contains( $csv_url_lower, 'staging' ) ||
+							str_contains( $csv_url_lower, 'mystagingwebsite' ) ||
+							str_contains( $csv_url_lower, 'wpcomstaging' ) ||
+							str_contains( $csv_url_lower, '-dev' ) ||
+							str_contains( $csv_url_lower, '-development' );
 
-					if ( $is_staging_url && in_array( $this->git_base_branch, array( 'trunk', 'master' ), true ) ) {
-						$note = "Staging URL but would use {$this->git_base_branch} branch - skipping for safety";
-						$this->update_csv_row( $index, '', '', $note );
-						$output->writeln( "<error>⚠ {$site_name}: {$note}</error>" );
-						++$skipped;
-						continue;
+						if ( $is_staging_url && in_array( $this->git_base_branch, array( 'trunk', 'master' ), true ) ) {
+							$note = "Staging URL but would use {$this->git_base_branch} branch - skipping for safety";
+							$this->update_csv_row( $index, '', '', $note );
+							$output->writeln( "<error>⚠ {$site_name}: {$note}</error>" );
+							++$skipped;
+							continue;
+						}
 					}
 				}
 
@@ -522,39 +602,67 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 				if ( Command::INVALID === $result ) {
 					// Site was skipped due to PHP version or branch issue.
 					$note = $this->skip_note ?? 'Site skipped (unknown reason)';
-					$this->update_csv_row( $index, '', '', $note );
+					if ( ! $this->dry_run ) {
+						$this->update_csv_row( $index, '', '', $note );
+					}
 					$output->writeln( "<comment>⚠ {$site_name}: {$note}</comment>" );
 					++$skipped;
 				} elseif ( Command::SUCCESS === $result ) {
-					if ( $this->skip_repository ) {
-						// Site-only processing: Atlantis installed and plugins handled, no repo operations.
-						$note = $this->skip_note
-							? "Site-only: Atlantis installed, {$this->skip_note}"
-							: 'Site-only: Atlantis installed, no deployment found (repo skipped)';
+					if ( $this->dry_run ) {
+						$output->writeln( "<fg=yellow>✓ {$site_name} dry run complete</>" );
+					} elseif ( $this->skip_repository ) {
+						// Site-only processing: no repo operations.
+						if ( $this->site_only_option ) {
+							$note = 'Site-only: Atlantis active, legacy plugins cleaned up';
+							if ( $this->skip_note ) {
+								$note .= '; ' . $this->skip_note;
+							}
+						} else {
+							$note = $this->skip_note
+								? "Site-only: Atlantis installed, {$this->skip_note}"
+								: 'Site-only: Atlantis installed, no deployment found (repo skipped)';
+						}
 						$this->update_csv_row( $index, '', 'Y', $note );
 						$output->writeln( "<info>✓ {$site_name} completed (site-only, no repository)</info>" );
 					} elseif ( $this->pr_url ) {
 						// Update CSV with PR URL and Merged status.
 						// Mark as 'Y' only if --merge-pr was used.
 						$merged_status = $this->merge_pr ? 'Y' : '';
-						$this->update_csv_row( $index, $this->pr_url, $merged_status );
+						$this->update_csv_row( $index, $this->pr_url, $merged_status, $this->skip_note ?? '' );
 						$output->writeln( "<info>✓ {$site_name} completed successfully</info>" );
 					} else {
 						// No PR created - plugin installed, no repo changes needed (no legacy modules in repo).
 						// This is still a successful completion.
-						$this->update_csv_row( $index, '', 'Y', 'Plugin installed (no repo changes needed)' );
+						$note = 'Plugin installed (no repo changes needed)';
+						if ( $this->skip_note ) {
+							$note .= '; ' . $this->skip_note;
+						}
+						$this->update_csv_row( $index, '', 'Y', $note );
 						$output->writeln( "<info>✓ {$site_name} completed successfully (no repo changes needed)</info>" );
 					}
-					++$processed;
+					if ( ! $this->dry_run ) {
+							$processed_sites[] = array(
+								'index'     => $index,
+								'site_name' => $site_name,
+								'site_url'  => $this->site->url ?? $site_url,
+								'host'      => $this->host,
+								'site'      => clone $this->site,
+							);
+						}
+						++$processed;
 				} else {
 					$note = $this->skip_note ?? 'Processing failed';
-					$this->update_csv_row( $index, '', '', $note );
+					if ( ! $this->dry_run ) {
+						$this->update_csv_row( $index, '', '', $note );
+					}
 					++$failed;
 					$output->writeln( "<error>✗ {$site_name} failed: {$note}</error>" );
 				}
 			} catch ( \Exception $e ) {
 				$note = 'Error: ' . $e->getMessage();
-				$this->update_csv_row( $index, '', '', $note );
+				if ( ! $this->dry_run ) {
+					$this->update_csv_row( $index, '', '', $note );
+				}
 				++$failed;
 				$output->writeln( "<error>✗ {$site_name} failed: {$e->getMessage()}</error>" );
 			}
@@ -570,6 +678,46 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 		$output->writeln( "<comment>Skipped: {$skipped}</comment>" );
 		if ( $failed > 0 ) {
 			$output->writeln( "<error>Failed: {$failed}</error>" );
+		}
+
+		// Second pass: verify site health for all processed sites.
+		// This runs after all deployments have had time to propagate.
+		if ( ! empty( $processed_sites ) ) {
+			$output->writeln( '' );
+			$output->writeln( '<fg=cyan;options=bold>=== Site Health Verification ===' );
+			$output->writeln( "<info>Verifying {$processed} processed sites...</info>" );
+			$output->writeln( '' );
+
+			$health_warnings = 0;
+			$health_counter  = 0;
+
+			foreach ( $processed_sites as $site_info ) {
+				++$health_counter;
+				$output->writeln( "<info>[{$health_counter}/{$processed}] Verifying: {$site_info['site_name']} ({$site_info['site_url']})</info>" );
+
+				// Restore site context for the health check.
+				$this->site      = $site_info['site'];
+				$this->host      = $site_info['host'];
+				$this->skip_note = null;
+
+				$this->verify_site_health( $output );
+
+				if ( $this->skip_note ) {
+					++$health_warnings;
+					$this->append_csv_note( $site_info['index'], $this->skip_note );
+					$output->writeln( "<error>⚠ {$site_info['site_name']}: {$this->skip_note}</error>" );
+				}
+
+				$output->writeln( '' );
+			}
+
+			$output->writeln( '<fg=cyan;options=bold>=== Health Check Summary ===' );
+			$output->writeln( "<info>Sites verified: {$processed}</info>" );
+			if ( $health_warnings > 0 ) {
+				$output->writeln( "<error>Sites with warnings: {$health_warnings}</error>" );
+			} else {
+				$output->writeln( '<info>All sites passed health checks</info>' );
+			}
 		}
 
 		return Command::SUCCESS;
@@ -590,7 +738,14 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 			$this->write_output( $output, "<fg=magenta;options=bold>Processing repository for site {$this->site->url} (base branch: {$this->git_base_branch}).</>" );
 		}
 
-		// Check PHP version first - Atlantis plugin requires PHP 8.3+.
+		// Pre-flight SSH check — verify connectivity before attempting any WP-CLI operations.
+		if ( ! $this->check_ssh_access( $output ) ) {
+			$this->skip_note = 'SSH access check failed (site may be unreachable)';
+			$this->write_output( $output, "<error>{$this->skip_note}. Skipping site.</error>" );
+			return Command::INVALID;
+		}
+
+		// Check PHP version first - Atlantis plugin requires PHP 8.2+.
 		$this->check_php_version( $output );
 		if ( null === $this->php_version ) {
 			$this->skip_note = 'Unable to connect to site (SSH may be disabled)';
@@ -630,8 +785,8 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 			}
 
 			if ( ! $this->skip_repository ) {
-				// Checkout the branch 'remove/atlantis-legacy-modules'.
-				$this->git_checkout_branch( 'remove/atlantis-legacy-modules', $output );
+				// Checkout the working branch for legacy module removal.
+				$this->git_checkout_branch( $this->working_branch, $output );
 
 				// Check for legacy modules and delete them if they exist.
 				$this->write_output( $output, '' );
@@ -647,9 +802,62 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 			}
 		}
 
+		// When --site-only was explicitly passed, check if Atlantis is already active.
+		// If not, install it (provided PHP version is sufficient).
+		if ( $this->skip_repository && $this->site_only_option ) {
+			$atlantis_active = $this->verify_atlantis_active( $output );
+
+			if ( $this->dry_run ) {
+				$this->write_output( $output, '<fg=yellow>[DRY RUN] Would ' . ( $atlantis_active ? 'uninstall legacy plugins' : 'install Atlantis and uninstall legacy plugins' ) . '</>' );
+				return Command::SUCCESS;
+			}
+
+			if ( $atlantis_active ) {
+				// Atlantis is already active — proceed directly to uninstalling legacy plugins.
+				$this->uninstall_plugins_from_wordpress( $output );
+				return Command::SUCCESS;
+			}
+
+			// Atlantis not active — install it.
+			$this->check_autoupdate_filter_status( $output );
+
+			$plugin_installed = $this->install_atlantis_plugin( $output );
+			if ( ! $plugin_installed ) {
+				$this->skip_note = 'Atlantis plugin installation failed (site has a critical error)';
+				return Command::FAILURE;
+			}
+
+			$this->uninstall_plugins_from_wordpress( $output );
+			return Command::SUCCESS;
+		}
+
 		// Check autoupdate filter status BEFORE installing Atlantis.
 		// This must happen first so the database option is set before Atlantis activates.
 		$this->check_autoupdate_filter_status( $output );
+
+		if ( $this->dry_run ) {
+			// In dry-run mode, report what would happen without making changes.
+			$this->write_output( $output, '' );
+			$this->write_output( $output, '<fg=yellow>[DRY RUN] Would install Atlantis plugin</>' );
+
+			if ( ! $this->skip_repository && ! empty( $found_modules ) ) {
+				foreach ( $found_modules as $plugin_name => $plugin_info ) {
+					$this->write_output( $output, "<fg=yellow>[DRY RUN] Would remove {$plugin_name} from {$plugin_info['location']}</>" );
+				}
+				$this->write_output( $output, "<fg=yellow>[DRY RUN] Would create PR to merge {$this->working_branch} into {$this->git_base_branch}</>" );
+			}
+
+			if ( $this->uninstall_plugins ) {
+				$this->write_output( $output, '<fg=yellow>[DRY RUN] Would uninstall legacy plugins from WordPress</>' );
+			}
+
+			// Clean up cloned repo.
+			if ( $this->repo_dir && $this->repos_dir && str_starts_with( $this->repo_dir, $this->repos_dir ) ) {
+				\run_system_command( array( 'rm', '-rf', $this->repo_dir ), $this->repo_dir, false );
+			}
+
+			return Command::SUCCESS;
+		}
 
 		// Always install the Atlantis plugin.
 		$plugin_installed = $this->install_atlantis_plugin( $output );
@@ -779,13 +987,14 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 			$wpcom_gh_repositories = get_wpcom_site_code_deployments( $this->site->ID );
 
 			if ( empty( $wpcom_gh_repositories ) ) {
-				// In CSV processing mode, throw exception instead of asking.
+				// In CSV processing mode, throw exception to trigger the "no deployment found"
+				// flow which offers manual repo entry, site-only, or skip options.
 				if ( $this->sites_csv_path ) {
-					throw new \Exception( 'Unable to find a WPCOM GitHub Deployments for the site.' );
+					throw new \Exception( 'Unable to find WPCOM GitHub Deployments for the site.' );
 				}
 
 				// In interactive mode, ask user.
-				$output->writeln( '<error>Unable to find a WPCOM GitHub Deployments for the site.</error>' );
+				$output->writeln( '<error>Unable to find WPCOM GitHub Deployments for the site.</error>' );
 				$question = new ConfirmationQuestion( '<question>Do you want to continue anyway? [y/N]</question> ', false );
 				if ( true !== $this->getHelper( 'question' )->ask( $input, $output, $question ) ) {
 					$output->writeln( '<comment>Command aborted by user.</comment>' );
@@ -971,8 +1180,13 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 			mkdir( $this->repo_dir, 0755, true );
 			$this->write_output( $output, "<info>Created folder: {$this->repo_dir}</info>" );
 
-			// Clone the repository.
-			\run_system_command( array( 'git', 'clone', $this->gh_repository->clone_url, $this->repo_dir ) );
+			// Shallow clone (depth 1) to save time on large repos, with no timeout.
+			// Use --no-single-branch so we can checkout the base branch later.
+			$clone_process = new \Symfony\Component\Process\Process(
+				array( 'git', 'clone', '--depth', '1', '--no-single-branch', $this->gh_repository->clone_url, $this->repo_dir )
+			);
+			$clone_process->setTimeout( null );
+			$clone_process->mustRun();
 			$this->write_output( $output, "<info>Cloned repository: {$this->gh_repository->name} ({$this->gh_repository->clone_url}) into {$this->repo_dir}</info>" );
 		}
 	}
@@ -1077,12 +1291,12 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 		// Push the branch with changes to remote.
 		// Use --force-with-lease to handle the case where the branch already exists from a previous run.
 		// This is safe because it's a temporary branch that will be deleted after merge.
-		\run_system_command( array( 'git', 'push', '--force-with-lease', '--set-upstream', 'origin', 'remove/atlantis-legacy-modules' ), $this->repo_dir, false );
-		$this->write_output( $output, "<info>Pushed branch 'remove/atlantis-legacy-modules' to remote.</info>" );
+		\run_system_command( array( 'git', 'push', '--force-with-lease', '--set-upstream', 'origin', $this->working_branch ), $this->repo_dir, false );
+		$this->write_output( $output, "<info>Pushed branch '{$this->working_branch}' to remote.</info>" );
 
-		// Create PR from remove/atlantis-legacy-modules to the base branch.
+		// Create PR from working branch to the base branch.
 		// Always show PR creation output, even in silent mode.
-		$this->write_output( $output, "<info>Creating PR to merge remove/atlantis-legacy-modules into {$this->git_base_branch}...</info>", OutputInterface::VERBOSITY_QUIET );
+		$this->write_output( $output, "<info>Creating PR to merge {$this->working_branch} into {$this->git_base_branch}...</info>", OutputInterface::VERBOSITY_QUIET );
 
 		// Try to create the PR. If it already exists, gh will output the existing PR URL.
 		$process = \run_system_command(
@@ -1093,11 +1307,11 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 				'--title',
 				'Atlantis Rollout - Remove legacy modules',
 				'--body',
-				'This PR was automatically generated by a script. Please review the changes and merge if they look good.',
+				"This PR was automatically generated by a script. Please review the changes and merge if they look good.\n\n@coderabbitai ignore",
 				'--base',
 				$this->git_base_branch,
 				'--head',
-				'remove/atlantis-legacy-modules',
+				$this->working_branch,
 				'--repo',
 				'a8cteam51/' . $this->gh_repository->name,
 			),
@@ -1140,7 +1354,7 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 					'gh',
 					'pr',
 					'merge',
-					'remove/atlantis-legacy-modules',
+					$this->working_branch,
 					'--squash',  // Squash all commits into one
 					'--auto',    // Auto-merge when requirements are met
 					'--delete-branch',  // Delete the branch after merge
@@ -1168,7 +1382,7 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 						'gh',
 						'pr',
 						'merge',
-						'remove/atlantis-legacy-modules',
+						$this->working_branch,
 						'--squash',
 						'--delete-branch',
 						'--repo',
@@ -1269,7 +1483,7 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 
 			// 2. Remove the submodule from git index.
 			$this->write_output( $output, '  2. Removing submodule from git index...' );
-			\run_system_command( array( 'git', 'rm', '-f', $submodule_path ), $this->repo_dir, false );
+			\run_system_command( array( 'git', 'rm', '-rf', $submodule_path ), $this->repo_dir, false );
 
 			// 3. Remove the submodule's .git directory.
 			$submodule_git_dir = $this->repo_dir . '/.git/modules/' . $submodule_path;
@@ -1296,7 +1510,7 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 	 * @return  bool True if plugin was installed and activated successfully, false otherwise.
 	 */
 	private function install_atlantis_plugin( OutputInterface $output ): bool {
-		$plugin_url      = 'https://github.com/a8cteam51/a8csp-atlantis/releases/download/v1.0.3/a8csp-atlantis.zip';
+		$plugin_url      = 'https://github.com/a8cteam51/a8csp-atlantis/releases/download/v1.0.9/a8csp-atlantis.zip';
 		$site_identifier = 'atomic' === $this->host ? $this->site->ID : $this->site->id;
 
 		$this->write_output( $output, '' );
@@ -1343,6 +1557,212 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 		} catch ( \Exception $e ) {
 			$this->write_output( $output, "  <error>Failed to install/activate Atlantis plugin: {$e->getMessage()}</error>" );
 			return false;
+		}
+	}
+
+	/**
+	 * Verifies that the Atlantis plugin is installed and active on the site.
+	 *
+	 * Used in --site-only mode to confirm Atlantis is present before
+	 * proceeding with legacy plugin cleanup.
+	 *
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  bool True if a8csp-atlantis is active, false otherwise.
+	 */
+	private function verify_atlantis_active( OutputInterface $output ): bool {
+		$site_identifier = 'atomic' === $this->host ? $this->site->ID : $this->site->id;
+
+		$this->write_output( $output, '' );
+		$this->write_output( $output, '<fg=cyan;options=bold>Verifying Atlantis plugin is active...</>' );
+
+		try {
+			$list_command = 'plugin list --format=json';
+
+			if ( 'pressable' === $this->host ) {
+				run_pressable_site_wp_cli_command( $site_identifier, $list_command, true );
+			} else {
+				run_wpcom_site_wp_cli_command( $site_identifier, $list_command, true );
+			}
+
+			if ( $this->wp_cli_output_has_errors() ) {
+				$this->write_output( $output, '  <error>Could not retrieve plugin list (site has a critical error).</error>' );
+				return false;
+			}
+
+			$wp_cli_output = $GLOBALS['wp_cli_output'] ?? '';
+			$plugins       = null;
+			if ( preg_match( '/\[.*\]/s', $wp_cli_output, $matches ) ) {
+				$plugins = json_decode( $matches[0], true );
+			}
+
+			if ( ! is_array( $plugins ) ) {
+				$this->write_output( $output, '  <error>Could not parse plugin list.</error>' );
+				return false;
+			}
+
+			$active_statuses = array( 'active', 'active-network', 'must-use' );
+			foreach ( $plugins as $plugin ) {
+				if ( isset( $plugin['name'] ) && 'a8csp-atlantis' === $plugin['name'] ) {
+					if ( in_array( $plugin['status'], $active_statuses, true ) ) {
+						$this->write_output( $output, "  <info>Atlantis is active (status: {$plugin['status']})</info>" );
+						return true;
+					}
+					$this->write_output( $output, "  <comment>Atlantis found but not active (status: {$plugin['status']})</comment>" );
+					return false;
+				}
+			}
+
+			$this->write_output( $output, '  <comment>Atlantis plugin not found on the site.</comment>' );
+			return false;
+		} catch ( \Exception $e ) {
+			$this->write_output( $output, "  <error>Failed to verify Atlantis status: {$e->getMessage()}</error>" );
+			return false;
+		}
+	}
+
+	/**
+	 * Verifies site health after changes by checking for PHP fatal errors and
+	 * exposed shortcodes on the front-end.
+	 *
+	 * Clears the site cache first, then:
+	 * 1. Runs `wp php-errors` to check for recent fatal errors.
+	 * 2. Fetches the front-end HTML and looks for unrendered shortcode tags
+	 *    (e.g. [team51-credits]) that indicate a missing shortcode handler.
+	 *
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  void
+	 */
+	private function verify_site_health( OutputInterface $output ): void {
+		$site_identifier = 'atomic' === $this->host ? $this->site->ID : $this->site->id;
+
+		$this->write_output( $output, '' );
+		$this->write_output( $output, '<fg=cyan;options=bold>Verifying site health...</>' );
+
+		// Clear caches before checking.
+		try {
+			$this->write_output( $output, '  Clearing object cache...' );
+			if ( 'pressable' === $this->host ) {
+				run_pressable_site_wp_cli_command( $site_identifier, 'cache flush', true );
+			} else {
+				run_wpcom_site_wp_cli_command( $site_identifier, 'cache flush', true );
+			}
+			$this->write_output( $output, '  <info>Object cache cleared</info>' );
+		} catch ( \Exception $e ) {
+			$this->write_output( $output, "  <comment>Object cache flush failed: {$e->getMessage()}</comment>" );
+		}
+
+		// Check 1: Exposed shortcodes on the front-end.
+		$shortcode_patterns = array(
+			'team51-credits',
+			'team51-tracking',
+			'colophon',
+		);
+
+		$has_exposed_shortcodes = false;
+		try {
+			$site_url = $this->site->url ?? '';
+			if ( ! empty( $site_url ) ) {
+				$this->write_output( $output, '  Checking front-end for exposed shortcodes...' );
+
+				// Ensure URL has a scheme.
+				if ( ! preg_match( '#^https?://#i', $site_url ) ) {
+					$site_url = 'https://' . $site_url;
+				}
+
+				// Add cache-busting query string to bypass edge cache.
+				$site_url = rtrim( $site_url, '/' ) . '/?nocache=' . time();
+
+				$context = stream_context_create(
+					array(
+						'http' => array(
+							'method'          => 'GET',
+							'timeout'         => 15,
+							'follow_location' => true,
+							'ignore_errors'   => true,
+							'header'          => 'User-Agent: Mozilla/5.0 (team51-cli health check)',
+						),
+						'ssl'  => array(
+							'verify_peer' => false,
+						),
+					)
+				);
+
+				$html = @file_get_contents( $site_url, false, $context );
+
+				if ( false !== $html ) {
+					foreach ( $shortcode_patterns as $shortcode ) {
+						// Match [shortcode] or [shortcode ...attributes].
+						if ( preg_match( '/\[' . preg_quote( $shortcode, '/' ) . '[\]\s]/i', $html ) ) {
+							$has_exposed_shortcodes = true;
+							$this->write_output( $output, "  <error>⚠ Exposed shortcode found: [{$shortcode}]</error>" );
+						}
+					}
+
+					if ( ! $has_exposed_shortcodes ) {
+						$this->write_output( $output, '  <info>No exposed shortcodes found on front-end</info>' );
+					}
+				} else {
+					$this->write_output( $output, '  <comment>Could not fetch front-end HTML</comment>' );
+				}
+			}
+		} catch ( \Exception $e ) {
+			$this->write_output( $output, "  <comment>Could not check front-end: {$e->getMessage()}</comment>" );
+		}
+
+		// Check 2: PHP fatal errors via wp php-errors.
+		$has_errors = false;
+		try {
+			$this->write_output( $output, '  Checking for PHP errors...' );
+
+			if ( 'pressable' === $this->host ) {
+				run_pressable_site_wp_cli_command( $site_identifier, 'php-errors', true );
+			} else {
+				run_wpcom_site_wp_cli_command( $site_identifier, 'php-errors', true );
+			}
+
+			$wp_cli_output = $GLOBALS['wp_cli_output'] ?? '';
+
+			// Only flag errors from today to avoid false positives from old log entries.
+			// Log format: [08-Apr-2026 12:34:56 UTC] PHP Fatal error: ...
+			$today_prefix = gmdate( 'd-M-Y' );
+			$lines        = array_filter( explode( "\n", $wp_cli_output ) );
+			$today_errors = array();
+
+			foreach ( $lines as $line ) {
+				if ( str_contains( $line, $today_prefix ) && preg_match( '/fatal|critical/i', $line ) ) {
+					$today_errors[] = $line;
+				}
+			}
+
+			if ( ! empty( $today_errors ) ) {
+				$has_errors  = true;
+				$error_count = count( $today_errors );
+				$this->write_output( $output, "  <error>⚠ {$error_count} PHP fatal/critical error(s) detected today:</error>" );
+				$count = 0;
+				foreach ( $today_errors as $line ) {
+					if ( $count < 5 ) {
+						$this->write_output( $output, "    <error>{$line}</error>" );
+						++$count;
+					}
+				}
+			} else {
+				$this->write_output( $output, '  <info>No PHP fatal errors detected today</info>' );
+			}
+		} catch ( \Exception $e ) {
+			$this->write_output( $output, "  <comment>Could not check PHP errors: {$e->getMessage()}</comment>" );
+		}
+
+		// Summary.
+		if ( $has_errors || $has_exposed_shortcodes ) {
+			$this->skip_note = ( $this->skip_note ? $this->skip_note . '; ' : '' ) . 'HEALTH CHECK WARNING:'
+				. ( $has_errors ? ' PHP fatal errors detected' : '' )
+				. ( $has_exposed_shortcodes ? ' Exposed shortcodes on front-end' : '' );
+			$this->write_output( $output, '' );
+			$this->write_output( $output, "<error>⚠ Site health check found issues — manual review recommended</error>" );
+		} else {
+			$this->write_output( $output, '  <info>✓ Site health check passed</info>' );
 		}
 	}
 
@@ -1399,7 +1819,7 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 			// Find any plugin-autoupdate-filter variants.
 			$autoupdate_plugins = array();
 			foreach ( $plugins as $plugin ) {
-				if ( isset( $plugin['name'] ) && str_starts_with( $plugin['name'], 'plugin-autoupdate-filter' ) ) {
+				if ( isset( $plugin['name'] ) && str_starts_with( strtolower( $plugin['name'] ), 'plugin-autoupdate-filter' ) ) {
 					$autoupdate_plugins[] = $plugin;
 				}
 			}
@@ -1422,18 +1842,22 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 
 			// If found but none are active, disable the Atlantis autoupdates module.
 			if ( ! $any_active ) {
-				$this->write_output( $output, '  <comment>Plugin found but not active. Disabling Atlantis autoupdates module...</comment>' );
-
-				// Use wp eval to set the option as an array directly (avoids shell escaping issues).
-				$option_command = 'eval "update_option( \'a8csp_module_autoupdates\', array( \'enabled\' => \'0\' ) );"';
-
-				if ( 'pressable' === $this->host ) {
-					run_pressable_site_wp_cli_command( $site_identifier, $option_command, $this->quiet );
+				if ( $this->dry_run ) {
+					$this->write_output( $output, '  <fg=yellow>[DRY RUN] Would disable Atlantis autoupdates module (plugin found but not active)</>' );
 				} else {
-					run_wpcom_site_wp_cli_command( $site_identifier, $option_command, $this->quiet );
-				}
+					$this->write_output( $output, '  <comment>Plugin found but not active. Disabling Atlantis autoupdates module...</comment>' );
 
-				$this->write_output( $output, '  <info>✓ Atlantis autoupdates module disabled</info>' );
+					// Use wp eval to set the option as an array directly (avoids shell escaping issues).
+					$option_command = 'eval "update_option( \'a8csp_module_autoupdates\', array( \'enabled\' => \'0\' ) );"';
+
+					if ( 'pressable' === $this->host ) {
+						run_pressable_site_wp_cli_command( $site_identifier, $option_command, $this->quiet );
+					} else {
+						run_wpcom_site_wp_cli_command( $site_identifier, $option_command, $this->quiet );
+					}
+
+					$this->write_output( $output, '  <info>✓ Atlantis autoupdates module disabled</info>' );
+				}
 			} else {
 				$this->write_output( $output, '  <info>Plugin is active, Atlantis autoupdates module will remain enabled.</info>' );
 			}
@@ -1444,7 +1868,11 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 	}
 
 	/**
-	 * Uninstalls all legacy plugins from WordPress in a single command.
+	 * Uninstalls all legacy plugins from WordPress.
+	 *
+	 * Discovers installed plugins by prefix-matching against the legacy module
+	 * slugs so that variants like "colophon-trunk", "colophon-1.2.1",
+	 * "plugin-autoupdate-filter-1", etc. are also caught.
 	 *
 	 * @param   OutputInterface $output The output object.
 	 *
@@ -1452,24 +1880,70 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 	 */
 	private function uninstall_plugins_from_wordpress( OutputInterface $output ): void {
 		$site_identifier = 'atomic' === $this->host ? $this->site->ID : $this->site->id;
-		$plugins_list    = implode( ' ', $this->legacy_modules );
 
 		$this->write_output( $output, '' );
 		$this->write_output( $output, '<fg=cyan;options=bold>Deactivating and uninstalling plugins from WordPress...</>' );
 
 		try {
-			// Run single command to deactivate and uninstall all plugins.
-			// The --uninstall flag will also deactivate if needed.
+			// Get the list of installed plugins to find variant slugs.
+			$list_command = 'plugin list --format=json';
+
+			if ( 'pressable' === $this->host ) {
+				run_pressable_site_wp_cli_command( $site_identifier, $list_command, true );
+			} else {
+				run_wpcom_site_wp_cli_command( $site_identifier, $list_command, true );
+			}
+
+			if ( $this->wp_cli_output_has_errors() ) {
+				$this->write_output( $output, '  <error>Plugin uninstall may have failed (site has a critical error).</error>' );
+				return;
+			}
+
+			$wp_cli_output = $GLOBALS['wp_cli_output'] ?? '';
+			$plugins       = null;
+			if ( preg_match( '/\[.*\]/s', $wp_cli_output, $matches ) ) {
+				$plugins = json_decode( $matches[0], true );
+			}
+
+			// Build the list of actual slugs to uninstall by prefix-matching.
+			$slugs_to_uninstall = array();
+
+			if ( is_array( $plugins ) ) {
+				foreach ( $plugins as $plugin ) {
+					if ( ! isset( $plugin['name'] ) ) {
+						continue;
+					}
+					$plugin_name_lower = strtolower( $plugin['name'] );
+					foreach ( $this->legacy_modules as $legacy_slug ) {
+						// Match exact slug or slug followed by a dash (variant suffix), case-insensitive.
+						if ( $plugin_name_lower === $legacy_slug || str_starts_with( $plugin_name_lower, $legacy_slug . '-' ) ) {
+							$slugs_to_uninstall[] = $plugin['name'];
+							break;
+						}
+					}
+				}
+			} else {
+				// Fallback to exact slugs if we can't parse the plugin list.
+				$this->write_output( $output, '  <comment>Could not parse plugin list, falling back to exact slugs.</comment>' );
+				$slugs_to_uninstall = $this->legacy_modules;
+			}
+
+			if ( empty( $slugs_to_uninstall ) ) {
+				$this->write_output( $output, '  <info>No legacy plugins found on the site to uninstall.</info>' );
+				return;
+			}
+
+			$plugins_list = implode( ' ', $slugs_to_uninstall );
+			$this->write_output( $output, "  Uninstalling: {$plugins_list}" );
+
 			$command = "plugin uninstall {$plugins_list} --deactivate";
 
-			// Skip output in silent mode.
 			if ( 'pressable' === $this->host ) {
 				run_pressable_site_wp_cli_command( $site_identifier, $command, $this->quiet );
 			} else {
 				run_wpcom_site_wp_cli_command( $site_identifier, $command, $this->quiet );
 			}
 
-			// Check for critical errors in WP-CLI output.
 			if ( $this->wp_cli_output_has_errors() ) {
 				$this->write_output( $output, '  <error>Plugin uninstall may have failed (site has a critical error).</error>' );
 				return;
@@ -1479,6 +1953,48 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 		} catch ( \Exception $e ) {
 			$this->write_output( $output, "  <error>Failed to uninstall plugins from WordPress: {$e->getMessage()}</error>" );
 			$this->write_output( $output, '  <comment>This is usually fine if the plugins were not installed on the site.</comment>' );
+		}
+	}
+
+	/**
+	 * Check if SSH access is available by running a simple WP-CLI command.
+	 *
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  bool True if SSH access works.
+	 */
+	private function check_ssh_access( OutputInterface $output ): bool {
+		$this->write_output( $output, '' );
+		$this->write_output( $output, '<fg=cyan;options=bold>Checking SSH access...</>' );
+
+		$site_identifier = 'atomic' === $this->host ? $this->site->ID : $this->site->id;
+
+		try {
+			$command = "eval 'echo \"ok\";'";
+
+			if ( 'pressable' === $this->host ) {
+				$result = run_pressable_site_wp_cli_command( $site_identifier, $command, true );
+			} else {
+				$result = run_wpcom_site_wp_cli_command( $site_identifier, $command, true );
+			}
+
+			$wp_cli_output = $GLOBALS['wp_cli_output'] ?? '';
+
+			if ( str_contains( $wp_cli_output, 'Fatal error:' ) || str_contains( $wp_cli_output, 'critical error on this website' ) ) {
+				$this->write_output( $output, '  <error>SSH connected but site has a fatal error</error>' );
+				return false;
+			}
+
+			if ( Command::SUCCESS === $result && str_contains( $wp_cli_output, 'ok' ) ) {
+				$this->write_output( $output, '  <info>SSH access verified</info>' );
+				return true;
+			}
+
+			$this->write_output( $output, '  <error>SSH access check failed</error>' );
+			return false;
+		} catch ( \Exception $e ) {
+			$this->write_output( $output, "  <error>SSH access check error: {$e->getMessage()}</error>" );
+			return false;
 		}
 	}
 
@@ -1559,7 +2075,7 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 		}
 
 		// Read header row.
-		$headers = fgetcsv( $handle );
+		$headers = fgetcsv( $handle, 0, ',', '"', '' );
 		if ( false === $headers ) {
 			fclose( $handle );
 			return $csv_data;
@@ -1567,7 +2083,7 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 
 		// Read data rows.
 		$row_index = 1; // Start at 1 (0 is header).
-		while ( ( $row = fgetcsv( $handle ) ) !== false ) {
+		while ( ( $row = fgetcsv( $handle, 0, ',', '"', '' ) ) !== false ) {
 			++$row_index;
 
 			// Skip empty rows.
@@ -1615,7 +2131,7 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 		}
 
 		// Read header to find column indices.
-		$headers = fgetcsv( $handle );
+		$headers = fgetcsv( $handle, 0, ',', '"', '' );
 		if ( false === $headers ) {
 			fclose( $handle );
 			return;
@@ -1636,7 +2152,7 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 		$rows[] = $headers; // Add header row.
 
 		$current_row = 1; // Start at 1 (header is row 0).
-		while ( ( $row = fgetcsv( $handle ) ) !== false ) {
+		while ( ( $row = fgetcsv( $handle, 0, ',', '"', '' ) ) !== false ) {
 			++$current_row;
 
 			// Update the target row.
@@ -1683,7 +2199,71 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 		}
 
 		foreach ( $rows as $row ) {
-			fputcsv( $handle, $row );
+			fputcsv( $handle, $row, ',', '"', '' );
+		}
+
+		fclose( $handle );
+	}
+
+	/**
+	 * Append a note to an existing CSV row without changing PR or Merged columns.
+	 *
+	 * @param   int    $row_index The row index to update.
+	 * @param   string $note      The note to append.
+	 *
+	 * @return  void
+	 */
+	private function append_csv_note( int $row_index, string $note ): void {
+		if ( ! $this->sites_csv_path || ! file_exists( $this->sites_csv_path ) ) {
+			return;
+		}
+
+		$rows   = array();
+		$handle = fopen( $this->sites_csv_path, 'r' );
+		if ( false === $handle ) {
+			return;
+		}
+
+		$headers = fgetcsv( $handle, 0, ',', '"', '' );
+		if ( false === $headers ) {
+			fclose( $handle );
+			return;
+		}
+
+		$notes_index = array_search( 'Notes', $headers, true );
+		if ( false === $notes_index ) {
+			$headers[]   = 'Notes';
+			$notes_index = count( $headers ) - 1;
+		}
+
+		$rows[] = $headers;
+
+		$current_row = 1;
+		while ( ( $row = fgetcsv( $handle, 0, ',', '"', '' ) ) !== false ) {
+			++$current_row;
+
+			// Ensure row has enough columns.
+			while ( count( $row ) < count( $headers ) ) {
+				$row[] = '';
+			}
+
+			if ( $current_row === $row_index ) {
+				$existing = trim( $row[ $notes_index ] ?? '' );
+				$row[ $notes_index ] = $existing ? $existing . '; ' . $note : $note;
+			}
+
+			$rows[] = $row;
+		}
+
+		fclose( $handle );
+
+		$handle = fopen( $this->sites_csv_path, 'w' );
+		if ( false === $handle ) {
+			return;
+		}
+
+		foreach ( $rows as $row ) {
+			fputcsv( $handle, $row, ',', '"', '' );
 		}
 
 		fclose( $handle );
@@ -1723,10 +2303,11 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 		$this->repo_dir             = null;
 		$this->removed_modules      = array();
 		$this->git_base_branch      = 'develop';
+		$this->working_branch       = 'remove/atlantis-legacy-modules-develop';
 		$this->php_version          = null;
 		$this->skip_note            = null;
 		$this->csv_url              = null;
-		$this->skip_repository      = false;
+		$this->skip_repository      = $this->site_only_option;
 		$this->deployment_not_found = false;
 	}
 

--- a/commands/Site_Remove_Atlantis_Legacy_Modules.php
+++ b/commands/Site_Remove_Atlantis_Legacy_Modules.php
@@ -547,8 +547,10 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 					}
 					++$processed;
 				} else {
+					$note = $this->skip_note ?? 'Processing failed';
+					$this->update_csv_row( $index, '', '', $note );
 					++$failed;
-					$output->writeln( "<error>✗ {$site_name} failed</error>" );
+					$output->writeln( "<error>✗ {$site_name} failed: {$note}</error>" );
 				}
 			} catch ( \Exception $e ) {
 				$note = 'Error: ' . $e->getMessage();
@@ -651,6 +653,11 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 
 		// Always install the Atlantis plugin.
 		$plugin_installed = $this->install_atlantis_plugin( $output );
+
+		if ( ! $plugin_installed ) {
+			$this->skip_note = 'Atlantis plugin installation failed (site has a critical error)';
+			return Command::FAILURE;
+		}
 
 		if ( ! $this->skip_repository && $plugin_installed && ! empty( $found_modules ) ) {
 			// Delete the found modules from the repository.
@@ -1289,7 +1296,7 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 	 * @return  bool True if plugin was installed and activated successfully, false otherwise.
 	 */
 	private function install_atlantis_plugin( OutputInterface $output ): bool {
-		$plugin_url      = 'https://github.com/a8cteam51/a8csp-atlantis/releases/download/v1.0.2/a8csp-atlantis.zip';
+		$plugin_url      = 'https://github.com/a8cteam51/a8csp-atlantis/releases/download/v1.0.3/a8csp-atlantis.zip';
 		$site_identifier = 'atomic' === $this->host ? $this->site->ID : $this->site->id;
 
 		$this->write_output( $output, '' );
@@ -1306,9 +1313,9 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 				$install_result = run_wpcom_site_wp_cli_command( $site_identifier, $install_command, $this->quiet );
 			}
 
-			// Check if installation was successful.
-			if ( Command::SUCCESS !== $install_result ) {
-				$this->write_output( $output, '  <error>Plugin installation failed.</error>' );
+			// Check if installation was successful (check both return code and WP-CLI output).
+			if ( Command::SUCCESS !== $install_result || $this->wp_cli_output_has_errors() ) {
+				$this->write_output( $output, '  <error>Plugin installation failed (site has a critical error).</error>' );
 				return false;
 			}
 
@@ -1324,9 +1331,9 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 				$activate_result = run_wpcom_site_wp_cli_command( $site_identifier, $activate_command, $this->quiet );
 			}
 
-			// Check if activation was successful.
-			if ( Command::SUCCESS !== $activate_result ) {
-				$this->write_output( $output, '  <error>Plugin activation failed.</error>' );
+			// Check if activation was successful (check both return code and WP-CLI output).
+			if ( Command::SUCCESS !== $activate_result || $this->wp_cli_output_has_errors() ) {
+				$this->write_output( $output, '  <error>Plugin activation failed (site has a critical error).</error>' );
 				return false;
 			}
 
@@ -1367,6 +1374,12 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 				run_pressable_site_wp_cli_command( $site_identifier, $list_command, true );
 			} else {
 				run_wpcom_site_wp_cli_command( $site_identifier, $list_command, true );
+			}
+
+			// Check for critical errors in WP-CLI output before parsing.
+			if ( $this->wp_cli_output_has_errors() ) {
+				$this->write_output( $output, '  <comment>Could not parse plugin list (site has a critical error).</comment>' );
+				return;
 			}
 
 			// Get the output from the global variable.
@@ -1454,6 +1467,12 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 				run_pressable_site_wp_cli_command( $site_identifier, $command, $this->quiet );
 			} else {
 				run_wpcom_site_wp_cli_command( $site_identifier, $command, $this->quiet );
+			}
+
+			// Check for critical errors in WP-CLI output.
+			if ( $this->wp_cli_output_has_errors() ) {
+				$this->write_output( $output, '  <error>Plugin uninstall may have failed (site has a critical error).</error>' );
+				return;
 			}
 
 			$this->write_output( $output, '  <info>✓ Plugins deactivated and uninstalled from WordPress</info>' );
@@ -1668,6 +1687,27 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 		}
 
 		fclose( $handle );
+	}
+
+	/**
+	 * Checks whether the last WP-CLI command output contains fatal/critical error indicators.
+	 *
+	 * The underlying WP-CLI command runners always return Command::SUCCESS as long as
+	 * the SSH connection succeeds, even when WP-CLI itself encounters a fatal PHP error.
+	 * This method inspects the captured output to detect such failures.
+	 *
+	 * @return  bool True if the output contains error indicators, false otherwise.
+	 */
+	private function wp_cli_output_has_errors(): bool {
+		$wp_cli_output = $GLOBALS['wp_cli_output'] ?? '';
+
+		if ( empty( $wp_cli_output ) ) {
+			return false;
+		}
+
+		// Check for common WP-CLI / PHP fatal error patterns.
+		return str_contains( $wp_cli_output, 'Fatal error:' )
+			|| str_contains( $wp_cli_output, 'critical error on this website' );
 	}
 
 	/**

--- a/commands/Site_Remove_Atlantis_Legacy_Modules.php
+++ b/commands/Site_Remove_Atlantis_Legacy_Modules.php
@@ -44,6 +44,12 @@ use WPCOMSpecialProjects\CLI\Helper\AutocompleteTrait;
  *   # Dry run: check all sites without making any changes
  *   team51 site:remove-atlantis-legacy-modules --sites=atlantis-sites.csv --dry-run
  *
+ *   # Repo-only mode: process repositories without any site operations (creates PRs only, no merge)
+ *   team51 site:remove-atlantis-legacy-modules --repos=repos-to-process.csv
+ *
+ *   # Repo-only dry run
+ *   team51 site:remove-atlantis-legacy-modules --repos=repos-to-process.csv --dry-run
+ *
  *
  * CSV File Format:
  *   The CSV file should have the following columns: Site, URL, Host, Merged, PR, Notes
@@ -199,6 +205,13 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 	private ?string $sites_csv_path = null;
 
 	/**
+	 * Path to the CSV file with repositories to process (repo-only mode).
+	 *
+	 * @var string|null
+	 */
+	private ?string $repos_csv_path = null;
+
+	/**
 	 * The URL of the created PR (captured during execution).
 	 *
 	 * @var string|null
@@ -252,13 +265,30 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 			->addOption( 'uninstall', null, InputOption::VALUE_NONE, 'Uninstall plugins from WordPress in addition to removing them from the repository.' )
 			->addOption( 'sites', null, InputOption::VALUE_REQUIRED, 'Path to a CSV file containing sites to process (Site,URL,Host,Merged,PR).' )
 			->addOption( 'site-only', null, InputOption::VALUE_NONE, 'Skip repository operations; only verify Atlantis is active and uninstall legacy plugins from WordPress.' )
-			->addOption( 'dry-run', null, InputOption::VALUE_NONE, 'Run all checks without making any changes (no plugin install/uninstall, no repo modifications, no CSV updates).' );
+			->addOption( 'dry-run', null, InputOption::VALUE_NONE, 'Run all checks without making any changes (no plugin install/uninstall, no repo modifications, no CSV updates).' )
+			->addOption( 'repos', null, InputOption::VALUE_REQUIRED, 'Path to a CSV file of repositories to process (repo-only mode, no site operations). Format: Repository,Branch,PR,Notes' );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
 	protected function initialize( InputInterface $input, OutputInterface $output ): void {
+		// Check if processing repositories from CSV (repo-only mode).
+		$this->repos_csv_path = $input->getOption( 'repos' );
+
+		if ( $this->repos_csv_path ) {
+			$this->quiet   = (bool) $input->getOption( 'no-output' );
+			$this->dry_run = (bool) $input->getOption( 'dry-run' );
+
+			if ( ! file_exists( $this->repos_csv_path ) ) {
+				$output->writeln( "<error>CSV file not found: {$this->repos_csv_path}</error>" );
+				exit( 1 );
+			}
+
+			// Skip individual site initialization.
+			return;
+		}
+
 		// Check if processing multiple sites from CSV.
 		$this->sites_csv_path = $input->getOption( 'sites' );
 
@@ -361,8 +391,8 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 	 * {@inheritDoc}
 	 */
 	protected function interact( InputInterface $input, OutputInterface $output ): void {
-		// Skip interaction if quiet mode is enabled or processing CSV.
-		if ( $this->quiet || $this->sites_csv_path ) {
+		// Skip interaction if quiet mode is enabled or processing CSV/repos.
+		if ( $this->quiet || $this->sites_csv_path || $this->repos_csv_path ) {
 			return;
 		}
 
@@ -384,6 +414,11 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 		if ( $this->dry_run ) {
 			$output->writeln( '<fg=yellow;options=bold>--- DRY RUN MODE: No changes will be made ---</>' );
 			$output->writeln( '' );
+		}
+
+		// If repos CSV provided, process repositories only.
+		if ( $this->repos_csv_path ) {
+			return $this->process_repos_csv( $input, $output );
 		}
 
 		// If CSV file provided, process multiple sites.
@@ -721,6 +756,343 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 		}
 
 		return Command::SUCCESS;
+	}
+
+	/**
+	 * Process repositories from a CSV file (repo-only mode).
+	 *
+	 * Performs only repository operations: clone, remove legacy modules, create PR.
+	 * No site operations (no SSH, no plugin install/uninstall).
+	 *
+	 * CSV format: Repository,Branch,PR,Notes
+	 *   Repository: GitHub repo name (e.g. "my-site-repo")
+	 *   Branch: Base branch to target (e.g. "trunk", "master", "main"). Defaults to "trunk".
+	 *   PR: Left empty, populated by the script with the PR URL.
+	 *   Notes: Left empty, populated by the script.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  int
+	 */
+	private function process_repos_csv( InputInterface $input, OutputInterface $output ): int {
+		$output->writeln( '<fg=magenta;options=bold>Processing repositories from CSV (repo-only mode)...</>' );
+		$output->writeln( '' );
+
+		// Read CSV.
+		$handle = fopen( $this->repos_csv_path, 'r' );
+		if ( false === $handle ) {
+			$output->writeln( '<error>Could not open CSV file.</error>' );
+			return Command::FAILURE;
+		}
+
+		$headers = fgetcsv( $handle, 0, ',', '"', '' );
+		if ( false === $headers ) {
+			fclose( $handle );
+			$output->writeln( '<error>Could not read CSV headers.</error>' );
+			return Command::FAILURE;
+		}
+
+		// Normalize headers.
+		$headers = array_map( 'trim', $headers );
+
+		// Find column indices.
+		$repo_col   = array_search( 'Repository', $headers, true );
+		$branch_col = array_search( 'Branch', $headers, true );
+
+		if ( false === $repo_col ) {
+			fclose( $handle );
+			$output->writeln( '<error>CSV is missing required "Repository" column.</error>' );
+			return Command::FAILURE;
+		}
+
+		// Read all rows.
+		$csv_data = array();
+		$row_idx  = 1;
+		while ( ( $row = fgetcsv( $handle, 0, ',', '"', '' ) ) !== false ) {
+			++$row_idx;
+			if ( empty( array_filter( $row ) ) ) {
+				continue;
+			}
+			// Pad row to match headers.
+			while ( count( $row ) < count( $headers ) ) {
+				$row[] = '';
+			}
+			$csv_data[ $row_idx ] = array_combine( $headers, $row );
+		}
+		fclose( $handle );
+
+		if ( empty( $csv_data ) ) {
+			$output->writeln( '<error>No repositories found in CSV.</error>' );
+			return Command::FAILURE;
+		}
+
+		$total     = count( $csv_data );
+		$processed = 0;
+		$skipped   = 0;
+		$failed    = 0;
+		$counter   = 0;
+
+		foreach ( $csv_data as $index => $row_data ) {
+			++$counter;
+			$repo_name = trim( $row_data['Repository'] ?? '' );
+			$base_branch = trim( $row_data['Branch'] ?? 'trunk' );
+
+			if ( empty( $repo_name ) ) {
+				$output->writeln( "<comment>[{$counter}/{$total}] Skipping empty repository name</comment>" );
+				++$skipped;
+				continue;
+			}
+
+			// Skip if already processed (has PR URL).
+			if ( ! empty( $row_data['PR'] ?? '' ) ) {
+				$output->writeln( "<comment>[{$counter}/{$total}] Skipping {$repo_name} - already has PR</comment>" );
+				++$skipped;
+				continue;
+			}
+
+			$output->writeln( "<info>[{$counter}/{$total}] Processing repository: {$repo_name} (branch: {$base_branch})</info>" );
+
+			try {
+				// Look up the GitHub repository.
+				$this->gh_repository = get_github_repository( $repo_name );
+				if ( ! $this->gh_repository || ! $this->gh_repository->name ) {
+					$note = "Repository not found: {$repo_name}";
+					$this->update_repos_csv_row( $index, '', $note );
+					$output->writeln( "<error>✗ {$repo_name}: {$note}</error>" );
+					++$failed;
+					continue;
+				}
+
+				// Set up branches.
+				$this->git_base_branch = $base_branch;
+				$this->working_branch  = 'remove/atlantis-legacy-modules-' . $base_branch;
+
+				// Set up paths.
+				$this->repos_dir = getcwd() . '/repos';
+				$this->repo_dir  = $this->repos_dir . '/' . $this->gh_repository->name;
+				$this->pr_url    = null;
+				$this->removed_modules = array();
+
+				// Clone.
+				$this->clone_repo( $output );
+
+				// Checkout base branch.
+				$checkout_process = new \Symfony\Component\Process\Process(
+					array( 'git', 'checkout', $this->git_base_branch ),
+					$this->repo_dir
+				);
+				$checkout_process->run();
+				if ( ! $checkout_process->isSuccessful() ) {
+					// Clean up.
+					if ( $this->repo_dir && $this->repos_dir && str_starts_with( $this->repo_dir, $this->repos_dir ) ) {
+						\run_system_command( array( 'rm', '-rf', $this->repo_dir ), $this->repo_dir, false );
+					}
+					$note = "Branch '{$this->git_base_branch}' not found";
+					$this->update_repos_csv_row( $index, '', $note );
+					$output->writeln( "<error>✗ {$repo_name}: {$note}</error>" );
+					++$failed;
+					continue;
+				}
+
+				// Checkout working branch.
+				$this->git_checkout_branch( $this->working_branch, $output );
+
+				// Search for legacy modules.
+				$output->writeln( '<fg=cyan;options=bold>Searching for legacy modules to remove...</>' );
+				$found_modules = array();
+				foreach ( $this->legacy_modules as $plugin_name ) {
+					$plugin_info = $this->find_plugin( $plugin_name, $output );
+					if ( null !== $plugin_info ) {
+						$found_modules[ $plugin_name ] = $plugin_info;
+					}
+				}
+
+				if ( $this->dry_run ) {
+					if ( ! empty( $found_modules ) ) {
+						foreach ( $found_modules as $plugin_name => $plugin_info ) {
+							$output->writeln( "<fg=yellow>[DRY RUN] Would remove {$plugin_name} from {$plugin_info['location']}</>" );
+						}
+						$output->writeln( "<fg=yellow>[DRY RUN] Would create PR to merge {$this->working_branch} into {$this->git_base_branch}</>" );
+					} else {
+						$output->writeln( '<fg=yellow>[DRY RUN] No legacy modules found in repository</>' );
+					}
+					// Clean up cloned repo.
+					if ( $this->repo_dir && $this->repos_dir && str_starts_with( $this->repo_dir, $this->repos_dir ) ) {
+						\run_system_command( array( 'rm', '-rf', $this->repo_dir ), $this->repo_dir, false );
+					}
+					$output->writeln( "<fg=yellow>✓ {$repo_name} dry run complete</>" );
+					++$processed;
+					continue;
+				}
+
+				if ( empty( $found_modules ) ) {
+					// Clean up.
+					if ( $this->repo_dir && $this->repos_dir && str_starts_with( $this->repo_dir, $this->repos_dir ) ) {
+						\run_system_command( array( 'rm', '-rf', $this->repo_dir ), $this->repo_dir, false );
+					}
+					$this->update_repos_csv_row( $index, '', 'No legacy modules found' );
+					$output->writeln( "<info>✓ {$repo_name}: No legacy modules found</info>" );
+					++$processed;
+					continue;
+				}
+
+				// Delete found modules.
+				foreach ( $found_modules as $plugin_name => $plugin_info ) {
+					$this->delete_plugin( $plugin_name, $plugin_info['location'], $plugin_info['path'], $output );
+				}
+
+				// Stage, commit, push, create PR (no merge in repo-only mode).
+				if ( count( $this->removed_modules ) > 0 ) {
+					// Stage and commit.
+					\run_system_command( array( 'git', 'add', '.' ), $this->repo_dir, false );
+					$output->writeln( '<info>Staged file changes.</info>' );
+
+					\run_system_command( array( 'git', 'commit', '-m', 'Remove legacy modules' ), $this->repo_dir, false );
+					$output->writeln( '<info>Committed file changes.</info>' );
+
+					// Push.
+					\run_system_command( array( 'git', 'push', '--force-with-lease', '--set-upstream', 'origin', $this->working_branch ), $this->repo_dir, false );
+					$output->writeln( "<info>Pushed branch '{$this->working_branch}' to remote.</info>" );
+
+					// Create PR (no merge).
+					$process = \run_system_command(
+						array(
+							'gh',
+							'pr',
+							'create',
+							'--title',
+							'Atlantis Rollout - Remove legacy modules',
+							'--body',
+							"This PR was automatically generated by a script. Please review the changes and merge if they look good.\n\n@coderabbitai ignore",
+							'--base',
+							$this->git_base_branch,
+							'--head',
+							$this->working_branch,
+							'--repo',
+							'a8cteam51/' . $this->gh_repository->name,
+						),
+						$this->repo_dir,
+						false
+					);
+
+					$pr_output = trim( $process->getOutput() . $process->getErrorOutput() );
+					if ( ! empty( $pr_output ) ) {
+						$output->writeln( $pr_output );
+						if ( preg_match( '#https://github\.com/[^/]+/[^/]+/pull/\d+#', $pr_output, $matches ) ) {
+							$this->pr_url = $matches[0];
+						}
+					}
+
+					$this->update_repos_csv_row( $index, $this->pr_url ?? '', '' );
+					$output->writeln( "<info>✓ {$repo_name} PR created</info>" );
+				} else {
+					$this->update_repos_csv_row( $index, '', 'Modules found but removal failed' );
+					$output->writeln( "<comment>⚠ {$repo_name}: Modules found but removal failed</comment>" );
+				}
+
+				// Clean up cloned repo.
+				if ( $this->repo_dir && $this->repos_dir && str_starts_with( $this->repo_dir, $this->repos_dir ) ) {
+					\run_system_command( array( 'rm', '-rf', $this->repo_dir ), $this->repo_dir, false );
+					$output->writeln( "<info>Deleted repository folder: {$this->repo_dir}</info>" );
+				}
+
+				++$processed;
+			} catch ( \Exception $e ) {
+				$this->update_repos_csv_row( $index, '', 'Error: ' . $e->getMessage() );
+				++$failed;
+				$output->writeln( "<error>✗ {$repo_name}: {$e->getMessage()}</error>" );
+			}
+
+			$output->writeln( '' );
+		}
+
+		// Summary.
+		$output->writeln( '' );
+		$output->writeln( '<fg=cyan;options=bold>=== Repository Processing Summary ===' );
+		$output->writeln( "<info>Total repositories: {$total}</info>" );
+		$output->writeln( "<info>Processed: {$processed}</info>" );
+		$output->writeln( "<comment>Skipped: {$skipped}</comment>" );
+		if ( $failed > 0 ) {
+			$output->writeln( "<error>Failed: {$failed}</error>" );
+		}
+
+		return Command::SUCCESS;
+	}
+
+	/**
+	 * Update a row in the repos CSV file.
+	 *
+	 * @param   int    $row_index The row index to update.
+	 * @param   string $pr_url    The PR URL.
+	 * @param   string $note      Optional note.
+	 *
+	 * @return  void
+	 */
+	private function update_repos_csv_row( int $row_index, string $pr_url, string $note ): void {
+		if ( ! $this->repos_csv_path || ! file_exists( $this->repos_csv_path ) ) {
+			return;
+		}
+
+		$rows   = array();
+		$handle = fopen( $this->repos_csv_path, 'r' );
+		if ( false === $handle ) {
+			return;
+		}
+
+		$headers = fgetcsv( $handle, 0, ',', '"', '' );
+		if ( false === $headers ) {
+			fclose( $handle );
+			return;
+		}
+
+		$pr_index    = array_search( 'PR', $headers, true );
+		$notes_index = array_search( 'Notes', $headers, true );
+
+		// Add missing columns if needed.
+		if ( false === $pr_index ) {
+			$headers[]  = 'PR';
+			$pr_index   = count( $headers ) - 1;
+		}
+		if ( false === $notes_index ) {
+			$headers[]   = 'Notes';
+			$notes_index = count( $headers ) - 1;
+		}
+
+		$rows[] = $headers;
+
+		$current_row = 1;
+		while ( ( $row = fgetcsv( $handle, 0, ',', '"', '' ) ) !== false ) {
+			++$current_row;
+
+			while ( count( $row ) < count( $headers ) ) {
+				$row[] = '';
+			}
+
+			if ( $current_row === $row_index ) {
+				if ( false !== $pr_index && ! empty( $pr_url ) ) {
+					$row[ $pr_index ] = $pr_url;
+				}
+				if ( false !== $notes_index && ! empty( $note ) ) {
+					$row[ $notes_index ] = $note;
+				}
+			}
+
+			$rows[] = $row;
+		}
+
+		fclose( $handle );
+
+		$handle = fopen( $this->repos_csv_path, 'w' );
+		if ( false === $handle ) {
+			return;
+		}
+
+		foreach ( $rows as $row ) {
+			fputcsv( $handle, $row, ',', '"', '' );
+		}
+
+		fclose( $handle );
 	}
 
 	/**

--- a/commands/Site_Remove_Atlantis_Legacy_Modules.php
+++ b/commands/Site_Remove_Atlantis_Legacy_Modules.php
@@ -144,6 +144,21 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 	private bool $uninstall_plugins = false;
 
 	/**
+	 * Whether to skip repository operations and only perform site operations.
+	 *
+	 * @var bool
+	 */
+	private bool $skip_repository = false;
+
+	/**
+	 * Whether the current site had no deployment found (used to gracefully
+	 * fall back to site-only if branch checkout fails for a manually entered repo).
+	 *
+	 * @var bool
+	 */
+	private bool $deployment_not_found = false;
+
+	/**
 	 * Path to the CSV file with sites to process.
 	 *
 	 * @var string|null
@@ -431,41 +446,74 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 						|| str_contains( $e->getMessage(), 'GitHub repository' )
 						|| str_contains( $e->getMessage(), 'DeployHQ' );
 
-					if ( $is_deployment_error ) {
-						$deployment_type = ( 'pressable' === $site_host ) ? 'DeployHQ' : 'WPCOM GitHub';
-						$note            = "Unable to find a {$deployment_type} deployment for the site";
+					if ( ! $is_deployment_error ) {
+						// Re-throw if it's a different error.
+						throw $e;
+					}
+
+					$deployment_type = ( 'pressable' === $host ) ? 'DeployHQ' : 'WPCOM GitHub';
+					$output->writeln( "<comment>⚠ {$site_name}: Unable to find a {$deployment_type} deployment for the site.</comment>" );
+
+					// Present the user with choices for how to proceed.
+					$choices = array(
+						'enter_repo' => 'Enter a repository URL or slug manually',
+						'site_only'  => 'Skip repository, process site only (install Atlantis, handle plugins)',
+						'skip'       => 'Skip this site entirely',
+					);
+
+					$question          = new ChoiceQuestion( '<question>How would you like to proceed?</question> ', $choices, 'skip' );
+					$deployment_choice = $this->getHelper( 'question' )->ask( $input, $output, $question );
+
+					if ( 'skip' === $deployment_choice ) {
+						$note = "No {$deployment_type} deployment for the site - skipped by user";
 						$this->update_csv_row( $index, '', '', $note );
 						$output->writeln( "<comment>⚠ {$site_name}: {$note}</comment>" );
 						++$skipped;
 						continue;
 					}
-					// Re-throw if it's a different error.
-					throw $e;
+
+					$this->deployment_not_found = true;
+
+					if ( 'enter_repo' === $deployment_choice ) {
+						$repo = $this->prompt_and_resolve_repository( $input, $output );
+						if ( null === $repo ) {
+							$note = "No {$deployment_type} deployment - manual repo entry failed";
+							$this->update_csv_row( $index, '', '', $note );
+							$output->writeln( "<comment>⚠ {$site_name}: {$note}</comment>" );
+							++$skipped;
+							continue;
+						}
+						$this->gh_repository = $repo;
+					} elseif ( 'site_only' === $deployment_choice ) {
+						$this->skip_repository = true;
+					}
 				}
 
-				$this->initialize_paths_and_branch( $input );
+				if ( ! $this->skip_repository ) {
+					$this->initialize_paths_and_branch( $input );
 
-				// Determine environment and base branch.
-				$environment = $this->get_site_environment( $output );
-				if ( 'production' === $environment ) {
-					$this->git_base_branch = 'trunk';
-				}
+					// Determine environment and base branch.
+					$environment = $this->get_site_environment( $output );
+					if ( 'production' === $environment ) {
+						$this->git_base_branch = 'trunk';
+					}
 
-				// Safety check: If CSV URL indicates staging, never use trunk/master.
-				// This prevents accidentally processing production when staging was intended.
-				$csv_url_lower  = strtolower( $site_url );
-				$is_staging_url = str_contains( $csv_url_lower, 'staging' ) ||
-					str_contains( $csv_url_lower, 'mystagingwebsite' ) ||
-					str_contains( $csv_url_lower, 'wpcomstaging' ) ||
-					str_contains( $csv_url_lower, '-dev' ) ||
-					str_contains( $csv_url_lower, '-development' );
+					// Safety check: If CSV URL indicates staging, never use trunk/master.
+					// This prevents accidentally processing production when staging was intended.
+					$csv_url_lower  = strtolower( $site_url );
+					$is_staging_url = str_contains( $csv_url_lower, 'staging' ) ||
+						str_contains( $csv_url_lower, 'mystagingwebsite' ) ||
+						str_contains( $csv_url_lower, 'wpcomstaging' ) ||
+						str_contains( $csv_url_lower, '-dev' ) ||
+						str_contains( $csv_url_lower, '-development' );
 
-				if ( $is_staging_url && in_array( $this->git_base_branch, array( 'trunk', 'master' ), true ) ) {
-					$note = "Staging URL but would use {$this->git_base_branch} branch - skipping for safety";
-					$this->update_csv_row( $index, '', '', $note );
-					$output->writeln( "<error>⚠ {$site_name}: {$note}</error>" );
-					++$skipped;
-					continue;
+					if ( $is_staging_url && in_array( $this->git_base_branch, array( 'trunk', 'master' ), true ) ) {
+						$note = "Staging URL but would use {$this->git_base_branch} branch - skipping for safety";
+						$this->update_csv_row( $index, '', '', $note );
+						$output->writeln( "<error>⚠ {$site_name}: {$note}</error>" );
+						++$skipped;
+						continue;
+					}
 				}
 
 				// Process the site.
@@ -478,7 +526,14 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 					$output->writeln( "<comment>⚠ {$site_name}: {$note}</comment>" );
 					++$skipped;
 				} elseif ( Command::SUCCESS === $result ) {
-					if ( $this->pr_url ) {
+					if ( $this->skip_repository ) {
+						// Site-only processing: Atlantis installed and plugins handled, no repo operations.
+						$note = $this->skip_note
+							? "Site-only: Atlantis installed, {$this->skip_note}"
+							: 'Site-only: Atlantis installed, no deployment found (repo skipped)';
+						$this->update_csv_row( $index, '', 'Y', $note );
+						$output->writeln( "<info>✓ {$site_name} completed (site-only, no repository)</info>" );
+					} elseif ( $this->pr_url ) {
 						// Update CSV with PR URL and Merged status.
 						// Mark as 'Y' only if --merge-pr was used.
 						$merged_status = $this->merge_pr ? 'Y' : '';
@@ -527,10 +582,19 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 	 * @return  int
 	 */
 	private function process_single_site( InputInterface $input, OutputInterface $output ): int {
-		$this->write_output( $output, "<fg=magenta;options=bold>Processing repository for site {$this->site->url} (base branch: {$this->git_base_branch}).</>" );
+		if ( $this->skip_repository ) {
+			$this->write_output( $output, "<fg=magenta;options=bold>Processing site-only operations for {$this->site->url} (no repository).</>" );
+		} else {
+			$this->write_output( $output, "<fg=magenta;options=bold>Processing repository for site {$this->site->url} (base branch: {$this->git_base_branch}).</>" );
+		}
 
 		// Check PHP version first - Atlantis plugin requires PHP 8.3+.
 		$this->check_php_version( $output );
+		if ( null === $this->php_version ) {
+			$this->skip_note = 'Unable to connect to site (SSH may be disabled)';
+			$this->write_output( $output, "<error>{$this->skip_note}. Skipping site.</error>" );
+			return Command::INVALID;
+		}
 		if ( ! $this->meets_php_requirement() ) {
 			$this->skip_note = "PHP version {$this->php_version} < {$this->min_php_version} required";
 			$this->write_output( $output, "<error>{$this->skip_note}. Skipping Atlantis plugin installation.</error>" );
@@ -538,34 +602,46 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 			return Command::INVALID;
 		}
 
-		$this->clone_repo( $output );
-
-		// Checkout the base branch - handle failure gracefully.
-		$checkout_process = \run_system_command( array( 'git', 'checkout', $this->git_base_branch ), $this->repo_dir, false );
-		if ( ! $checkout_process->isSuccessful() ) {
-			$this->skip_note = "Branch '{$this->git_base_branch}' not found";
-			$this->write_output( $output, "<error>{$this->skip_note}. Skipping site.</error>" );
-			// Clean up the cloned repo folder.
-			if ( $this->repo_dir && $this->repos_dir && str_starts_with( $this->repo_dir, $this->repos_dir ) ) {
-				\run_system_command( array( 'rm', '-rf', $this->repo_dir ), $this->repo_dir, false );
-			}
-			// Return a special status to indicate branch issue (caller will handle CSV update).
-			return Command::INVALID;
-		}
-
-		// Checkout the branch 'remove/atlantis-legacy-modules'.
-		$this->git_checkout_branch( 'remove/atlantis-legacy-modules', $output );
-
-		// Check for legacy modules and delete them if they exist.
-		$this->write_output( $output, '' );
-		$this->write_output( $output, '<fg=cyan;options=bold>Searching for legacy modules to remove...</>' );
-
-		// First, find which legacy modules exist.
 		$found_modules = array();
-		foreach ( $this->legacy_modules as $plugin_name ) {
-			$plugin_info = $this->find_plugin( $plugin_name, $output );
-			if ( null !== $plugin_info ) {
-				$found_modules[ $plugin_name ] = $plugin_info;
+
+		if ( ! $this->skip_repository ) {
+			$this->clone_repo( $output );
+
+			// Checkout the base branch - handle failure gracefully.
+			$checkout_process = \run_system_command( array( 'git', 'checkout', $this->git_base_branch ), $this->repo_dir, false );
+			if ( ! $checkout_process->isSuccessful() ) {
+				// Clean up the cloned repo folder.
+				if ( $this->repo_dir && $this->repos_dir && str_starts_with( $this->repo_dir, $this->repos_dir ) ) {
+					\run_system_command( array( 'rm', '-rf', $this->repo_dir ), $this->repo_dir, false );
+				}
+
+				if ( $this->deployment_not_found ) {
+					// Repo was manually entered due to missing deployment — fall back to site-only.
+					$this->skip_repository = true;
+					$this->skip_note       = "Repo specified but branch '{$this->git_base_branch}' not found";
+					$this->write_output( $output, "<comment>{$this->skip_note}. Continuing with site-only operations.</comment>" );
+				} else {
+					$this->skip_note = "Branch '{$this->git_base_branch}' not found";
+					$this->write_output( $output, "<error>{$this->skip_note}. Skipping site.</error>" );
+					return Command::INVALID;
+				}
+			}
+
+			if ( ! $this->skip_repository ) {
+				// Checkout the branch 'remove/atlantis-legacy-modules'.
+				$this->git_checkout_branch( 'remove/atlantis-legacy-modules', $output );
+
+				// Check for legacy modules and delete them if they exist.
+				$this->write_output( $output, '' );
+				$this->write_output( $output, '<fg=cyan;options=bold>Searching for legacy modules to remove...</>' );
+
+				// First, find which legacy modules exist.
+				foreach ( $this->legacy_modules as $plugin_name ) {
+					$plugin_info = $this->find_plugin( $plugin_name, $output );
+					if ( null !== $plugin_info ) {
+						$found_modules[ $plugin_name ] = $plugin_info;
+					}
+				}
 			}
 		}
 
@@ -576,7 +652,7 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 		// Always install the Atlantis plugin.
 		$plugin_installed = $this->install_atlantis_plugin( $output );
 
-		if ( $plugin_installed && ! empty( $found_modules ) ) {
+		if ( ! $this->skip_repository && $plugin_installed && ! empty( $found_modules ) ) {
 			// Delete the found modules from the repository.
 			foreach ( $found_modules as $plugin_name => $plugin_info ) {
 				$this->delete_plugin( $plugin_name, $plugin_info['location'], $plugin_info['path'], $output );
@@ -590,7 +666,7 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 			$this->uninstall_plugins_from_wordpress( $output );
 		}
 
-		if ( count( $this->removed_modules ) > 0 ) {
+		if ( ! $this->skip_repository && count( $this->removed_modules ) > 0 ) {
 			$this->stage_commit_push_pr_and_merge( $input, $output );
 
 			// Delete the repository folder (with safety check).
@@ -785,6 +861,56 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 		}
 
 		return $this->getHelper( 'question' )->ask( $input, $output, $question );
+	}
+
+	/**
+	 * Prompts the user for a GitHub repository URL or slug and resolves it via the GitHub API.
+	 *
+	 * Accepts a plain slug ("my-repo"), org/slug ("a8cteam51/my-repo"),
+	 * a full HTTPS URL ("https://github.com/a8cteam51/my-repo"), or
+	 * an SSH clone URL ("git@github.com:a8cteam51/my-repo.git").
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  \stdClass|null The resolved GitHub repository object, or null on failure.
+	 */
+	private function prompt_and_resolve_repository( InputInterface $input, OutputInterface $output ): ?\stdClass {
+		$question   = new Question( '<question>Enter the GitHub repository URL or slug (e.g. "my-repo" or "https://github.com/a8cteam51/my-repo"):</question> ' );
+		$repo_input = $this->getHelper( 'question' )->ask( $input, $output, $question );
+
+		if ( empty( $repo_input ) ) {
+			$output->writeln( '<error>No repository provided.</error>' );
+			return null;
+		}
+
+		$repo_input = trim( $repo_input );
+
+		// Try to parse as a full URL (HTTPS or SSH).
+		$git_url = str_ends_with( $repo_input, '.git' ) ? $repo_input : $repo_input . '.git';
+		$parsed  = parse_github_remote_repository_url( $git_url );
+
+		if ( null !== $parsed && ! empty( $parsed->repo ) ) {
+			$repo_slug = $parsed->repo;
+		} elseif ( str_contains( $repo_input, '/' ) ) {
+			// Handle "org/repo" format — extract the repo part.
+			$parts     = explode( '/', rtrim( $repo_input, '/' ) );
+			$repo_slug = end( $parts );
+		} else {
+			// Plain slug.
+			$repo_slug = $repo_input;
+		}
+
+		$output->writeln( "<comment>Resolving repository: {$repo_slug}...</comment>" );
+
+		$repository = get_github_repository( $repo_slug );
+		if ( null === $repository || empty( $repository->name ) ) {
+			$output->writeln( "<error>Could not find GitHub repository: {$repo_slug}</error>" );
+			return null;
+		}
+
+		$output->writeln( "<info>Found repository: {$repository->name} ({$repository->clone_url})</info>" );
+		return $repository;
 	}
 
 	/**
@@ -1550,16 +1676,18 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 	 * @return  void
 	 */
 	private function reset_site_state(): void {
-		$this->site             = null;
-		$this->deployhq_project = null;
-		$this->gh_repository    = null;
-		$this->gh_repo_branch   = null;
-		$this->repo_dir         = null;
-		$this->removed_modules  = array();
-		$this->git_base_branch  = 'develop';
-		$this->php_version      = null;
-		$this->skip_note        = null;
-		$this->csv_url          = null;
+		$this->site                 = null;
+		$this->deployhq_project     = null;
+		$this->gh_repository        = null;
+		$this->gh_repo_branch       = null;
+		$this->repo_dir             = null;
+		$this->removed_modules      = array();
+		$this->git_base_branch      = 'develop';
+		$this->php_version          = null;
+		$this->skip_note            = null;
+		$this->csv_url              = null;
+		$this->skip_repository      = false;
+		$this->deployment_not_found = false;
 	}
 
 	// endregion

--- a/commands/Site_Remove_Atlantis_Legacy_Modules.php
+++ b/commands/Site_Remove_Atlantis_Legacy_Modules.php
@@ -105,6 +105,7 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 	private array $legacy_modules = array(
 		'colophon',
 		'plugin-autoupdate-filter',
+		'team51-tracking',
 	);
 
 	/**
@@ -475,6 +476,9 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 		// Only install the Atlantis plugin if we found legacy modules to replace.
 		if ( ! empty( $found_modules ) ) {
 			$this->install_atlantis_plugin( $output );
+
+			// Check if plugin-autoupdate-filter exists but is deactivated, and disable Atlantis module if so.
+			$this->check_autoupdate_filter_status( $output );
 
 			// Now delete the found modules.
 			foreach ( $found_modules as $plugin_name => $plugin_info ) {
@@ -1093,6 +1097,90 @@ final class Site_Remove_Atlantis_Legacy_Modules extends Command {
 
 		} catch ( \Exception $e ) {
 			$this->write_output( $output, "  <error>Failed to install/activate Atlantis plugin: {$e->getMessage()}</error>" );
+			$this->write_output( $output, '  <comment>Continuing with legacy module removal...</comment>' );
+		}
+	}
+
+	/**
+	 * Checks if plugin-autoupdate-filter (or variants) is installed but deactivated,
+	 * and if so, disables the Atlantis autoupdates module via option.
+	 *
+	 * The plugin slug can have variants like:
+	 * - plugin-autoupdate-filter
+	 * - plugin-autoupdate-filter-5
+	 * - plugin-autoupdate-filter-trunk
+	 * - plugin-autoupdate-filter-1.4.3
+	 *
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  void
+	 */
+	private function check_autoupdate_filter_status( OutputInterface $output ): void {
+		$site_identifier = 'atomic' === $this->host ? $this->site->ID : $this->site->id;
+
+		$this->write_output( $output, '' );
+		$this->write_output( $output, '<fg=cyan;options=bold>Checking plugin-autoupdate-filter status...</>' );
+
+		try {
+			// Get list of all plugins in JSON format.
+			$list_command = 'plugin list --format=json';
+
+			if ( 'pressable' === $this->host ) {
+				$result = run_pressable_site_wp_cli_command( $site_identifier, $list_command, true );
+			} else {
+				$result = run_wpcom_site_wp_cli_command( $site_identifier, $list_command, true );
+			}
+
+			// Parse the JSON output.
+			$plugins = json_decode( $result, true );
+			if ( ! is_array( $plugins ) ) {
+				$this->write_output( $output, '  <comment>Could not parse plugin list.</comment>' );
+				return;
+			}
+
+			// Find any plugin-autoupdate-filter variants.
+			$autoupdate_plugins = array();
+			foreach ( $plugins as $plugin ) {
+				if ( isset( $plugin['name'] ) && str_starts_with( $plugin['name'], 'plugin-autoupdate-filter' ) ) {
+					$autoupdate_plugins[] = $plugin;
+				}
+			}
+
+			if ( empty( $autoupdate_plugins ) ) {
+				$this->write_output( $output, '  <info>No plugin-autoupdate-filter variants found on the site.</info>' );
+				return;
+			}
+
+			// Check if any of them are active.
+			// Note: must-use plugins are always active (they load automatically).
+			$active_statuses = array( 'active', 'active-network', 'must-use' );
+			$any_active      = false;
+			foreach ( $autoupdate_plugins as $plugin ) {
+				$this->write_output( $output, "  Found: {$plugin['name']} (status: {$plugin['status']})" );
+				if ( in_array( $plugin['status'], $active_statuses, true ) ) {
+					$any_active = true;
+				}
+			}
+
+			// If found but none are active, disable the Atlantis autoupdates module.
+			if ( ! $any_active ) {
+				$this->write_output( $output, '  <comment>Plugin found but not active. Disabling Atlantis autoupdates module...</comment>' );
+
+				// Set option to disable the autoupdates module: a:1:{s:7:"enabled";s:1:"0";}
+				$option_command = "option update a8csp_module_autoupdates 'a:1:{s:7:\"enabled\";s:1:\"0\";}'";
+
+				if ( 'pressable' === $this->host ) {
+					run_pressable_site_wp_cli_command( $site_identifier, $option_command, $this->quiet );
+				} else {
+					run_wpcom_site_wp_cli_command( $site_identifier, $option_command, $this->quiet );
+				}
+
+				$this->write_output( $output, '  <info>✓ Atlantis autoupdates module disabled</info>' );
+			} else {
+				$this->write_output( $output, '  <info>Plugin is active, Atlantis autoupdates module will remain enabled.</info>' );
+			}
+		} catch ( \Exception $e ) {
+			$this->write_output( $output, "  <error>Failed to check plugin status: {$e->getMessage()}</error>" );
 			$this->write_output( $output, '  <comment>Continuing with legacy module removal...</comment>' );
 		}
 	}

--- a/commands/Site_Repos_Export.php
+++ b/commands/Site_Repos_Export.php
@@ -1,0 +1,396 @@
+<?php
+
+namespace WPCOMSpecialProjects\CLI\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Exports a CSV mapping sites to their GitHub repositories.
+ *
+ * Examples:
+ *   # Export repos for all sites in a CSV file
+ *   team51 site:export-repos --sites=atlantis-w1-w2-staging-master.csv
+ *
+ *   # Export to a custom output file
+ *   team51 site:export-repos --sites=atlantis-w1-w2-staging-master.csv --export=custom-output.csv
+ */
+#[AsCommand( name: 'site:export-repos' )]
+final class Site_Repos_Export extends Command {
+	// region FIELDS AND CONSTANTS
+
+	/**
+	 * Path to the input CSV file.
+	 *
+	 * @var string|null
+	 */
+	private ?string $sites_csv_path = null;
+
+	/**
+	 * File handle for the output CSV.
+	 *
+	 * @var resource|null
+	 */
+	private $output_stream = null;
+
+	/**
+	 * Path to the output CSV file.
+	 *
+	 * @var string
+	 */
+	private string $export_path = 'sites-repos.csv';
+
+	// endregion
+
+	// region INHERITED METHODS
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function configure(): void {
+		$this->setDescription( 'Exports a CSV mapping sites to their GitHub repositories.' )
+			->setHelp( 'Reads a CSV file with Site, URL, Host columns and resolves the GitHub repository for each site.' );
+
+		$this->addOption( 'sites', null, InputOption::VALUE_REQUIRED, 'Path to a CSV file containing sites to process (requires Site, URL, Host columns).' )
+			->addOption( 'export', null, InputOption::VALUE_REQUIRED, 'Path to export CSV results to.', 'sites-repos.csv' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function initialize( InputInterface $input, OutputInterface $output ): void {
+		// Validate input CSV path.
+		$this->sites_csv_path = $input->getOption( 'sites' );
+		if ( empty( $this->sites_csv_path ) ) {
+			throw new \RuntimeException( '--sites option is required. Provide a path to a CSV file.' );
+		}
+		if ( ! file_exists( $this->sites_csv_path ) ) {
+			throw new \RuntimeException( "CSV file not found: {$this->sites_csv_path}" );
+		}
+
+		// Open output CSV file.
+		$this->export_path   = $input->getOption( 'export' );
+		$this->output_stream = get_file_handle( $this->export_path, 'csv' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( InputInterface $input, OutputInterface $output ): int {
+		$csv_data = $this->read_csv( $this->sites_csv_path );
+		if ( empty( $csv_data ) ) {
+			$output->writeln( '<error>No valid sites found in CSV file.</error>' );
+			return Command::FAILURE;
+		}
+
+		// Validate required columns.
+		$first_row = reset( $csv_data );
+		foreach ( array( 'Site', 'URL', 'Host' ) as $col ) {
+			if ( ! isset( $first_row[ $col ] ) ) {
+				$output->writeln( "<error>CSV missing required column: {$col}</error>" );
+				return Command::FAILURE;
+			}
+		}
+
+		$total = count( $csv_data );
+		$output->writeln( "<info>Processing {$total} sites from CSV...</info>" );
+
+		// Write output CSV header.
+		fputcsv( $this->output_stream, array( 'Site', 'URL', 'Host', 'Repository', 'Repository URL', 'Notes' ) );
+
+		// Set up progress bar.
+		$progress_bar = new ProgressBar( $output, $total );
+		$progress_bar->setFormat( ' %current%/%max% [%bar%] %percent:3s%% %message%' );
+		$progress_bar->setMessage( 'Starting...' );
+		$progress_bar->start();
+
+		// Cache: URL => resolved result (to handle duplicate URLs).
+		$url_cache = array();
+		$success   = 0;
+		$failed    = 0;
+		$skipped   = 0;
+
+		foreach ( $csv_data as $site_data ) {
+			$site_name = $site_data['Site'] ?? 'Unknown';
+			$site_url  = trim( $site_data['URL'] ?? '' );
+			$host      = strtolower( trim( $site_data['Host'] ?? '' ) );
+
+			$progress_bar->setMessage( $site_name );
+			$progress_bar->advance();
+
+			// Validate row.
+			if ( empty( $site_url ) || empty( $host ) ) {
+				$this->write_output_row( $site_name, $site_url, $host, '', '', 'Missing URL or Host' );
+				++$skipped;
+				continue;
+			}
+
+			if ( ! in_array( $host, array( 'pressable', 'atomic' ), true ) ) {
+				$this->write_output_row( $site_name, $site_url, $host, '', '', "Unknown host type: {$host}" );
+				++$skipped;
+				continue;
+			}
+
+			// Check cache for duplicate URLs.
+			if ( isset( $url_cache[ $site_url ] ) ) {
+				$cached = $url_cache[ $site_url ];
+				$this->write_output_row( $site_name, $site_url, $host, $cached['repo_name'], $cached['repo_url'], $cached['notes'] );
+				if ( ! empty( $cached['repo_name'] ) ) {
+					++$success;
+				} else {
+					++$failed;
+				}
+				continue;
+			}
+
+			// Resolve repository.
+			$result = $this->resolve_repository( $site_url, $host );
+
+			$url_cache[ $site_url ] = $result;
+			$this->write_output_row( $site_name, $site_url, $host, $result['repo_name'], $result['repo_url'], $result['notes'] );
+
+			if ( ! empty( $result['repo_name'] ) ) {
+				++$success;
+			} else {
+				++$failed;
+			}
+		}
+
+		$progress_bar->finish();
+		$output->writeln( '' );
+		fclose( $this->output_stream );
+
+		// Summary.
+		$output->writeln( '' );
+		$output->writeln( '<fg=cyan;options=bold>=== Export Summary ===' );
+		$output->writeln( "<info>Total sites:  {$total}</info>" );
+		$output->writeln( "<info>Resolved:     {$success}</info>" );
+		$output->writeln( "<comment>Skipped:      {$skipped}</comment>" );
+		$output->writeln( "<error>Failed:       {$failed}</error>" );
+		$output->writeln( "<info>Results exported to: {$this->export_path}</info>" );
+
+		return Command::SUCCESS;
+	}
+
+	// endregion
+
+	// region HELPERS
+
+	/**
+	 * Resolves the GitHub repository for a given site URL and host type.
+	 *
+	 * @param   string $site_url The site URL.
+	 * @param   string $host     The host type ('pressable' or 'atomic').
+	 *
+	 * @return  array{ repo_name: string, repo_url: string, notes: string }
+	 */
+	private function resolve_repository( string $site_url, string $host ): array {
+		$result = array(
+			'repo_name' => '',
+			'repo_url'  => '',
+			'notes'     => '',
+		);
+
+		try {
+			$domain = $this->extract_domain_from_url( $site_url );
+
+			if ( 'pressable' === $host ) {
+				$result = $this->resolve_pressable_repository( $domain );
+			} else {
+				$result = $this->resolve_atomic_repository( $domain );
+			}
+		} catch ( \Exception $e ) {
+			$result['notes'] = 'Error: ' . $e->getMessage();
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Resolves GitHub repository for a Pressable site via DeployHQ.
+	 *
+	 * @param   string $domain The site domain.
+	 *
+	 * @return  array{ repo_name: string, repo_url: string, notes: string }
+	 */
+	private function resolve_pressable_repository( string $domain ): array {
+		$result = array( 'repo_name' => '', 'repo_url' => '', 'notes' => '' );
+
+		// Step 1: Look up the Pressable site.
+		$site = get_pressable_site( $domain );
+		if ( ! $site ) {
+			$result['notes'] = 'Pressable site not found';
+			return $result;
+		}
+
+		// Step 2: Get DeployHQ config.
+		$deployhq_config = get_pressable_site_deployhq_config( $site->id );
+		if ( ! $deployhq_config || ! isset( $deployhq_config->project ) ) {
+			$result['notes'] = 'No DeployHQ project found';
+			return $result;
+		}
+
+		// Step 3: Get GitHub repository from DeployHQ project.
+		$gh_repo = get_github_repository_from_deployhq_project( $deployhq_config->project->permalink );
+		if ( ! $gh_repo || ! isset( $gh_repo->name ) ) {
+			$result['notes'] = 'GitHub repository not found via DeployHQ';
+			return $result;
+		}
+
+		$result['repo_name'] = $gh_repo->full_name ?? ( 'a8cteam51/' . $gh_repo->name );
+		$result['repo_url']  = $gh_repo->html_url ?? "https://github.com/a8cteam51/{$gh_repo->name}";
+		return $result;
+	}
+
+	/**
+	 * Resolves GitHub repository for an Atomic/WPCOM site via code deployments.
+	 *
+	 * @param   string $domain The site domain.
+	 *
+	 * @return  array{ repo_name: string, repo_url: string, notes: string }
+	 */
+	private function resolve_atomic_repository( string $domain ): array {
+		$result = array( 'repo_name' => '', 'repo_url' => '', 'notes' => '' );
+
+		// Step 1: Look up the WPCOM site.
+		$site = get_wpcom_site( $domain );
+		if ( ! $site ) {
+			$result['notes'] = 'WPCOM site not found';
+			return $result;
+		}
+
+		// Step 2: Get code deployments.
+		$deployments = get_wpcom_site_code_deployments( $site->ID );
+		if ( empty( $deployments ) ) {
+			$result['notes'] = 'No WPCOM GitHub deployments found';
+			return $result;
+		}
+
+		// Step 3: Use the first deployment. Note if there are multiple.
+		$repository_name = $deployments[0]->repository_name ?? null;
+		if ( ! $repository_name ) {
+			$result['notes'] = 'Deployment has no repository_name';
+			return $result;
+		}
+
+		if ( count( $deployments ) > 1 ) {
+			$all_repos       = array_column( $deployments, 'repository_name' );
+			$result['notes'] = 'Multiple deployments: ' . implode( ', ', $all_repos );
+		}
+
+		// Step 4: Extract slug and fetch repository.
+		$parts     = explode( '/', $repository_name );
+		$repo_slug = $parts[1] ?? null;
+		if ( ! $repo_slug ) {
+			$result['notes'] = "Could not parse repository slug from: {$repository_name}";
+			return $result;
+		}
+
+		$gh_repo = get_github_repository( $repo_slug );
+		if ( ! $gh_repo || ! isset( $gh_repo->name ) ) {
+			// Still store the name even if API lookup fails.
+			$result['repo_name'] = $repository_name;
+			$result['repo_url']  = "https://github.com/{$repository_name}";
+			$result['notes']     = ( $result['notes'] ? $result['notes'] . '; ' : '' ) . 'GitHub API lookup failed, using deployment name';
+			return $result;
+		}
+
+		$result['repo_name'] = $gh_repo->full_name ?? $repository_name;
+		$result['repo_url']  = $gh_repo->html_url ?? "https://github.com/{$repository_name}";
+		return $result;
+	}
+
+	/**
+	 * Writes a single row to the output CSV.
+	 *
+	 * @param   string $site      The site name.
+	 * @param   string $url       The site URL.
+	 * @param   string $host      The host type.
+	 * @param   string $repo_name The repository full name.
+	 * @param   string $repo_url  The repository URL.
+	 * @param   string $notes     Any notes or error messages.
+	 *
+	 * @return  void
+	 */
+	private function write_output_row( string $site, string $url, string $host, string $repo_name, string $repo_url, string $notes ): void {
+		fputcsv( $this->output_stream, array( $site, $url, $host, $repo_name, $repo_url, $notes ) );
+		fflush( $this->output_stream );
+	}
+
+	/**
+	 * Extract domain from URL (remove protocol, path, etc.).
+	 *
+	 * @param   string $url The URL to parse.
+	 *
+	 * @return  string The domain only.
+	 */
+	private function extract_domain_from_url( string $url ): string {
+		if ( empty( $url ) ) {
+			return '';
+		}
+
+		// Remove protocol (http://, https://).
+		$domain = preg_replace( '#^https?://#i', '', $url );
+
+		// Remove path, query string, and fragment.
+		$domain = preg_replace( '~[/?#].*$~', '', $domain );
+
+		// Remove trailing slash if any.
+		$domain = rtrim( $domain ?? '', '/' );
+
+		return $domain;
+	}
+
+	/**
+	 * Reads a CSV file into an associative array keyed by row index.
+	 *
+	 * @param   string $csv_path The path to the CSV file.
+	 *
+	 * @return  array
+	 */
+	private function read_csv( string $csv_path ): array {
+		$csv_data = array();
+		$handle   = fopen( $csv_path, 'r' );
+
+		if ( false === $handle ) {
+			return $csv_data;
+		}
+
+		// Read header row.
+		$headers = fgetcsv( $handle );
+		if ( false === $headers ) {
+			fclose( $handle );
+			return $csv_data;
+		}
+
+		// Read data rows.
+		$row_index = 1; // Start at 1 (0 is header).
+		while ( ( $row = fgetcsv( $handle ) ) !== false ) {
+			++$row_index;
+
+			// Skip empty rows.
+			if ( empty( array_filter( $row ) ) ) {
+				continue;
+			}
+
+			// Ensure row has same number of columns as headers.
+			if ( count( $row ) !== count( $headers ) ) {
+				$row = array_pad( array_slice( $row, 0, count( $headers ) ), count( $headers ), '' );
+			}
+
+			$site_data = array_combine( $headers, $row );
+			if ( $site_data ) {
+				$csv_data[ $row_index ] = $site_data;
+			}
+		}
+
+		fclose( $handle );
+		return $csv_data;
+	}
+
+	// endregion
+}

--- a/includes/functions-github.php
+++ b/includes/functions-github.php
@@ -84,6 +84,26 @@ function get_github_repository_branches( string $repository ): ?array {
 }
 
 /**
+ * Returns the contents of a directory in a GitHub repository at a given ref.
+ *
+ * @param   string $repository The name of the repository.
+ * @param   string $path       The path within the repository (e.g., 'plugins', 'mu-plugins').
+ * @param   string $ref        The branch, tag, or commit SHA to read from.
+ *
+ * @return  stdClass[]|null
+ */
+function get_github_repository_contents( string $repository, string $path, string $ref = 'develop' ): ?array {
+	$endpoint = 'repos/a8cteam51/' . urlencode( $repository ) . '/contents/' . $path . '?' . http_build_query( array( 'ref' => $ref ) );
+	$result   = shell_exec( 'gh api ' . escapeshellarg( $endpoint ) . ' 2>/dev/null' );
+	if ( empty( $result ) ) {
+		return null;
+	}
+
+	$decoded = json_decode( $result );
+	return is_array( $decoded ) ? $decoded : null;
+}
+
+/**
  * Creates a new branch in a given GitHub repository.
  *
  * @param   string $repository The name of the repository to create the branch in.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -63,7 +63,7 @@ function get_remote_content( string $url, array $headers = array(), string $meth
 	}
 
 	return array(
-		'headers' => parse_http_headers( $http_response_header ),
+		'headers' => parse_http_headers( http_get_last_response_headers() ),
 		'body'    => $result,
 	);
 }


### PR DESCRIPTION
This is a temporary command designed to bulk remove the legacy modules replaced by Atlantis (Colophon and the Plugin Autoupdate Filter) automatically.

I'm still testing it, so adjustments may be added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a CLI tool to remove legacy Atlantis modules from WordPress sites, supporting single-site and CSV batch workflows.
  * Supports interactive and non-interactive modes with host/site/branch selection, CSV validation, per-site logs, and a final processing summary.
  * Automates repository updates and pull request creation (optional auto-merge and branch cleanup), can install/uninstall related plugins, and safely cleans up local working copies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->