### PR TITLE
Add MCP server for AI assistant integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,6 +243,9 @@ dist
 # *.iml
 # *.ipr
 
+# SQLLite
+wp-content
+
 # CMake
 cmake-build-*/
 

--- a/.gitignore
+++ b/.gitignore
@@ -243,7 +243,7 @@ dist
 # *.iml
 # *.ipr
 
-# SQLLite
+# WP-Content
 wp-content
 
 # CMake

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The CLI includes a built-in [Model Context Protocol (MCP)](https://modelcontextp
 
 Start the MCP server with:
 
-```
+```bash
 team51 --mcp
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,63 @@ The CLI tool automatically updates itself. It does a hard reset to the latest ve
 - Run the tool with the `--force-update` flag to force an update check regardless of when the last check was performed.
 - Add a `.dev` file to the root folder containing your current timestamp to disable updates for a week.
 
+## MCP Server (AI Assistant Integration)
+
+The CLI includes a built-in [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server that exposes Team51 operations as tools for AI assistants like Cursor and Claude Code. This allows you to query WPCOM sites, check Pressable PHP errors, list GitHub repos, and more — directly from your AI-powered editor.
+
+### Setup
+
+Start the MCP server with:
+
+```
+team51 --mcp
+```
+
+#### Cursor
+
+Add the following to `.cursor/mcp.json` in any project (or in the team51-cli repo):
+
+```json
+{
+  "mcpServers": {
+    "team51": {
+      "command": "team51",
+      "args": ["--mcp"]
+    }
+  }
+}
+```
+
+Then restart Cursor and verify "team51" appears under **Cursor Settings > MCP**.
+
+#### Claude Code
+
+Add it globally so the tools are available in every project:
+
+```bash
+claude mcp add team51 -- team51 --mcp
+```
+
+### Available Tools
+
+The MCP server exposes 39 tools across all services:
+
+| Service | Read Tools | Write Tools |
+|---------|-----------|-------------|
+| **WPCOM** | `wpcom_list_sites`, `wpcom_get_site`, `wpcom_list_site_plugins`, `wpcom_list_site_stickers`, `wpcom_list_sites_with_sticker`, `wpcom_get_site_stats`, `wpcom_list_site_users` | `wpcom_add_sticker`, `wpcom_remove_sticker`, `wpcom_update_site`, `wpcom_rotate_sftp_password` |
+| **Pressable** | `pressable_list_sites`, `pressable_get_site`, `pressable_get_php_errors`, `pressable_list_collaborators`, `pressable_list_sftp_users`, `pressable_list_site_domains` | `pressable_create_site_note`, `pressable_add_collaborator`, `pressable_remove_collaborator`, `pressable_add_domain`, `pressable_rotate_sftp_password` |
+| **GitHub** | `github_list_repositories`, `github_get_repository`, `github_list_branches`, `github_list_secrets`, `github_list_workflow_runs` | `github_set_topics`, `github_create_branch`, `github_set_secret`, `github_create_issue` |
+| **Jetpack** | `jetpack_list_modules`, `jetpack_list_site_modules` | `jetpack_update_module_settings` |
+| **DeployHQ** | `deployhq_list_projects`, `deployhq_get_project`, `deployhq_list_project_servers` | `deployhq_rotate_private_key`, `deployhq_connect_repository` |
+
+Write tools are annotated with MCP `ToolAnnotations` (`destructiveHint`, `readOnlyHint`, etc.) so clients prompt for confirmation before executing destructive actions.
+
+High-risk operations (site creation, user deletion, WP-CLI execution, deployments) are intentionally excluded.
+
+### Extending
+
+To add a new tool, add a method with `#[McpTool]` to `mcp/Team51McpTools.php`. The server auto-discovers it — no registration needed.
+
 ## Usage
 
 This CLI tool is self-documenting. You can view a list of available commands with `team51 list`.

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "phpseclib/phpseclib": "^3.0",
     "symfony/console": "^v7.0",
     "symfony/event-dispatcher": "^v7.0",
-    "symfony/process": "^v7.0"
+    "symfony/process": "^v7.0",
+    "php-mcp/server": "^3.3"
   },
   "require-dev": {
     "a8cteam51/team51-configs": "dev-trunk",
@@ -26,7 +27,8 @@
 
   "autoload": {
     "psr-4": {
-      "WPCOMSpecialProjects\\CLI\\Command\\": "commands/"
+      "WPCOMSpecialProjects\\CLI\\Command\\": "commands/",
+      "WPCOMSpecialProjects\\CLI\\Mcp\\": "mcp/"
     },
     "files": [
       "includes/api-helper.php",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,349 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "21c283728bc047eafc257546b216582b",
+    "content-hash": "25f20afff7e67e64ce659d153dc8a06c",
     "packages": [
+        {
+            "name": "doctrine/deprecations",
+            "version": "1.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<=7.5 || >=14"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^12 || ^14",
+                "phpstan/phpstan": "1.4.10 || 2.1.30",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12.4 || ^13.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
+            },
+            "time": "2026-02-07T07:09:04+00:00"
+        },
+        {
+            "name": "evenement/evenement",
+            "version": "v3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/igorw/evenement.git",
+                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/igorw/evenement/zipball/0a16b0d71ab13284339abb99d9d2bd813640efbc",
+                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9 || ^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Evenement\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                }
+            ],
+            "description": "Événement is a very simple event dispatching library for PHP",
+            "keywords": [
+                "event-dispatcher",
+                "event-emitter"
+            ],
+            "support": {
+                "issues": "https://github.com/igorw/evenement/issues",
+                "source": "https://github.com/igorw/evenement/tree/v3.0.2"
+            },
+            "time": "2023-08-08T05:53:35+00:00"
+        },
+        {
+            "name": "fig/http-message-util",
+            "version": "1.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message-util.git",
+                "reference": "9d94dc0154230ac39e5bf89398b324a86f63f765"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message-util/zipball/9d94dc0154230ac39e5bf89398b324a86f63f765",
+                "reference": "9d94dc0154230ac39e5bf89398b324a86f63f765",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3 || ^7.0 || ^8.0"
+            },
+            "suggest": {
+                "psr/http-message": "The package containing the PSR-7 interfaces"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Fig\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Utility classes and constants for use with PSR-7 (psr/http-message)",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/http-message-util/issues",
+                "source": "https://github.com/php-fig/http-message-util/tree/1.1.5"
+            },
+            "time": "2020-11-24T22:02:12+00:00"
+        },
+        {
+            "name": "opis/json-schema",
+            "version": "2.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opis/json-schema.git",
+                "reference": "8458763e0dd0b6baa310e04f1829fc73da4e8c8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opis/json-schema/zipball/8458763e0dd0b6baa310e04f1829fc73da4e8c8a",
+                "reference": "8458763e0dd0b6baa310e04f1829fc73da4e8c8a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "opis/string": "^2.1",
+                "opis/uri": "^1.0",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "ext-bcmath": "*",
+                "ext-intl": "*",
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Opis\\JsonSchema\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Sorin Sarca",
+                    "email": "sarca_sorin@hotmail.com"
+                },
+                {
+                    "name": "Marius Sarca",
+                    "email": "marius.sarca@gmail.com"
+                }
+            ],
+            "description": "Json Schema Validator for PHP",
+            "homepage": "https://opis.io/json-schema",
+            "keywords": [
+                "json",
+                "json-schema",
+                "schema",
+                "validation",
+                "validator"
+            ],
+            "support": {
+                "issues": "https://github.com/opis/json-schema/issues",
+                "source": "https://github.com/opis/json-schema/tree/2.6.0"
+            },
+            "time": "2025-10-17T12:46:48+00:00"
+        },
+        {
+            "name": "opis/string",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opis/string.git",
+                "reference": "3e4d2aaff518ac518530b89bb26ed40f4503635e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opis/string/zipball/3e4d2aaff518ac518530b89bb26ed40f4503635e",
+                "reference": "3e4d2aaff518ac518530b89bb26ed40f4503635e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "ext-json": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Opis\\String\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Marius Sarca",
+                    "email": "marius.sarca@gmail.com"
+                },
+                {
+                    "name": "Sorin Sarca",
+                    "email": "sarca_sorin@hotmail.com"
+                }
+            ],
+            "description": "Multibyte strings as objects",
+            "homepage": "https://opis.io/string",
+            "keywords": [
+                "multi-byte",
+                "opis",
+                "string",
+                "string manipulation",
+                "utf-8"
+            ],
+            "support": {
+                "issues": "https://github.com/opis/string/issues",
+                "source": "https://github.com/opis/string/tree/2.1.0"
+            },
+            "time": "2025-10-17T12:38:41+00:00"
+        },
+        {
+            "name": "opis/uri",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opis/uri.git",
+                "reference": "0f3ca49ab1a5e4a6681c286e0b2cc081b93a7d5a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opis/uri/zipball/0f3ca49ab1a5e4a6681c286e0b2cc081b93a7d5a",
+                "reference": "0f3ca49ab1a5e4a6681c286e0b2cc081b93a7d5a",
+                "shasum": ""
+            },
+            "require": {
+                "opis/string": "^2.0",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Opis\\Uri\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Marius Sarca",
+                    "email": "marius.sarca@gmail.com"
+                },
+                {
+                    "name": "Sorin Sarca",
+                    "email": "sarca_sorin@hotmail.com"
+                }
+            ],
+            "description": "Build, parse and validate URIs and URI-templates",
+            "homepage": "https://opis.io",
+            "keywords": [
+                "URI Template",
+                "parse url",
+                "punycode",
+                "uri",
+                "uri components",
+                "url",
+                "validate uri"
+            ],
+            "support": {
+                "issues": "https://github.com/opis/uri/issues",
+                "source": "https://github.com/opis/uri/tree/1.1.0"
+            },
+            "time": "2021-05-22T15:57:08+00:00"
+        },
         {
             "name": "paragonie/constant_time_encoding",
             "version": "v3.0.0",
@@ -124,6 +465,297 @@
             "time": "2020-10-15T08:29:30+00:00"
         },
         {
+            "name": "php-mcp/schema",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-mcp/schema.git",
+                "reference": "18f9f09b1564dd222f59674249eb4aa43615afe7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-mcp/schema/zipball/18f9f09b1564dd222f59674249eb4aa43615afe7",
+                "reference": "18f9f09b1564dd222f59674249eb4aa43615afe7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpMcp\\Schema\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kyrian Obikwelu",
+                    "email": "koshnawaza@gmail.com"
+                }
+            ],
+            "description": "PHP Data Transfer Objects (DTOs) and Enums for the Model Context Protocol (MCP) schema.",
+            "support": {
+                "issues": "https://github.com/php-mcp/schema/issues",
+                "source": "https://github.com/php-mcp/schema/tree/1.0.2"
+            },
+            "time": "2025-07-25T12:45:32+00:00"
+        },
+        {
+            "name": "php-mcp/server",
+            "version": "3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-mcp/server.git",
+                "reference": "37b40d5e91f0600442677ddd226e5a22d5661ee1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-mcp/server/zipball/37b40d5e91f0600442677ddd226e5a22d5661ee1",
+                "reference": "37b40d5e91f0600442677ddd226e5a22d5661ee1",
+                "shasum": ""
+            },
+            "require": {
+                "opis/json-schema": "^2.4",
+                "php": ">=8.1",
+                "php-mcp/schema": "^1.0",
+                "phpdocumentor/reflection-docblock": "^5.6",
+                "psr/clock": "^1.0",
+                "psr/container": "^1.0 || ^2.0",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
+                "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
+                "react/event-loop": "^1.5",
+                "react/http": "^1.11",
+                "react/promise": "^3.0",
+                "react/stream": "^1.4",
+                "symfony/finder": "^6.4 || ^7.2"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.75",
+                "mockery/mockery": "^1.6",
+                "pestphp/pest": "^2.36.0|^3.5.0",
+                "react/async": "^4.0",
+                "react/child-process": "^0.6.6",
+                "symfony/var-dumper": "^6.4.11|^7.1.5"
+            },
+            "suggest": {
+                "ext-pcntl": "For signal handling support when using StdioServerTransport with StreamSelectLoop"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpMcp\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kyrian Obikwelu",
+                    "email": "koshnawaza@gmail.com"
+                }
+            ],
+            "description": "PHP SDK for building Model Context Protocol (MCP) servers - Create MCP tools, resources, and prompts",
+            "keywords": [
+                "Model Context Protocol",
+                "mcp",
+                "php",
+                "php mcp",
+                "php mcp prompts",
+                "php mcp resources",
+                "php mcp sdk",
+                "php mcp server",
+                "php mcp tools",
+                "php model context protocol",
+                "server"
+            ],
+            "support": {
+                "issues": "https://github.com/php-mcp/server/issues",
+                "source": "https://github.com/php-mcp/server/tree/3.3.0"
+            },
+            "time": "2025-07-12T22:19:39+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
+            "time": "2020-06-27T09:03:43+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "5.6.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "5cee1d3dfc2d2aa6599834520911d246f656bcb8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/5cee1d3dfc2d2aa6599834520911d246f656bcb8",
+                "reference": "5cee1d3dfc2d2aa6599834520911d246f656bcb8",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.1",
+                "ext-filter": "*",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/type-resolver": "^1.7",
+                "phpstan/phpdoc-parser": "^1.7|^2.0",
+                "webmozart/assert": "^1.9.1 || ^2"
+            },
+            "require-dev": {
+                "mockery/mockery": "~1.3.5 || ~1.6.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-mockery": "^1.1",
+                "phpstan/phpstan-webmozart-assert": "^1.2",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^5.26"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.6"
+            },
+            "time": "2025-12-22T21:13:58+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "1.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/92a98ada2b93d9b201a613cb5a33584dde25f195",
+                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.0",
+                "php": "^7.3 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpstan/phpdoc-parser": "^1.18|^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpunit/phpunit": "^9.5",
+                "rector/rector": "^0.13.9",
+                "vimeo/psalm": "^4.25"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.12.0"
+            },
+            "time": "2025-11-21T15:09:14+00:00"
+        },
+        {
             "name": "phpseclib/phpseclib",
             "version": "3.0.46",
             "source": {
@@ -234,6 +866,101 @@
             "time": "2025-06-26T16:29:55+00:00"
         },
         {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
+            },
+            "time": "2026-01-25T14:56:51+00:00"
+        },
+        {
+            "name": "psr/clock",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/clock.git",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/clock/zipball/e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "reference": "e41a24703d4560fd0acb709162f73b8adfc3aa0d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Clock\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for reading the clock.",
+            "homepage": "https://github.com/php-fig/clock",
+            "keywords": [
+                "clock",
+                "now",
+                "psr",
+                "psr-20",
+                "time"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/clock/issues",
+                "source": "https://github.com/php-fig/clock/tree/1.0.0"
+            },
+            "time": "2022-11-25T14:36:26+00:00"
+        },
+        {
             "name": "psr/container",
             "version": "2.0.2",
             "source": {
@@ -335,6 +1062,702 @@
                 "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
             },
             "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
+                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/1.1"
+            },
+            "time": "2023-04-04T09:50:52+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
+            },
+            "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
+            },
+            "time": "2021-10-29T13:26:27+00:00"
+        },
+        {
+            "name": "react/cache",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/cache.git",
+                "reference": "d47c472b64aa5608225f47965a484b75c7817d5b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/cache/zipball/d47c472b64aa5608225f47965a484b75c7817d5b",
+                "reference": "d47c472b64aa5608225f47965a484b75c7817d5b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "react/promise": "^3.0 || ^2.0 || ^1.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async, Promise-based cache interface for ReactPHP",
+            "keywords": [
+                "cache",
+                "caching",
+                "promise",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/cache/issues",
+                "source": "https://github.com/reactphp/cache/tree/v1.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2022-11-30T15:59:55+00:00"
+        },
+        {
+            "name": "react/dns",
+            "version": "v1.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/dns.git",
+                "reference": "7562c05391f42701c1fccf189c8225fece1cd7c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/dns/zipball/7562c05391f42701c1fccf189c8225fece1cd7c3",
+                "reference": "7562c05391f42701c1fccf189c8225fece1cd7c3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "react/cache": "^1.0 || ^0.6 || ^0.5",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.7 || ^1.2.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/async": "^4.3 || ^3 || ^2",
+                "react/promise-timer": "^1.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Dns\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async DNS resolver for ReactPHP",
+            "keywords": [
+                "async",
+                "dns",
+                "dns-resolver",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/dns/issues",
+                "source": "https://github.com/reactphp/dns/tree/v1.14.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-18T19:34:28+00:00"
+        },
+        {
+            "name": "react/event-loop",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/event-loop.git",
+                "reference": "ba276bda6083df7e0050fd9b33f66ad7a4ac747a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/ba276bda6083df7e0050fd9b33f66ad7a4ac747a",
+                "reference": "ba276bda6083df7e0050fd9b33f66ad7a4ac747a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "suggest": {
+                "ext-pcntl": "For signal handling support when using the StreamSelectLoop"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\EventLoop\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "ReactPHP's core reactor event loop that libraries can use for evented I/O.",
+            "keywords": [
+                "asynchronous",
+                "event-loop"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/event-loop/issues",
+                "source": "https://github.com/reactphp/event-loop/tree/v1.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-17T20:46:25+00:00"
+        },
+        {
+            "name": "react/http",
+            "version": "v1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/http.git",
+                "reference": "8db02de41dcca82037367f67a2d4be365b1c4db9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/http/zipball/8db02de41dcca82037367f67a2d4be365b1c4db9",
+                "reference": "8db02de41dcca82037367f67a2d4be365b1c4db9",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "fig/http-message-util": "^1.1",
+                "php": ">=5.3.0",
+                "psr/http-message": "^1.0",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.3 || ^1.2.1",
+                "react/socket": "^1.16",
+                "react/stream": "^1.4"
+            },
+            "require-dev": {
+                "clue/http-proxy-react": "^1.8",
+                "clue/reactphp-ssh-proxy": "^1.4",
+                "clue/socks-react": "^1.4",
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/async": "^4.2 || ^3 || ^2",
+                "react/promise-stream": "^1.4",
+                "react/promise-timer": "^1.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Http\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Event-driven, streaming HTTP client and server implementation for ReactPHP",
+            "keywords": [
+                "async",
+                "client",
+                "event-driven",
+                "http",
+                "http client",
+                "http server",
+                "https",
+                "psr-7",
+                "reactphp",
+                "server",
+                "streaming"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/http/issues",
+                "source": "https://github.com/reactphp/http/tree/v1.11.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-11-20T15:24:08+00:00"
+        },
+        {
+            "name": "react/promise",
+            "version": "v3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/23444f53a813a3296c1368bb104793ce8d88f04a",
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "1.12.28 || 1.4.10",
+                "phpunit/phpunit": "^9.6 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "keywords": [
+                "promise",
+                "promises"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/promise/issues",
+                "source": "https://github.com/reactphp/promise/tree/v3.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-08-19T18:57:03+00:00"
+        },
+        {
+            "name": "react/socket",
+            "version": "v1.17.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/socket.git",
+                "reference": "ef5b17b81f6f60504c539313f94f2d826c5faa08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/socket/zipball/ef5b17b81f6f60504c539313f94f2d826c5faa08",
+                "reference": "ef5b17b81f6f60504c539313f94f2d826c5faa08",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.0",
+                "react/dns": "^1.13",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.6 || ^1.2.1",
+                "react/stream": "^1.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/async": "^4.3 || ^3.3 || ^2",
+                "react/promise-stream": "^1.4",
+                "react/promise-timer": "^1.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Socket\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async, streaming plaintext TCP/IP and secure TLS socket server and client connections for ReactPHP",
+            "keywords": [
+                "Connection",
+                "Socket",
+                "async",
+                "reactphp",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/socket/issues",
+                "source": "https://github.com/reactphp/socket/tree/v1.17.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-19T20:47:34+00:00"
+        },
+        {
+            "name": "react/stream",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/stream.git",
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/stream/zipball/1e5b0acb8fe55143b5b426817155190eb6f5b18d",
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.8",
+                "react/event-loop": "^1.2"
+            },
+            "require-dev": {
+                "clue/stream-filter": "~1.2",
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Stream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Event-driven readable and writable streams for non-blocking I/O in ReactPHP",
+            "keywords": [
+                "event-driven",
+                "io",
+                "non-blocking",
+                "pipe",
+                "reactphp",
+                "readable",
+                "stream",
+                "writable"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/stream/issues",
+                "source": "https://github.com/reactphp/stream/tree/v1.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-06-11T12:45:25+00:00"
         },
         {
             "name": "symfony/console",
@@ -656,6 +2079,74 @@
                 }
             ],
             "time": "2024-09-25T14:21:43+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v7.4.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "ad4daa7c38668dcb031e63bc99ea9bd42196a2cb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/ad4daa7c38668dcb031e63bc99ea9bd42196a2cb",
+                "reference": "ad4daa7c38668dcb031e63bc99ea9bd42196a2cb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "symfony/filesystem": "^6.4|^7.0|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Finds files and directories via an intuitive fluent interface",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/finder/tree/v7.4.5"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-26T15:07:59+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1210,6 +2701,68 @@
                 }
             ],
             "time": "2025-07-10T08:47:49+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "ce6a2f100c404b2d32a1dd1270f9b59ad4f57649"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/ce6a2f100c404b2d32a1dd1270f9b59ad4f57649",
+                "reference": "ce6a2f100c404b2d32a1dd1270f9b59ad4f57649",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-date": "*",
+                "ext-filter": "*",
+                "php": "^8.2"
+            },
+            "suggest": {
+                "ext-intl": "",
+                "ext-simplexml": "",
+                "ext-spl": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-feature/2-0": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                },
+                {
+                    "name": "Woody Gilk",
+                    "email": "woody.gilk@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/2.1.2"
+            },
+            "time": "2026-01-13T14:02:24+00:00"
         }
     ],
     "packages-dev": [
@@ -2379,56 +3932,6 @@
                 "source": "https://github.com/phpstan/phpstan-strict-rules/tree/2.0.6"
             },
             "time": "2025-07-21T12:19:29+00:00"
-        },
-        {
-            "name": "psr/log",
-            "version": "3.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
-                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
-            "keywords": [
-                "log",
-                "psr",
-                "psr-3"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/log/tree/3.0.2"
-            },
-            "time": "2024-09-11T13:17:53+00:00"
         },
         {
             "name": "roave/security-advisories",
@@ -4059,7 +5562,7 @@
         "a8cteam51/team51-configs": 20,
         "roave/security-advisories": 20
     },
-    "prefer-stable": true,
+    "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
         "ext-gd": "*",
@@ -4071,5 +5574,5 @@
     "platform-overrides": {
         "php": "8.3"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/includes/functions-wpcom.php
+++ b/includes/functions-wpcom.php
@@ -215,7 +215,13 @@ function get_wpcom_site_users( string $site_id_or_url, array $params = array() )
 		$endpoint .= '?' . http_build_query( $params );
 	}
 
-	return API_Helper::make_wpcom_request( $endpoint )->records ?? API_Helper::make_wpcom_request( $endpoint );
+	$response = API_Helper::make_wpcom_request( $endpoint );
+	if ( null === $response ) {
+		return null;
+	}
+
+	$users = $response->users ?? ( is_array( $response ) ? ( $response['users'] ?? null ) : null );
+	return is_array( $users ) ? $users : null;
 }
 
 /**

--- a/mcp-server.php
+++ b/mcp-server.php
@@ -1,0 +1,76 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Team51 CLI - MCP Server Entry Point
+ *
+ * This script starts an MCP (Model Context Protocol) server that exposes
+ * Team51 CLI functionality as tools for AI assistants.
+ *
+ * It uses stdio transport, meaning the server communicates via STDIN/STDOUT
+ * using JSON-RPC. All debug output MUST go to STDERR.
+ *
+ * Usage:
+ *   php mcp-server.php
+ *
+ * Configuration (in .cursor/mcp.json):
+ *   {
+ *     "mcpServers": {
+ *       "team51": {
+ *         "command": "php",
+ *         "args": ["/path/to/team51-cli/mcp-server.php"]
+ *       }
+ *     }
+ *   }
+ */
+
+use PhpMcp\Server\Server;
+use PhpMcp\Server\Transports\StdioServerTransport;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\StreamOutput;
+
+// Set up constants needed by the CLI environment.
+const TEAM51_CLI_ROOT_DIR = __DIR__;
+const TEAM51_CLI_FILE     = __FILE__;
+
+// Load Composer autoloader (skip self-update.php — we don't want update checks or ASCII art in MCP mode).
+require_once TEAM51_CLI_ROOT_DIR . '/vendor/autoload.php';
+
+// Set up global output to STDERR so that helper functions (like console_writeln)
+// don't pollute STDOUT, which is reserved for JSON-RPC communication.
+$team51_cli_output = new StreamOutput( fopen( 'php://stderr', 'w' ) );
+
+// Mark as non-autocomplete so that identity loading proceeds.
+$GLOBALS['team51_is_autocomplete'] = false;
+
+// Load the Team51 identity (1Password credentials).
+// This is required for all API calls to work.
+try {
+	require_once TEAM51_CLI_ROOT_DIR . '/load-identity.php';
+} catch ( \Throwable $e ) {
+	fwrite( STDERR, "[MCP] Failed to load identity: {$e->getMessage()}\n" );
+	exit( 1 );
+}
+
+fwrite( STDERR, "[MCP] Identity loaded. Starting MCP server...\n" );
+
+// Build and start the MCP server.
+try {
+	$server = Server::make()
+		->withServerInfo( 'Team51 CLI', '1.0.0' )
+		->build();
+
+	// Discover MCP tools from the mcp/ directory.
+	$server->discover(
+		basePath: TEAM51_CLI_ROOT_DIR,
+		scanDirs: array( 'mcp' ),
+		excludeDirs: array( 'vendor', 'commands', 'includes' ),
+	);
+
+	// Start listening via stdio transport.
+	$transport = new StdioServerTransport();
+	$server->listen( $transport );
+} catch ( \Throwable $e ) {
+	fwrite( STDERR, "[MCP CRITICAL] {$e->getMessage()}\n" );
+	fwrite( STDERR, $e->getTraceAsString() . "\n" );
+	exit( 1 );
+}

--- a/mcp-server.php
+++ b/mcp-server.php
@@ -10,14 +10,15 @@
  * using JSON-RPC. All debug output MUST go to STDERR.
  *
  * Usage:
+ *   team51 --mcp
  *   php mcp-server.php
  *
- * Configuration (in .cursor/mcp.json):
+ * Configuration (in .cursor/mcp.json or .mcp.json):
  *   {
  *     "mcpServers": {
  *       "team51": {
- *         "command": "php",
- *         "args": ["/path/to/team51-cli/mcp-server.php"]
+ *         "command": "team51",
+ *         "args": ["--mcp"]
  *       }
  *     }
  *   }
@@ -25,12 +26,16 @@
 
 use PhpMcp\Server\Server;
 use PhpMcp\Server\Transports\StdioServerTransport;
-use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\StreamOutput;
 
 // Set up constants needed by the CLI environment.
-const TEAM51_CLI_ROOT_DIR = __DIR__;
-const TEAM51_CLI_FILE     = __FILE__;
+// When invoked via `team51 --mcp`, these are already defined by team51-cli.php.
+if ( ! defined( 'TEAM51_CLI_ROOT_DIR' ) ) {
+	define( 'TEAM51_CLI_ROOT_DIR', __DIR__ );
+}
+if ( ! defined( 'TEAM51_CLI_FILE' ) ) {
+	define( 'TEAM51_CLI_FILE', __FILE__ );
+}
 
 // Load Composer autoloader (skip self-update.php — we don't want update checks or ASCII art in MCP mode).
 require_once TEAM51_CLI_ROOT_DIR . '/vendor/autoload.php';

--- a/mcp/Team51McpTools.php
+++ b/mcp/Team51McpTools.php
@@ -1,0 +1,525 @@
+<?php
+
+namespace WPCOMSpecialProjects\CLI\Mcp;
+
+use PhpMcp\Server\Attributes\McpTool;
+
+/**
+ * MCP Tool definitions for the Team51 CLI.
+ *
+ * These tools expose read-only (and select write) operations from the Team51 CLI
+ * as MCP tools, allowing AI assistants to interact with WPCOM, Pressable,
+ * GitHub, Jetpack, and DeployHQ services.
+ *
+ * IMPORTANT: When adding new tools, keep in mind that STDOUT is reserved for
+ * JSON-RPC communication. Use STDERR for any debug output.
+ */
+final class Team51McpTools {
+
+	// region WPCOM TOOLS
+
+	/**
+	 * List all sites connected to the team's WordPress.com account.
+	 * Returns site ID, name, URL, and connection type for each site.
+	 *
+	 * @param string $type Filter by site type: 'all' (default), 'jetpack', or 'agency'.
+	 */
+	#[McpTool( name: 'wpcom_list_sites' )]
+	public function wpcom_list_sites( string $type = 'all' ): array {
+		$params = array();
+		if ( 'all' !== $type ) {
+			$params['type'] = $type;
+		}
+
+		$sites = get_wpcom_sites( $params );
+		if ( null === $sites ) {
+			return array( 'error' => 'Failed to fetch WPCOM sites.' );
+		}
+
+		return array(
+			'count' => count( $sites ),
+			'sites' => array_map(
+				static function ( $site ) {
+					return array(
+						'id'              => $site->ID ?? $site->userblog_id ?? $site->id ?? null,
+						'name'            => $site->name ?? null,
+						'url'             => $site->URL ?? $site->siteurl ?? null, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+						'is_private'      => $site->is_private ?? null,
+						'is_coming_soon'  => $site->is_coming_soon ?? null,
+						'is_wpcom_atomic' => $site->is_wpcom_atomic ?? null,
+						'jetpack'         => $site->jetpack ?? null,
+					);
+				},
+				array_values( $sites )
+			),
+		);
+	}
+
+	/**
+	 * Get details about a specific WordPress.com site by domain or site ID.
+	 *
+	 * @param string $site_id_or_url The domain name or WPCOM site ID.
+	 */
+	#[McpTool( name: 'wpcom_get_site' )]
+	public function wpcom_get_site( string $site_id_or_url ): array {
+		$site = get_wpcom_site( $site_id_or_url );
+		if ( null === $site ) {
+			return array( 'error' => "Failed to fetch WPCOM site: $site_id_or_url" );
+		}
+
+		return (array) $site;
+	}
+
+	/**
+	 * List plugins installed on a specific WordPress.com or Jetpack-connected site.
+	 *
+	 * @param string $site_id_or_domain The domain name or WPCOM site ID.
+	 */
+	#[McpTool( name: 'wpcom_list_site_plugins' )]
+	public function wpcom_list_site_plugins( string $site_id_or_domain ): array {
+		$plugins = get_wpcom_site_plugins( $site_id_or_domain );
+		if ( null === $plugins ) {
+			return array( 'error' => "Failed to fetch plugins for site: $site_id_or_domain" );
+		}
+
+		return array(
+			'count'   => count( $plugins ),
+			'plugins' => array_map(
+				static function ( string $plugin_file, $plugin_data ) {
+					return array(
+						'file'        => $plugin_file,
+						'name'        => $plugin_data->Name, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+						'slug'        => dirname( $plugin_file ),
+						'version'     => $plugin_data->Version, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+						'active'      => $plugin_data->active,
+						'text_domain' => $plugin_data->TextDomain ?? null, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+					);
+				},
+				array_keys( $plugins ),
+				array_values( $plugins )
+			),
+		);
+	}
+
+	/**
+	 * List stickers (tags/labels) associated with a WordPress.com site.
+	 *
+	 * @param string $site_id_or_domain The domain name or WPCOM site ID.
+	 */
+	#[McpTool( name: 'wpcom_list_site_stickers' )]
+	public function wpcom_list_site_stickers( string $site_id_or_domain ): array {
+		$stickers = get_wpcom_site_stickers( $site_id_or_domain );
+		if ( null === $stickers ) {
+			return array( 'error' => "Failed to fetch stickers for site: $site_id_or_domain" );
+		}
+
+		return array(
+			'count'    => count( $stickers ),
+			'stickers' => $stickers,
+		);
+	}
+
+	/**
+	 * List all WordPress.com sites that have a specific sticker applied.
+	 *
+	 * @param string $sticker The sticker name to search for.
+	 */
+	#[McpTool( name: 'wpcom_list_sites_with_sticker' )]
+	public function wpcom_list_sites_with_sticker( string $sticker ): array {
+		$sites = get_wpcom_sites_with_sticker( $sticker );
+		if ( null === $sites ) {
+			return array( 'error' => "Failed to fetch sites with sticker: $sticker" );
+		}
+
+		return array(
+			'count' => count( $sites ),
+			'sites' => array_map(
+				static function ( $site ) {
+					return array(
+						'id'   => $site->userblog_id ?? $site->ID ?? null,
+						'name' => $site->blogname ?? $site->name ?? null,
+						'url'  => $site->siteurl ?? $site->URL ?? null, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+					);
+				},
+				array_values( $sites )
+			),
+		);
+	}
+
+	/**
+	 * Get site statistics summary for a WordPress.com site.
+	 *
+	 * @param string $site_id_or_url The domain name or WPCOM site ID.
+	 */
+	#[McpTool( name: 'wpcom_get_site_stats' )]
+	public function wpcom_get_site_stats( string $site_id_or_url ): array {
+		$stats = get_wpcom_site_stats( $site_id_or_url );
+		if ( null === $stats ) {
+			return array( 'error' => "Failed to fetch stats for site: $site_id_or_url" );
+		}
+
+		return (array) $stats;
+	}
+
+	/**
+	 * List WordPress users on a WPCOM or Jetpack-connected site.
+	 *
+	 * @param string $site_id_or_url The domain name or WPCOM site ID.
+	 */
+	#[McpTool( name: 'wpcom_list_site_users' )]
+	public function wpcom_list_site_users( string $site_id_or_url ): array {
+		$users = get_wpcom_site_users( $site_id_or_url );
+		if ( null === $users ) {
+			return array( 'error' => "Failed to fetch users for site: $site_id_or_url" );
+		}
+
+		return array(
+			'count' => count( $users ),
+			'users' => array_map(
+				static fn( $user ) => (array) $user,
+				$users
+			),
+		);
+	}
+
+	// endregion
+
+	// region PRESSABLE TOOLS
+
+	/**
+	 * List all Pressable hosting sites.
+	 */
+	#[McpTool( name: 'pressable_list_sites' )]
+	public function pressable_list_sites(): array {
+		$sites = get_pressable_sites();
+		if ( null === $sites ) {
+			return array( 'error' => 'Failed to fetch Pressable sites.' );
+		}
+
+		return array(
+			'count' => count( $sites ),
+			'sites' => array_map(
+				static function ( $site ) {
+					return array(
+						'id'          => $site->id,
+						'name'        => $site->name,
+						'url'         => $site->url,
+						'state'       => $site->state ?? null,
+						'datacenter'  => $site->datacenterCode ?? null, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+					);
+				},
+				$sites
+			),
+		);
+	}
+
+	/**
+	 * Get details about a specific Pressable site by ID or URL.
+	 *
+	 * @param string $site_id_or_url The Pressable site ID or URL.
+	 */
+	#[McpTool( name: 'pressable_get_site' )]
+	public function pressable_get_site( string $site_id_or_url ): array {
+		$site = get_pressable_site( $site_id_or_url );
+		if ( null === $site ) {
+			return array( 'error' => "Failed to fetch Pressable site: $site_id_or_url" );
+		}
+
+		return (array) $site;
+	}
+
+	/**
+	 * Get PHP error logs for a Pressable site.
+	 *
+	 * @param string $site_id      The Pressable site ID.
+	 * @param int    $max_entries  Maximum number of log entries to return (default: 200).
+	 */
+	#[McpTool( name: 'pressable_get_php_errors' )]
+	public function pressable_get_php_errors( string $site_id, int $max_entries = 200 ): array {
+		$errors = get_pressable_site_php_logs( $site_id, null, $max_entries );
+		if ( null === $errors ) {
+			return array( 'error' => "Failed to fetch PHP errors for Pressable site: $site_id" );
+		}
+
+		return array(
+			'count'  => count( $errors ),
+			'errors' => $errors,
+		);
+	}
+
+	/**
+	 * List collaborators on a Pressable account.
+	 */
+	#[McpTool( name: 'pressable_list_collaborators' )]
+	public function pressable_list_collaborators(): array {
+		$collaborators = get_pressable_collaborators();
+		if ( null === $collaborators ) {
+			return array( 'error' => 'Failed to fetch Pressable collaborators.' );
+		}
+
+		return array(
+			'count'         => count( $collaborators ),
+			'collaborators' => array_map(
+				static fn( $c ) => (array) $c,
+				$collaborators
+			),
+		);
+	}
+
+	/**
+	 * List SFTP users for a Pressable site.
+	 *
+	 * @param string $site_id_or_url The Pressable site ID or URL.
+	 */
+	#[McpTool( name: 'pressable_list_sftp_users' )]
+	public function pressable_list_sftp_users( string $site_id_or_url ): array {
+		$users = get_pressable_site_sftp_users( $site_id_or_url );
+		if ( null === $users ) {
+			return array( 'error' => "Failed to fetch SFTP users for site: $site_id_or_url" );
+		}
+
+		return array(
+			'count' => count( $users ),
+			'users' => array_map(
+				static fn( $u ) => (array) $u,
+				$users
+			),
+		);
+	}
+
+	/**
+	 * List domains configured for a Pressable site.
+	 *
+	 * @param string $site_id_or_url The Pressable site ID or URL.
+	 */
+	#[McpTool( name: 'pressable_list_site_domains' )]
+	public function pressable_list_site_domains( string $site_id_or_url ): array {
+		$domains = get_pressable_site_domains( $site_id_or_url );
+		if ( null === $domains ) {
+			return array( 'error' => "Failed to fetch domains for site: $site_id_or_url" );
+		}
+
+		return array(
+			'count'   => count( $domains ),
+			'domains' => array_map(
+				static fn( $d ) => (array) $d,
+				$domains
+			),
+		);
+	}
+
+	// endregion
+
+	// region GITHUB TOOLS
+
+	/**
+	 * List all GitHub repositories in the organization.
+	 */
+	#[McpTool( name: 'github_list_repositories' )]
+	public function github_list_repositories(): array {
+		$repos = get_github_repositories();
+		if ( null === $repos ) {
+			return array( 'error' => 'Failed to fetch GitHub repositories.' );
+		}
+
+		return array(
+			'count'        => count( $repos ),
+			'repositories' => array_map(
+				static function ( $repo ) {
+					return array(
+						'name'        => $repo->name ?? null,
+						'full_name'   => $repo->full_name ?? null,
+						'description' => $repo->description ?? null,
+						'url'         => $repo->html_url ?? null,
+						'private'     => $repo->private ?? null,
+						'archived'    => $repo->archived ?? null,
+					);
+				},
+				$repos
+			),
+		);
+	}
+
+	/**
+	 * Get details about a specific GitHub repository.
+	 *
+	 * @param string $repository The repository name (e.g., 'my-repo' without the org prefix).
+	 */
+	#[McpTool( name: 'github_get_repository' )]
+	public function github_get_repository( string $repository ): array {
+		$repo = get_github_repository( $repository );
+		if ( null === $repo ) {
+			return array( 'error' => "Failed to fetch GitHub repository: $repository" );
+		}
+
+		return (array) $repo;
+	}
+
+	/**
+	 * List branches of a GitHub repository.
+	 *
+	 * @param string $repository The repository name.
+	 */
+	#[McpTool( name: 'github_list_branches' )]
+	public function github_list_branches( string $repository ): array {
+		$branches = get_github_repository_branches( $repository );
+		if ( null === $branches ) {
+			return array( 'error' => "Failed to fetch branches for repository: $repository" );
+		}
+
+		return array(
+			'count'    => count( $branches ),
+			'branches' => array_map(
+				static fn( $b ) => (array) $b,
+				$branches
+			),
+		);
+	}
+
+	/**
+	 * List secrets configured for a GitHub repository.
+	 *
+	 * @param string $repository The repository name.
+	 */
+	#[McpTool( name: 'github_list_secrets' )]
+	public function github_list_secrets( string $repository ): array {
+		$secrets = get_github_repository_secrets( $repository );
+		if ( null === $secrets ) {
+			return array( 'error' => "Failed to fetch secrets for repository: $repository" );
+		}
+
+		return array(
+			'count'   => count( $secrets ),
+			'secrets' => array_map(
+				static fn( $s ) => (array) $s,
+				$secrets
+			),
+		);
+	}
+
+	/**
+	 * List recent workflow runs for a GitHub repository.
+	 *
+	 * @param string $repository The repository name.
+	 */
+	#[McpTool( name: 'github_list_workflow_runs' )]
+	public function github_list_workflow_runs( string $repository ): array {
+		$runs = get_github_repository_workflow_runs( $repository );
+		if ( null === $runs ) {
+			return array( 'error' => "Failed to fetch workflow runs for repository: $repository" );
+		}
+
+		return array(
+			'count' => count( $runs ),
+			'runs'  => array_map(
+				static fn( $r ) => (array) $r,
+				$runs
+			),
+		);
+	}
+
+	// endregion
+
+	// region JETPACK TOOLS
+
+	/**
+	 * List all available Jetpack modules with their descriptions and status info.
+	 */
+	#[McpTool( name: 'jetpack_list_modules' )]
+	public function jetpack_list_modules(): array {
+		$modules = get_jetpack_modules();
+		if ( null === $modules ) {
+			return array( 'error' => 'Failed to fetch Jetpack modules.' );
+		}
+
+		return array(
+			'count'   => count( $modules ),
+			'modules' => array_map(
+				static fn( $m ) => (array) $m,
+				$modules
+			),
+		);
+	}
+
+	/**
+	 * List Jetpack modules and their status for a specific site.
+	 *
+	 * @param string $site_id_or_url The WPCOM site ID or domain.
+	 */
+	#[McpTool( name: 'jetpack_list_site_modules' )]
+	public function jetpack_list_site_modules( string $site_id_or_url ): array {
+		$modules = get_jetpack_site_modules( $site_id_or_url );
+		if ( null === $modules ) {
+			return array( 'error' => "Failed to fetch Jetpack modules for site: $site_id_or_url" );
+		}
+
+		return array(
+			'count'   => count( $modules ),
+			'modules' => array_map(
+				static fn( $m ) => (array) $m,
+				$modules
+			),
+		);
+	}
+
+	// endregion
+
+	// region DEPLOYHQ TOOLS
+
+	/**
+	 * List all DeployHQ projects.
+	 */
+	#[McpTool( name: 'deployhq_list_projects' )]
+	public function deployhq_list_projects(): array {
+		$projects = get_deployhq_projects();
+		if ( null === $projects ) {
+			return array( 'error' => 'Failed to fetch DeployHQ projects.' );
+		}
+
+		return array(
+			'count'    => count( $projects ),
+			'projects' => array_map(
+				static fn( $p ) => (array) $p,
+				$projects
+			),
+		);
+	}
+
+	/**
+	 * Get details about a specific DeployHQ project.
+	 *
+	 * @param string $project The DeployHQ project permalink/slug.
+	 */
+	#[McpTool( name: 'deployhq_get_project' )]
+	public function deployhq_get_project( string $project ): array {
+		$proj = get_deployhq_project( $project );
+		if ( null === $proj ) {
+			return array( 'error' => "Failed to fetch DeployHQ project: $project" );
+		}
+
+		return (array) $proj;
+	}
+
+	/**
+	 * List servers configured for a DeployHQ project.
+	 *
+	 * @param string $project The DeployHQ project permalink/slug.
+	 */
+	#[McpTool( name: 'deployhq_list_project_servers' )]
+	public function deployhq_list_project_servers( string $project ): array {
+		$servers = get_deployhq_project_servers( $project );
+		if ( null === $servers ) {
+			return array( 'error' => "Failed to fetch servers for project: $project" );
+		}
+
+		return array(
+			'count'   => count( $servers ),
+			'servers' => array_map(
+				static fn( $s ) => (array) $s,
+				$servers
+			),
+		);
+	}
+
+	// endregion
+}

--- a/mcp/Team51McpTools.php
+++ b/mcp/Team51McpTools.php
@@ -181,6 +181,12 @@ final class Team51McpTools {
 		if ( null === $users ) {
 			return array( 'error' => "Failed to fetch users for site: $site_id_or_url" );
 		}
+		if ( ! is_array( $users ) ) {
+			return array(
+				'error'   => 'Unexpected response from get_wpcom_site_users',
+				'details' => $users,
+			);
+		}
 
 		return array(
 			'count' => count( $users ),

--- a/mcp/Team51McpTools.php
+++ b/mcp/Team51McpTools.php
@@ -3,13 +3,17 @@
 namespace WPCOMSpecialProjects\CLI\Mcp;
 
 use PhpMcp\Server\Attributes\McpTool;
+use PhpMcp\Schema\ToolAnnotations;
 
 /**
  * MCP Tool definitions for the Team51 CLI.
  *
- * These tools expose read-only (and select write) operations from the Team51 CLI
- * as MCP tools, allowing AI assistants to interact with WPCOM, Pressable,
- * GitHub, Jetpack, and DeployHQ services.
+ * These tools expose read-only and low/medium-risk write operations from the
+ * Team51 CLI as MCP tools, allowing AI assistants to interact with WPCOM,
+ * Pressable, GitHub, Jetpack, and DeployHQ services.
+ *
+ * High-risk operations (site creation, user deletion, WP-CLI execution,
+ * deployments) are intentionally excluded. See the README for details.
  *
  * IMPORTANT: When adding new tools, keep in mind that STDOUT is reserved for
  * JSON-RPC communication. Use STDERR for any debug output.
@@ -182,6 +186,126 @@ final class Team51McpTools {
 		);
 	}
 
+	/**
+	 * Add a sticker (tag/label) to a WordPress.com site.
+	 *
+	 * @param string $site_id_or_domain The domain name or WPCOM site ID.
+	 * @param string $sticker           The sticker name to add.
+	 */
+	#[McpTool(
+		name: 'wpcom_add_sticker',
+		annotations: new ToolAnnotations(
+			title: 'Add WPCOM Site Sticker',
+			readOnlyHint: false,
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true,
+		)
+	)]
+	public function wpcom_add_sticker( string $site_id_or_domain, string $sticker ): array {
+		$result = add_wpcom_site_sticker( $site_id_or_domain, $sticker );
+		if ( null === $result ) {
+			return array( 'error' => "Failed to add sticker '$sticker' to site: $site_id_or_domain" );
+		}
+
+		return array(
+			'success' => true,
+			'site'    => $site_id_or_domain,
+			'sticker' => $sticker,
+			'action'  => 'added',
+		);
+	}
+
+	/**
+	 * Remove a sticker (tag/label) from a WordPress.com site.
+	 *
+	 * @param string $site_id_or_domain The domain name or WPCOM site ID.
+	 * @param string $sticker           The sticker name to remove.
+	 */
+	#[McpTool(
+		name: 'wpcom_remove_sticker',
+		annotations: new ToolAnnotations(
+			title: 'Remove WPCOM Site Sticker',
+			readOnlyHint: false,
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true,
+		)
+	)]
+	public function wpcom_remove_sticker( string $site_id_or_domain, string $sticker ): array {
+		$result = remove_wpcom_site_sticker( $site_id_or_domain, $sticker );
+		if ( null === $result ) {
+			return array( 'error' => "Failed to remove sticker '$sticker' from site: $site_id_or_domain" );
+		}
+
+		return array(
+			'success' => true,
+			'site'    => $site_id_or_domain,
+			'sticker' => $sticker,
+			'action'  => 'removed',
+		);
+	}
+
+	/**
+	 * Update settings for a WordPress.com site.
+	 *
+	 * @param string $site_id_or_url The domain name or WPCOM site ID.
+	 * @param string $settings_json  JSON object of settings to update (e.g. {"blogname": "New Name"}).
+	 */
+	#[McpTool(
+		name: 'wpcom_update_site',
+		annotations: new ToolAnnotations(
+			title: 'Update WPCOM Site Settings',
+			readOnlyHint: false,
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true,
+		)
+	)]
+	public function wpcom_update_site( string $site_id_or_url, string $settings_json ): array {
+		$settings = json_decode( $settings_json, true );
+		if ( null === $settings || ! is_array( $settings ) ) {
+			return array( 'error' => 'Invalid settings_json. Must be a valid JSON object.' );
+		}
+
+		$result = update_wpcom_site( $site_id_or_url, $settings );
+		if ( null === $result ) {
+			return array( 'error' => "Failed to update site settings for: $site_id_or_url" );
+		}
+
+		return array(
+			'success'          => true,
+			'site'             => $site_id_or_url,
+			'updated_settings' => $settings,
+		);
+	}
+
+	/**
+	 * Rotate the SFTP user password for a WordPress.com site.
+	 * Returns the new credentials.
+	 *
+	 * @param string $site_id_or_url The domain name or WPCOM site ID.
+	 * @param string $username       The SFTP username to rotate the password for.
+	 */
+	#[McpTool(
+		name: 'wpcom_rotate_sftp_password',
+		annotations: new ToolAnnotations(
+			title: 'Rotate WPCOM SFTP Password',
+			readOnlyHint: false,
+			destructiveHint: true,
+			idempotentHint: false,
+			openWorldHint: true,
+		)
+	)]
+	public function wpcom_rotate_sftp_password( string $site_id_or_url, string $username ): array {
+		$result = rotate_wpcom_site_sftp_user_password( $site_id_or_url, $username );
+		if ( null === $result ) {
+			return array( 'error' => "Failed to rotate SFTP password for user '$username' on site: $site_id_or_url" );
+		}
+
+		return (array) $result;
+	}
+
 	// endregion
 
 	// region PRESSABLE TOOLS
@@ -308,6 +432,144 @@ final class Team51McpTools {
 		);
 	}
 
+	/**
+	 * Create a note on a Pressable site. Useful for documenting changes or issues.
+	 *
+	 * @param string $site_id_or_url The Pressable site ID or URL.
+	 * @param string $subject        The note subject/title.
+	 * @param string $content        The note content/body.
+	 */
+	#[McpTool(
+		name: 'pressable_create_site_note',
+		annotations: new ToolAnnotations(
+			title: 'Create Pressable Site Note',
+			readOnlyHint: false,
+			destructiveHint: false,
+			idempotentHint: false,
+			openWorldHint: true,
+		)
+	)]
+	public function pressable_create_site_note( string $site_id_or_url, string $subject, string $content ): array {
+		$result = create_pressable_site_note( $site_id_or_url, $subject, $content );
+		if ( null === $result ) {
+			return array( 'error' => "Failed to create note on Pressable site: $site_id_or_url" );
+		}
+
+		return (array) $result;
+	}
+
+	/**
+	 * Add a collaborator to a Pressable site by email address.
+	 *
+	 * @param string $site_id_or_url    The Pressable site ID or URL.
+	 * @param string $collaborator_email The email address of the collaborator to add.
+	 */
+	#[McpTool(
+		name: 'pressable_add_collaborator',
+		annotations: new ToolAnnotations(
+			title: 'Add Pressable Site Collaborator',
+			readOnlyHint: false,
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true,
+		)
+	)]
+	public function pressable_add_collaborator( string $site_id_or_url, string $collaborator_email ): array {
+		$result = create_pressable_site_collaborator( $site_id_or_url, $collaborator_email );
+		if ( null === $result ) {
+			return array( 'error' => "Failed to add collaborator '$collaborator_email' to site: $site_id_or_url" );
+		}
+
+		return (array) $result;
+	}
+
+	/**
+	 * Remove a collaborator from a Pressable site.
+	 *
+	 * @param string $site_id_or_url The Pressable site ID or URL.
+	 * @param string $collaborator   The collaborator ID or email to remove.
+	 * @param bool   $delete_wp_user Whether to also delete the collaborator's WordPress user account.
+	 */
+	#[McpTool(
+		name: 'pressable_remove_collaborator',
+		annotations: new ToolAnnotations(
+			title: 'Remove Pressable Site Collaborator',
+			readOnlyHint: false,
+			destructiveHint: true,
+			idempotentHint: true,
+			openWorldHint: true,
+		)
+	)]
+	public function pressable_remove_collaborator( string $site_id_or_url, string $collaborator, bool $delete_wp_user = false ): array {
+		$result = delete_pressable_site_collaborator( $site_id_or_url, $collaborator, $delete_wp_user );
+		if ( null === $result ) {
+			return array( 'error' => "Failed to remove collaborator '$collaborator' from site: $site_id_or_url" );
+		}
+
+		return array(
+			'success'        => true,
+			'site'           => $site_id_or_url,
+			'collaborator'   => $collaborator,
+			'wp_user_deleted' => $delete_wp_user,
+		);
+	}
+
+	/**
+	 * Add a domain to a Pressable site.
+	 *
+	 * @param string $site_id_or_url The Pressable site ID or URL.
+	 * @param string $domain         The domain name to add (e.g., 'example.com').
+	 */
+	#[McpTool(
+		name: 'pressable_add_domain',
+		annotations: new ToolAnnotations(
+			title: 'Add Domain to Pressable Site',
+			readOnlyHint: false,
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true,
+		)
+	)]
+	public function pressable_add_domain( string $site_id_or_url, string $domain ): array {
+		$result = add_pressable_site_domain( $site_id_or_url, $domain );
+		if ( null === $result ) {
+			return array( 'error' => "Failed to add domain '$domain' to site: $site_id_or_url" );
+		}
+
+		return array(
+			'success' => true,
+			'site'    => $site_id_or_url,
+			'domain'  => $domain,
+			'domains' => $result,
+		);
+	}
+
+	/**
+	 * Rotate the SFTP user password for a Pressable site.
+	 * Returns the new credentials.
+	 *
+	 * @param string $site_id_or_url The Pressable site ID or URL.
+	 * @param string $username       The SFTP username to rotate the password for.
+	 */
+	#[McpTool(
+		name: 'pressable_rotate_sftp_password',
+		annotations: new ToolAnnotations(
+			title: 'Rotate Pressable SFTP Password',
+			readOnlyHint: false,
+			destructiveHint: true,
+			idempotentHint: false,
+			openWorldHint: true,
+		)
+	)]
+	public function pressable_rotate_sftp_password( string $site_id_or_url, string $username ): array {
+		$result = rotate_pressable_site_sftp_user_password( $site_id_or_url, $username );
+		if ( null === $result ) {
+			return array( 'error' => "Failed to rotate SFTP password for user '$username' on site: $site_id_or_url" );
+		}
+
+		return (array) $result;
+	}
+
 	// endregion
 
 	// region GITHUB TOOLS
@@ -418,6 +680,129 @@ final class Team51McpTools {
 		);
 	}
 
+	/**
+	 * Set topics/tags for a GitHub repository. Replaces all existing topics.
+	 *
+	 * @param string $repository  The repository name.
+	 * @param string $topics_json JSON array of topic strings (e.g., ["wordpress", "plugin"]).
+	 */
+	#[McpTool(
+		name: 'github_set_topics',
+		annotations: new ToolAnnotations(
+			title: 'Set GitHub Repository Topics',
+			readOnlyHint: false,
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true,
+		)
+	)]
+	public function github_set_topics( string $repository, string $topics_json ): array {
+		$topics = json_decode( $topics_json, true );
+		if ( null === $topics || ! is_array( $topics ) ) {
+			return array( 'error' => 'Invalid topics_json. Must be a JSON array of strings.' );
+		}
+
+		$result = set_github_repository_topics( $repository, $topics );
+		if ( null === $result ) {
+			return array( 'error' => "Failed to set topics for repository: $repository" );
+		}
+
+		return array(
+			'success'    => true,
+			'repository' => $repository,
+			'topics'     => $result,
+		);
+	}
+
+	/**
+	 * Create a new branch in a GitHub repository.
+	 *
+	 * @param string $repository The repository name.
+	 * @param string $name       The name for the new branch.
+	 * @param string $source     The source branch to create from (e.g., 'trunk').
+	 */
+	#[McpTool(
+		name: 'github_create_branch',
+		annotations: new ToolAnnotations(
+			title: 'Create GitHub Branch',
+			readOnlyHint: false,
+			destructiveHint: false,
+			idempotentHint: false,
+			openWorldHint: true,
+		)
+	)]
+	public function github_create_branch( string $repository, string $name, string $source = 'trunk' ): array {
+		$result = create_github_repository_branch( $repository, $name, $source );
+		if ( null === $result ) {
+			return array( 'error' => "Failed to create branch '$name' in repository: $repository" );
+		}
+
+		return (array) $result;
+	}
+
+	/**
+	 * Create or update a secret in a GitHub repository.
+	 *
+	 * @param string $repository   The repository name.
+	 * @param string $secret_name  The name of the secret.
+	 * @param string $secret_value The value to set for the secret.
+	 */
+	#[McpTool(
+		name: 'github_set_secret',
+		annotations: new ToolAnnotations(
+			title: 'Set GitHub Repository Secret',
+			readOnlyHint: false,
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true,
+		)
+	)]
+	public function github_set_secret( string $repository, string $secret_name, string $secret_value ): array {
+		$result = set_github_repository_secret( $repository, $secret_name, $secret_value );
+		if ( null === $result ) {
+			return array( 'error' => "Failed to set secret '$secret_name' in repository: $repository" );
+		}
+
+		return array(
+			'success'    => true,
+			'repository' => $repository,
+			'secret'     => $secret_name,
+			'action'     => 'set',
+		);
+	}
+
+	/**
+	 * Create a new issue in a GitHub repository.
+	 *
+	 * @param string $repository The repository name.
+	 * @param string $title      The issue title.
+	 * @param string $body       The issue body/description (supports Markdown).
+	 * @param string $labels_json JSON array of label strings (e.g., ["bug", "urgent"]). Optional, defaults to [].
+	 */
+	#[McpTool(
+		name: 'github_create_issue',
+		annotations: new ToolAnnotations(
+			title: 'Create GitHub Issue',
+			readOnlyHint: false,
+			destructiveHint: false,
+			idempotentHint: false,
+			openWorldHint: true,
+		)
+	)]
+	public function github_create_issue( string $repository, string $title, string $body, string $labels_json = '[]' ): array {
+		$labels = json_decode( $labels_json, true );
+		if ( null === $labels || ! is_array( $labels ) ) {
+			$labels = array();
+		}
+
+		$result = create_github_issue( $repository, $title, $body, $labels );
+		if ( null === $result ) {
+			return array( 'error' => "Failed to create issue in repository: $repository" );
+		}
+
+		return (array) $result;
+	}
+
 	// endregion
 
 	// region JETPACK TOOLS
@@ -459,6 +844,41 @@ final class Team51McpTools {
 				static fn( $m ) => (array) $m,
 				$modules
 			),
+		);
+	}
+
+	/**
+	 * Update Jetpack module settings for a site. Use this to enable or disable
+	 * specific Jetpack modules.
+	 *
+	 * @param string $site_id_or_url The WPCOM site ID or domain.
+	 * @param string $settings_json  JSON object of module settings (e.g., {"module-name": true} to enable, false to disable).
+	 */
+	#[McpTool(
+		name: 'jetpack_update_module_settings',
+		annotations: new ToolAnnotations(
+			title: 'Update Jetpack Module Settings',
+			readOnlyHint: false,
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true,
+		)
+	)]
+	public function jetpack_update_module_settings( string $site_id_or_url, string $settings_json ): array {
+		$settings = json_decode( $settings_json, true );
+		if ( null === $settings || ! is_array( $settings ) ) {
+			return array( 'error' => 'Invalid settings_json. Must be a valid JSON object (e.g., {"module-name": true}).' );
+		}
+
+		$result = update_jetpack_site_modules_settings( $site_id_or_url, $settings );
+		if ( null === $result ) {
+			return array( 'error' => "Failed to update Jetpack module settings for site: $site_id_or_url" );
+		}
+
+		return array(
+			'success'          => $result,
+			'site'             => $site_id_or_url,
+			'updated_settings' => $settings,
 		);
 	}
 
@@ -519,6 +939,55 @@ final class Team51McpTools {
 				$servers
 			),
 		);
+	}
+
+	/**
+	 * Rotate the SSH private key for a DeployHQ project.
+	 *
+	 * @param string $project The DeployHQ project permalink/slug.
+	 */
+	#[McpTool(
+		name: 'deployhq_rotate_private_key',
+		annotations: new ToolAnnotations(
+			title: 'Rotate DeployHQ Project Private Key',
+			readOnlyHint: false,
+			destructiveHint: true,
+			idempotentHint: false,
+			openWorldHint: true,
+		)
+	)]
+	public function deployhq_rotate_private_key( string $project ): array {
+		$result = rotate_deployhq_project_private_key( $project );
+		if ( null === $result ) {
+			return array( 'error' => "Failed to rotate private key for DeployHQ project: $project" );
+		}
+
+		return (array) $result;
+	}
+
+	/**
+	 * Update the connected GitHub repository for a DeployHQ project.
+	 *
+	 * @param string $project    The DeployHQ project permalink/slug.
+	 * @param string $repository The SSH URL of the GitHub repository to connect.
+	 */
+	#[McpTool(
+		name: 'deployhq_connect_repository',
+		annotations: new ToolAnnotations(
+			title: 'Connect Repository to DeployHQ Project',
+			readOnlyHint: false,
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true,
+		)
+	)]
+	public function deployhq_connect_repository( string $project, string $repository ): array {
+		$result = update_deployhq_project_repository( $project, $repository );
+		if ( null === $result ) {
+			return array( 'error' => "Failed to connect repository to DeployHQ project: $project" );
+		}
+
+		return (array) $result;
 	}
 
 	// endregion

--- a/mcp/Team51McpTools.php
+++ b/mcp/Team51McpTools.php
@@ -90,10 +90,15 @@ final class Team51McpTools {
 			'count'   => count( $plugins ),
 			'plugins' => array_map(
 				static function ( string $plugin_file, $plugin_data ) {
+					$plugin_dir = dirname( $plugin_file );
+					$slug       = ( '.' === $plugin_dir || '' === $plugin_dir )
+						? basename( $plugin_file, '.php' )
+						: $plugin_dir;
+
 					return array(
 						'file'        => $plugin_file,
 						'name'        => $plugin_data->Name, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-						'slug'        => dirname( $plugin_file ),
+						'slug'        => $slug,
 						'version'     => $plugin_data->Version, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 						'active'      => $plugin_data->active,
 						'text_domain' => $plugin_data->TextDomain ?? null, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase

--- a/mcp/Team51McpTools.php
+++ b/mcp/Team51McpTools.php
@@ -371,6 +371,10 @@ final class Team51McpTools {
 	 */
 	#[McpTool( name: 'pressable_get_php_errors' )]
 	public function pressable_get_php_errors( string $site_id, int $max_entries = 200 ): array {
+		if ( $max_entries < 1 ) {
+			return array( 'error' => 'max_entries must be a positive integer' );
+		}
+
 		$errors = get_pressable_site_php_logs( $site_id, null, $max_entries );
 		if ( null === $errors ) {
 			return array( 'error' => "Failed to fetch PHP errors for Pressable site: $site_id" );

--- a/team51-cli.php
+++ b/team51-cli.php
@@ -11,6 +11,13 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 
 const TEAM51_CLI_ROOT_DIR = __DIR__;
 const TEAM51_CLI_FILE     = __FILE__;
+
+// If --mcp flag is passed, start the MCP server instead of the CLI.
+if ( in_array( '--mcp', $argv ?? $_SERVER['argv'] ?? array(), true ) ) {
+	require __DIR__ . '/mcp-server.php';
+	exit;
+}
+
 require_once TEAM51_CLI_ROOT_DIR . '/self-update.php';
 require_once TEAM51_CLI_ROOT_DIR . '/vendor/autoload.php';
 


### PR DESCRIPTION
## Summary

- Adds a Model Context Protocol (MCP) server that exposes Team51 CLI functionality as structured tools for AI assistants (Cursor, Claude Code, etc.)
- Implements **39 MCP tools** across all services: 23 read-only + 16 low/medium-risk write tools
- Uses `php-mcp/server` with stdio transport; reuses existing helper functions from `includes/` — no logic duplication
- **Universal config**: Run via `team51 --mcp` — no hardcoded paths; works anywhere `team51` is installed

## Details

The MCP server starts via `team51 --mcp`, which is detected early in `team51-cli.php` (before self-update/ASCII art) and delegates to `mcp-server.php`. The server bootstraps the same environment (autoloader + 1Password credentials) but skips self-update. All `console_writeln` output goes to STDERR so STDOUT stays clean for JSON-RPC.

Tools are defined in `mcp/Team51McpTools.php` using PHP 8 attributes (`#[McpTool]`) and `ToolAnnotations` for write tools, and are auto-discovered by the server.

### Available tools

| Service   | Read tools | Write tools |
|-----------|------------|-------------|
| **WPCOM** | `wpcom_list_sites`, `wpcom_get_site`, `wpcom_list_site_plugins`, `wpcom_list_site_stickers`, `wpcom_list_sites_with_sticker`, `wpcom_get_site_stats`, `wpcom_list_site_users` | `wpcom_add_sticker`, `wpcom_remove_sticker`, `wpcom_update_site`, `wpcom_rotate_sftp_password` |
| **Pressable** | `pressable_list_sites`, `pressable_get_site`, `pressable_get_php_errors`, `pressable_list_collaborators`, `pressable_list_sftp_users`, `pressable_list_site_domains` | `pressable_create_site_note`, `pressable_add_collaborator`, `pressable_remove_collaborator`, `pressable_add_domain`, `pressable_rotate_sftp_password` |
| **GitHub** | `github_list_repositories`, `github_get_repository`, `github_list_branches`, `github_list_secrets`, `github_list_workflow_runs` | `github_set_topics`, `github_create_branch`, `github_set_secret`, `github_create_issue` |
| **Jetpack** | `jetpack_list_modules`, `jetpack_list_site_modules` | `jetpack_update_module_settings` |
| **DeployHQ** | `deployhq_list_projects`, `deployhq_get_project`, `deployhq_list_project_servers` | `deployhq_rotate_private_key`, `deployhq_connect_repository` |

Write tools use MCP `ToolAnnotations` (`destructiveHint`, `readOnlyHint`, etc.) so clients can prompt for confirmation before destructive actions. High-risk operations (site creation, user deletion, WP-CLI execution, deployments) are intentionally excluded.

### Configuration

**Cursor** (`.cursor/mcp.json`):
{
  "mcpServers": {
    "team51": {
      "command": "team51",
      "args": ["--mcp"]
    }
  }
}


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP Server integration exposing an AI-compatible JSON-RPC interface and a new CLI flag to start it
  * Large set of MCP tools for listing, inspecting, and performing management actions across WordPress.com, Pressable, GitHub, Jetpack, and DeployHQ

* **Bug Fixes**
  * Improved robustness when retrieving site user lists to handle varied API responses

* **Documentation**
  * Added MCP Server setup, usage, and extension guide in README

* **Chores**
  * Updated ignore rules for generated/build artifacts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->