### PR TITLE
Handle `site_already_exists` error and message

### DIFF
--- a/commands/WPCOM_Site_Create.php
+++ b/commands/WPCOM_Site_Create.php
@@ -111,8 +111,8 @@ final class WPCOM_Site_Create extends Command {
 
 		// Create the site and wait for it to be provisioned.
 		$agency_site = create_wpcom_site( $this->name );
-		if ( \is_null( $agency_site ) ) {
-			$output->writeln( '<error>Failed to create the site.</error>' );
+		if ( \is_null( $agency_site ) || isset( $agency_site->code ) && 'site_already_exists' === $agency_site->code ) {
+			$output->writeln( '<error>Failed to create the site.' . ( isset( $agency_site->message ) ? ' ' . $agency_site->message : '' ) . '</error>' );
 			return Command::FAILURE;
 		}
 

--- a/commands/WPCOM_Site_Create.php
+++ b/commands/WPCOM_Site_Create.php
@@ -111,8 +111,13 @@ final class WPCOM_Site_Create extends Command {
 
 		// Create the site and wait for it to be provisioned.
 		$agency_site = create_wpcom_site( $this->name );
-		if ( \is_null( $agency_site ) || isset( $agency_site->code ) && 'site_already_exists' === $agency_site->code ) {
-			$output->writeln( '<error>Failed to create the site.' . ( isset( $agency_site->message ) ? ' ' . $agency_site->message : '' ) . '</error>' );
+		if ( \is_null( $agency_site ) ) {
+			$output->writeln( '<error>Failed to create the site.</error>' );
+			return Command::FAILURE;
+		}
+
+		if ( isset( $agency_site->code ) && 'site_already_exists' === $agency_site->code ) {
+			$output->writeln( "<error>Failed to create the site. {$agency_site->message}.</error>" );
 			return Command::FAILURE;
 		}
 

--- a/includes/api-helper.php
+++ b/includes/api-helper.php
@@ -123,7 +123,7 @@ final class API_Helper {
 		if ( ! str_starts_with( (string) $result['headers']['http_code'], '2' ) ) {
 			if ( 500 === $result['headers']['http_code'] && str_contains( $result['body'], 'site_already_exists' ) ) {
 				console_writeln( "❌ API error ({$result['headers']['http_code']} $endpoint): " . $result['body'] );
-				return (object) array( 'code' => 'site_already_exists', 'message' => 'A site with that name already exists.' );
+				return (object) array( 'code' => 'site_already_exists', 'message' => 'A site with this name already exists' );
 			}
 
 			console_writeln( "❌ API error ({$result['headers']['http_code']} $endpoint): " . $result['body'] );

--- a/includes/api-helper.php
+++ b/includes/api-helper.php
@@ -121,6 +121,11 @@ final class API_Helper {
 		);
 
 		if ( ! str_starts_with( (string) $result['headers']['http_code'], '2' ) ) {
+			if ( 500 === $result['headers']['http_code'] && str_contains( $result['body'], 'site_already_exists' ) ) {
+				console_writeln( "❌ API error ({$result['headers']['http_code']} $endpoint): " . $result['body'] );
+				return (object) array( 'code' => 'site_already_exists', 'message' => 'A site with that name already exists.' );
+			}
+
 			console_writeln( "❌ API error ({$result['headers']['http_code']} $endpoint): " . $result['body'] );
 			return null;
 		}


### PR DESCRIPTION
This handles a special case when a site already exists and we want to display a nice message in the CLI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when creating a site that already exists — shows a specific, user-facing message instead of a generic failure.
  * Creation flow now stops earlier for duplicate-site cases, avoiding unnecessary waiting and providing immediate feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->