### PR TITLE
Improve theme selection process during new site or new repo.

### DIFF
--- a/commands/GitHub_Repository_Create.php
+++ b/commands/GitHub_Repository_Create.php
@@ -643,30 +643,7 @@ final class GitHub_Repository_Create extends Command {
 	 * @return  string|null
 	 */
 	private function prompt_no_code_theme_input( InputInterface $input, OutputInterface $output, array $themes ): ?string {
-		$theme_slugs  = array_map( fn( $theme ) => $theme->slug, $themes );
-		$theme_names  = array_map( fn( $theme ) => $theme->name, $themes );
-		$name_to_slug = array_combine( $theme_names, $theme_slugs );
-
-		$autocompleter_values = array_merge( $theme_slugs, $theme_names );
-
-		$question = new Question(
-			'<question>Please start typing the slug or name of the no-code theme to use. Choose "wpcom-theme" for internal or unlisted themes:</question> '
-		);
-		$question->setAutocompleterValues( $autocompleter_values );
-
-		$selected = $this->getHelper( 'question' )->ask( $input, $output, $question );
-
-		// Normalize input: if it's a name, convert to slug
-		if ( in_array( $selected, $theme_slugs, true ) ) {
-			return $selected;
-		}
-
-		if ( isset( $name_to_slug[ $selected ] ) ) {
-			return $name_to_slug[ $selected ];
-		}
-
-		$output->writeln( '<error>Invalid theme slug or name selected.</error>' );
-		return null;
+		return prompt_wporg_theme_input( $input, $output, $this->getHelper( 'question' ), $themes );
 	}
 
 	/**

--- a/commands/Pressable_Site_Create.php
+++ b/commands/Pressable_Site_Create.php
@@ -233,30 +233,7 @@ final class Pressable_Site_Create extends Command {
 	 * @return  string|null
 	 */
 	private function prompt_no_code_theme_input( InputInterface $input, OutputInterface $output, array $themes ): ?string {
-		$theme_slugs  = array_map( fn( $theme ) => $theme->slug, $themes );
-		$theme_names  = array_map( fn( $theme ) => $theme->name, $themes );
-		$name_to_slug = array_combine( $theme_names, $theme_slugs );
-
-		$autocompleter_values = array_merge( $theme_slugs, $theme_names );
-
-		$question = new Question(
-			'<question>Please start typing the slug or name of the no-code theme to use. Choose "wpcom-theme" for internal or unlisted themes:</question> '
-		);
-		$question->setAutocompleterValues( $autocompleter_values );
-
-		$selected = $this->getHelper( 'question' )->ask( $input, $output, $question );
-
-		// Normalize input: if it's a name, convert to slug
-		if ( in_array( $selected, $theme_slugs, true ) ) {
-			return $selected;
-		}
-
-		if ( isset( $name_to_slug[ $selected ] ) ) {
-			return $name_to_slug[ $selected ];
-		}
-
-		$output->writeln( '<error>Invalid theme slug or name selected.</error>' );
-		return null;
+		return prompt_wporg_theme_input( $input, $output, $this->getHelper( 'question' ), $themes );
 	}
 
 	/**

--- a/commands/WPCOM_Site_Create.php
+++ b/commands/WPCOM_Site_Create.php
@@ -346,30 +346,7 @@ final class WPCOM_Site_Create extends Command {
 	 * @return  string|null
 	 */
 	private function prompt_no_code_theme_input( InputInterface $input, OutputInterface $output, array $themes ): ?string {
-		$theme_slugs  = array_map( fn( $theme ) => $theme->slug, $themes );
-		$theme_names  = array_map( fn( $theme ) => $theme->name, $themes );
-		$name_to_slug = array_combine( $theme_names, $theme_slugs );
-
-		$autocompleter_values = array_merge( $theme_slugs, $theme_names );
-
-		$question = new Question(
-			'<question>Please start typing the slug or name of the no-code theme to use. Choose "wpcom-theme" for internal or unlisted themes:</question> '
-		);
-		$question->setAutocompleterValues( $autocompleter_values );
-
-		$selected = $this->getHelper( 'question' )->ask( $input, $output, $question );
-
-		// Normalize input: if it's a name, convert to slug
-		if ( in_array( $selected, $theme_slugs, true ) ) {
-			return $selected;
-		}
-
-		if ( isset( $name_to_slug[ $selected ] ) ) {
-			return $name_to_slug[ $selected ];
-		}
-
-		$output->writeln( '<error>Invalid theme slug or name selected.</error>' );
-		return null;
+		return prompt_wporg_theme_input( $input, $output, $this->getHelper( 'question' ), $themes );
 	}
 
 	// endregion

--- a/includes/functions-wporg.php
+++ b/includes/functions-wporg.php
@@ -1,6 +1,9 @@
 <?php
 
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
 
 // region API
 
@@ -32,4 +35,101 @@ function get_wporg_theme_choices(): array {
 		$valid_themes
 	);
 }
+
+// endregion
+
+// region HELPERS
+
+/**
+ * Prompts the user to select a WordPress.org theme with autocomplete, retry, and "did you mean?" suggestions.
+ *
+ * @param   InputInterface  $input           The input object.
+ * @param   OutputInterface $output          The output object.
+ * @param   QuestionHelper  $question_helper The question helper instance.
+ * @param   array           $themes          The list of available themes (objects with ->slug and ->name).
+ * @param   int             $max_attempts    Maximum number of attempts before giving up.
+ *
+ * @return  string|null The selected theme slug, or null if cancelled.
+ */
+function prompt_wporg_theme_input( InputInterface $input, OutputInterface $output, QuestionHelper $question_helper, array $themes, int $max_attempts = 5 ): ?string {
+	$theme_slugs  = array_map( fn( $theme ) => $theme->slug, $themes );
+	$theme_names  = array_map( fn( $theme ) => $theme->name, $themes );
+	$name_to_slug = array_combine( $theme_names, $theme_slugs );
+
+	$autocompleter_values = array_merge( $theme_slugs, $theme_names );
+
+	for ( $attempt = 0; $attempt < $max_attempts; $attempt++ ) {
+		$output->writeln( '<info>Type a theme slug or name. Use "wpcom-theme" for internal/unlisted themes.</info>' );
+		$question = new Question( '<question>Theme:</question> ' );
+		$question->setAutocompleterValues( $autocompleter_values );
+
+		$selected = $question_helper->ask( $input, $output, $question );
+
+		if ( null === $selected || '' === \trim( (string) $selected ) ) {
+			return null;
+		}
+
+		if ( \in_array( $selected, $theme_slugs, true ) ) {
+			return $selected;
+		}
+
+		if ( isset( $name_to_slug[ $selected ] ) ) {
+			return $name_to_slug[ $selected ];
+		}
+
+		$output->writeln( '<error>' . $selected . ' is not a valid theme slug or name.</error>' );
+
+		$suggestions = find_similar_wporg_themes( $selected, $autocompleter_values );
+
+		if ( ! empty( $suggestions ) ) {
+			$output->writeln( '<comment>Did you mean one of these?</comment>' );
+			foreach ( $suggestions as $suggestion ) {
+				$output->writeln( '  • ' . $suggestion );
+			}
+		} else {
+			$output->writeln( '<info>Available themes:</info>' );
+			foreach ( $themes as $theme ) {
+				$output->writeln( '  ' . $theme->slug . ' — ' . $theme->name );
+			}
+		}
+
+		$output->writeln( '' );
+	}
+
+	$output->writeln( '<error>Too many invalid attempts.</error>' );
+	return null;
+}
+
+/**
+ * Finds theme slugs/names similar to the given input using Levenshtein distance and substring matching.
+ *
+ * @param   string   $needle     The user's input.
+ * @param   string[] $candidates All valid slugs and names.
+ * @param   int      $max        Maximum number of suggestions to return.
+ *
+ * @return  string[]
+ */
+function find_similar_wporg_themes( string $needle, array $candidates, int $max = 5 ): array {
+	$needle_lower = \strtolower( $needle );
+	$scored       = array();
+
+	foreach ( $candidates as $candidate ) {
+		$candidate_lower = \strtolower( $candidate );
+
+		if ( \str_contains( $candidate_lower, $needle_lower ) || \str_contains( $needle_lower, $candidate_lower ) ) {
+			$scored[ $candidate ] = 0;
+			continue;
+		}
+
+		$distance  = \levenshtein( $needle_lower, $candidate_lower );
+		$threshold = (int) \max( 3, \strlen( $needle ) * 0.5 );
+		if ( $distance <= $threshold ) {
+			$scored[ $candidate ] = $distance;
+		}
+	}
+
+	\asort( $scored );
+	return \array_slice( \array_keys( $scored ), 0, $max );
+}
+
 // endregion


### PR DESCRIPTION
### Changes

These changes are related to the commands to create a New GitHub Repo, New Pressable Site and New WPCOM Site. There's a step in which the user needs to type in the `wporg` theme slug. 

This was confusing, so now"

- There's suggestions for theme slugs from the list pulled from wporg.
- If the user is wrong, the process does not continue with the site creation, instead, they are offered feedback.
- Add a method to find similar theme names/slugs based on user input.
- Update error handling for invalid selections.

<img width="1093" height="338" alt="Screenshot 2026-03-09 at 1 46 15 PM" src="https://github.com/user-attachments/assets/ea44dcc0-40c4-40cf-a2fc-2b1ab0d3a270" />

---

Linear: [T51ENG-1392](https://linear.app/a8c/issue/T51ENG-1392/team-51-cli-or-issue-when-creating-new-site)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UX refactor limited to interactive theme selection; primary risk is changed prompting/validation flow that could block creation if theme input handling is unexpectedly strict.
> 
> **Overview**
> **Improves no-code theme selection** during `github:create-repository`, `pressable:create-site`, and `wpcom:create-site` by replacing the duplicated prompt logic with a shared `prompt_wporg_theme_input()` helper.
> 
> The new helper adds autocomplete over both theme *slugs and names*, retries on invalid input, and provides *"did you mean"* suggestions (substring + Levenshtein) or a full theme list before giving up, preventing silent progression after a bad selection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2400b9ae2515de87b1c111078582335955725854. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced WordPress.org theme selection with autocomplete suggestions and "did you mean?" recommendations for better discoverability.
  * Unified theme input handling across site creation workflows for consistent behavior and improved validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->