### PR TITLE
Add WPCOM deployment webhook setup and management support

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,11 @@ claude mcp add team51 -- team51 --mcp
 
 ### Available Tools
 
-The MCP server exposes 39 tools across all services:
+The MCP server exposes 43 tools across all services:
 
 | Service | Read Tools | Write Tools |
 |---------|-----------|-------------|
-| **WPCOM** | `wpcom_list_sites`, `wpcom_get_site`, `wpcom_list_site_plugins`, `wpcom_list_site_stickers`, `wpcom_list_sites_with_sticker`, `wpcom_get_site_stats`, `wpcom_list_site_users` | `wpcom_add_sticker`, `wpcom_remove_sticker`, `wpcom_update_site`, `wpcom_rotate_sftp_password` |
+| **WPCOM** | `wpcom_list_sites`, `wpcom_get_site`, `wpcom_list_site_plugins`, `wpcom_list_site_stickers`, `wpcom_list_sites_with_sticker`, `wpcom_get_site_stats`, `wpcom_list_site_users`, `wpcom_list_deployment_webhooks` | `wpcom_add_sticker`, `wpcom_remove_sticker`, `wpcom_update_site`, `wpcom_rotate_sftp_password`, `wpcom_create_deployment_webhook`, `wpcom_delete_deployment_webhook`, `wpcom_sync_deployment_webhook_secret` |
 | **Pressable** | `pressable_list_sites`, `pressable_get_site`, `pressable_get_php_errors`, `pressable_list_collaborators`, `pressable_list_sftp_users`, `pressable_list_site_domains` | `pressable_create_site_note`, `pressable_add_collaborator`, `pressable_remove_collaborator`, `pressable_add_domain`, `pressable_rotate_sftp_password` |
 | **GitHub** | `github_list_repositories`, `github_get_repository`, `github_list_branches`, `github_list_secrets`, `github_list_workflow_runs` | `github_set_topics`, `github_create_branch`, `github_set_secret`, `github_create_issue` |
 | **Jetpack** | `jetpack_list_modules`, `jetpack_list_site_modules` | `jetpack_update_module_settings` |
@@ -121,6 +121,29 @@ This CLI tool is self-documenting. You can view a list of available commands wit
 You can then do `team51 <command-name> --help`.
 
 A copy of that documentation is also available on the [Github Wiki for this repository](https://github.com/a8cteam51/team51-cli/wiki). When developing, if you add any new commands or update any descriptions, help, or arguments, [follow these instructions to update the documentation](https://github.com/a8cteam51/team51-cli/wiki/Updating-the-CLI-command-documentation).
+
+### WPCOM GitHub Deployment webhooks
+
+When running `wpcom:connect-site-repository`, Team51 CLI now also creates a WordPress.com deployment webhook and attempts to sync the one-time webhook secret to OpsOasis so signature verification works on:
+
+- `https://opsoasis.wpspecialprojects.com/wp-json/wpcomsp/webhooks/v1/wpcom-deployments`
+
+Standalone webhook commands are also available:
+
+```bash
+# Create and sync a deployment webhook secret to OpsOasis (default behavior)
+team51 wpcom:site:deployment:webhook:create <site> [deployment_id]
+
+# Skip automatic secret sync (prints structured payload for manual sync)
+team51 wpcom:site:deployment:webhook:create <site> [deployment_id] --no-sync-secret
+
+# Optional management commands
+team51 wpcom:site:deployment:webhook:list <site> [deployment_id]
+team51 wpcom:site:deployment:webhook:delete <site> [deployment_id] <webhook_id>
+
+# Manual secret sync fallback (if automatic sync fails)
+team51 wpcom:site:deployment:webhook:sync-secret <site> <deployment_id> <webhook_id> <secret> --url="https://opsoasis.wpspecialprojects.com/wp-json/wpcomsp/webhooks/v1/wpcom-deployments" --events="building,queued,started,completed,failed,cancelled"
+```
 
 ### Conventions around defaults
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ team51 wpcom:site:deployment:webhook:list <site> [deployment_id]
 team51 wpcom:site:deployment:webhook:delete <site> [deployment_id] <webhook_id>
 
 # Manual secret sync fallback (if automatic sync fails)
-team51 wpcom:site:deployment:webhook:sync-secret <site> <deployment_id> <webhook_id> <secret> --url="https://opsoasis.wpspecialprojects.com/wp-json/wpcomsp/webhooks/v1/wpcom-deployments" --events="building,queued,started,completed,failed,cancelled"
+team51 wpcom:site:deployment:webhook:sync-secret <site> <deployment_id> <webhook_id> <secret>
 ```
 
 ### Conventions around defaults

--- a/commands/WPCOM_Site_Create.php
+++ b/commands/WPCOM_Site_Create.php
@@ -160,7 +160,7 @@ final class WPCOM_Site_Create extends Command {
 
 		// Create a GitHub Deployment project for the site.
 		if ( ! \is_null( $this->gh_repository ) ) {
-			run_app_command(
+			$status = run_app_command(
 				WPCOM_Site_Repository_Connect::getDefaultName(),
 				array(
 					'site'         => $transfer->blog_id,
@@ -170,6 +170,10 @@ final class WPCOM_Site_Create extends Command {
 					'--deploy'     => true,
 				)
 			);
+			if ( Command::SUCCESS !== $status ) {
+				$output->writeln( '<error>Site was created, but connecting the GitHub deployment (including webhook setup) failed.</error>' );
+				return Command::FAILURE;
+			}
 		}
 
 		$output->writeln( "<fg=green;options=bold>Site $this->name created successfully.</>" );

--- a/commands/WPCOM_Site_Deployment_Webhook_Create.php
+++ b/commands/WPCOM_Site_Deployment_Webhook_Create.php
@@ -1,0 +1,333 @@
+<?php
+
+namespace WPCOMSpecialProjects\CLI\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use WPCOMSpecialProjects\CLI\Helper\AutocompleteTrait;
+
+/**
+ * Creates a deployment webhook for a WordPress.com site deployment.
+ */
+#[AsCommand( name: 'wpcom:site:deployment:webhook:create' )]
+final class WPCOM_Site_Deployment_Webhook_Create extends Command {
+	use AutocompleteTrait;
+
+	// region FIELDS AND CONSTANTS
+
+	/**
+	 * WPCOM site definition to create the webhook for.
+	 *
+	 * @var \stdClass|null
+	 */
+	private ?\stdClass $site = null;
+
+	/**
+	 * Code deployment ID.
+	 *
+	 * @var string|null
+	 */
+	private ?string $deployment_id = null;
+
+	/**
+	 * Webhook destination URL.
+	 *
+	 * @var string|null
+	 */
+	private ?string $url = null;
+
+	/**
+	 * Comma-separated event list.
+	 *
+	 * @var string|null
+	 */
+	private ?string $events = null;
+
+	/**
+	 * Whether to sync webhook secret to OpsOasis.
+	 *
+	 * @var bool
+	 */
+	private bool $sync_secret = true;
+
+	// endregion
+
+	// region INHERITED METHODS
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function configure(): void {
+		$this->setDescription( 'Creates a deployment webhook for a WordPress.com code deployment.' )
+			->setHelp( 'Use this command to create a WPCOM code deployment webhook and persist its one-time secret to OpsOasis.' );
+
+		$this->addArgument( 'site', InputArgument::REQUIRED, 'Domain or WPCOM ID of the site.' )
+			->addArgument( 'deployment_id', InputArgument::OPTIONAL, 'The code deployment ID. If omitted, the command auto-selects from deployments for the site.' );
+
+		$this->addOption( 'url', null, InputOption::VALUE_REQUIRED, 'Webhook destination URL.', get_wpcom_site_code_deployment_webhook_default_url() )
+			->addOption( 'events', null, InputOption::VALUE_REQUIRED, 'Comma-separated webhook events to subscribe to.', get_wpcom_site_code_deployment_webhook_default_events() )
+			->addOption( 'sync-secret', null, InputOption::VALUE_NEGATABLE, 'Persist the one-time webhook secret in OpsOasis immediately.', true );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function initialize( InputInterface $input, OutputInterface $output ): void {
+		$this->site = get_wpcom_site_input( $input, fn() => $this->prompt_site_input( $input, $output ) );
+		$input->setArgument( 'site', $this->site );
+
+		$this->deployment_id = maybe_get_string_input( $input, 'deployment_id' );
+		if ( is_null( $this->deployment_id ) ) {
+			$this->deployment_id = $this->resolve_deployment_id( $input, $output );
+		}
+		$input->setArgument( 'deployment_id', $this->deployment_id );
+
+		$this->url = get_string_input( $input, 'url', fn() => $this->prompt_url_input( $input, $output ) );
+		$input->setOption( 'url', $this->url );
+
+		$this->events = get_string_input( $input, 'events', fn() => $this->prompt_events_input( $input, $output ) );
+		$input->setOption( 'events', $this->events );
+
+		$this->sync_secret = get_bool_input( $input, 'sync-secret' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( InputInterface $input, OutputInterface $output ): int {
+		$output->writeln( "<fg=magenta;options=bold>Creating deployment webhook for site `{$this->site->name}` (ID {$this->site->ID}) and deployment {$this->deployment_id}.</>" );
+
+		$webhook_response = create_wpcom_site_code_deployment_webhook(
+			(string) $this->site->ID,
+			$this->deployment_id,
+			$this->url,
+			$this->events
+		);
+		if ( \is_null( $webhook_response ) ) {
+			$output->writeln( '<error>Failed to create deployment webhook.</error>' );
+			return Command::FAILURE;
+		}
+
+		$webhook = get_wpcom_site_code_deployment_webhook_from_response( $webhook_response );
+		$secret  = get_wpcom_site_code_deployment_webhook_secret_from_response( $webhook_response );
+		if ( \is_null( $secret ) || '' === trim( $secret ) ) {
+			$output->writeln( '<error>Webhook was created but no secret was returned by WPCOM. The secret can only be read on creation.</error>' );
+			return Command::FAILURE;
+		}
+
+		$webhook_url    = $webhook->url ?? $this->url;
+		$webhook_events = normalize_wpcom_site_code_deployment_webhook_events( $webhook->events ?? $this->events );
+
+		$secret_sync_status = 'skipped';
+		if ( $this->sync_secret ) {
+			$secret_sync_succeeded = true === sync_wpcom_site_code_deployment_webhook_secret(
+				(string) $this->site->ID,
+				$this->deployment_id,
+				(string) $webhook->id,
+				$webhook_url,
+				$webhook_events,
+				$secret
+			);
+
+			if ( ! $secret_sync_succeeded ) {
+				$output->writeln( '<error>Webhook was created, but syncing the webhook secret to OpsOasis failed.</error>' );
+				$this->output_manual_sync_payload( $output, (string) $webhook->id, $webhook_url, $webhook_events, $secret );
+				return Command::FAILURE;
+			}
+
+			$secret_sync_status = 'yes';
+		} else {
+			$output->writeln( '<comment>Secret sync skipped. Store this secret in OpsOasis immediately.</comment>' );
+			$this->output_manual_sync_payload( $output, (string) $webhook->id, $webhook_url, $webhook_events, $secret );
+		}
+
+		output_table(
+			$output,
+			array(
+				array(
+					(string) $this->site->ID,
+					$this->deployment_id,
+					(string) $webhook->id,
+					is_array( $webhook->events ?? null ) ? implode( ',', $webhook->events ) : ( $webhook->events ?? $this->events ),
+					$secret_sync_status,
+				),
+			),
+			array( 'Site ID', 'Deployment ID', 'Webhook ID', 'Events', 'Secret sync succeeded' ),
+			'Created WPCOM deployment webhook'
+		);
+
+		$output->writeln( '<fg=green;options=bold>Deployment webhook created successfully.</>' );
+		return Command::SUCCESS;
+	}
+
+	// endregion
+
+	// region HELPERS
+
+	/**
+	 * Prompts the user for a site.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  string|null
+	 */
+	private function prompt_site_input( InputInterface $input, OutputInterface $output ): ?string {
+		$question = new Question( '<question>Enter the domain or WPCOM site ID:</question> ' );
+		if ( ! $input->getOption( 'no-autocomplete' ) ) {
+			$question->setAutocompleterValues(
+				\array_map(
+					static fn( string $url ) => \parse_url( $url, PHP_URL_HOST ),
+					\array_column( get_wpcom_sites( array( 'fields' => 'ID,URL' ) ) ?? array(), 'URL' )
+				)
+			);
+		}
+
+		return $this->ask_question( $input, $output, $question );
+	}
+
+	/**
+	 * Prompts for the deployment ID.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  string|null
+	 */
+	private function prompt_deployment_id_input( InputInterface $input, OutputInterface $output ): ?string {
+		$question = new Question( '<question>Enter the code deployment ID:</question> ' );
+		return $this->ask_question( $input, $output, $question );
+	}
+
+	/**
+	 * Resolves the deployment ID for the selected site.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @throws  \InvalidArgumentException If no code deployments are found or they cannot be retrieved.
+	 *
+	 * @return  string
+	 */
+	private function resolve_deployment_id( InputInterface $input, OutputInterface $output ): string {
+		$deployments = get_wpcom_site_code_deployments( (string) $this->site->ID );
+		if ( \is_null( $deployments ) ) {
+			throw new \InvalidArgumentException( 'Failed to retrieve code deployments for this site.' );
+		}
+
+		if ( empty( $deployments ) ) {
+			throw new \InvalidArgumentException( 'No code deployments found for this site.' );
+		}
+
+		if ( 1 === count( $deployments ) ) {
+			$deployment = reset( $deployments );
+			$output->writeln( "<comment>Using site deployment {$deployment->id} ({$deployment->repository_name}).</comment>" );
+			return (string) $deployment->id;
+		}
+
+		$choices      = array();
+		$choice_to_id = array();
+		foreach ( $deployments as $deployment ) {
+			$choice                  = sprintf(
+				'%s (ID %s%s)',
+				$deployment->repository_name ?? 'deployment',
+				$deployment->id,
+				isset( $deployment->branch_name ) ? ", branch {$deployment->branch_name}" : ''
+			);
+			$choices[]               = $choice;
+			$choice_to_id[ $choice ] = (string) $deployment->id;
+		}
+
+		$question = new ChoiceQuestion( '<question>Select the code deployment to use:</question> ', $choices, 0 );
+		$question->setErrorMessage( 'Deployment %s is invalid.' );
+		$selected_choice = $this->ask_question( $input, $output, $question );
+
+		return $choice_to_id[ $selected_choice ];
+	}
+
+	/**
+	 * Prompts for the webhook destination URL.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  string|null
+	 */
+	private function prompt_url_input( InputInterface $input, OutputInterface $output ): ?string {
+		$question = new Question(
+			'<question>Enter the webhook destination URL:</question> ',
+			get_wpcom_site_code_deployment_webhook_default_url()
+		);
+		return $this->ask_question( $input, $output, $question );
+	}
+
+	/**
+	 * Prompts for the events to subscribe to.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  string|null
+	 */
+	private function prompt_events_input( InputInterface $input, OutputInterface $output ): ?string {
+		$question = new Question(
+			'<question>Enter comma-separated webhook events:</question> ',
+			get_wpcom_site_code_deployment_webhook_default_events()
+		);
+		return $this->ask_question( $input, $output, $question );
+	}
+
+	/**
+	 * Outputs a structured payload that can be used for immediate manual secret sync.
+	 *
+	 * @param   OutputInterface $output     The output object.
+	 * @param   string          $webhook_id The webhook ID.
+	 * @param   string          $url        The webhook URL.
+	 * @param   array           $events     The webhook events.
+	 * @param   string          $secret     The webhook secret.
+	 *
+	 * @return  void
+	 */
+	private function output_manual_sync_payload( OutputInterface $output, string $webhook_id, string $url, array $events, string $secret ): void {
+		$output->writeln(
+			encode_json_content(
+				array(
+					'site_id'       => (int) $this->site->ID,
+					'deployment_id' => $this->deployment_id,
+					'webhook_id'    => $webhook_id,
+					'url'           => $url,
+					'events'        => $events,
+					'secret'        => $secret,
+				)
+			)
+		);
+	}
+
+	/**
+	 * Asks a Symfony console question with the question helper.
+	 *
+	 * @param   InputInterface  $input    The input object.
+	 * @param   OutputInterface $output   The output object.
+	 * @param   Question        $question The question to ask.
+	 *
+	 * @throws  \RuntimeException If the Symfony question helper is unavailable.
+	 *
+	 * @return  mixed
+	 */
+	private function ask_question( InputInterface $input, OutputInterface $output, Question $question ): mixed {
+		$question_helper = $this->getHelper( 'question' );
+		if ( ! $question_helper instanceof \Symfony\Component\Console\Helper\QuestionHelper ) {
+			throw new \RuntimeException( 'Question helper is unavailable.' );
+		}
+
+		return $question_helper->ask( $input, $output, $question );
+	}
+
+	// endregion
+}

--- a/commands/WPCOM_Site_Deployment_Webhook_Create.php
+++ b/commands/WPCOM_Site_Deployment_Webhook_Create.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WPCOMSpecialProjects\CLI\Command;
 
 use Symfony\Component\Console\Attribute\AsCommand;

--- a/commands/WPCOM_Site_Deployment_Webhook_Delete.php
+++ b/commands/WPCOM_Site_Deployment_Webhook_Delete.php
@@ -1,0 +1,261 @@
+<?php
+
+namespace WPCOMSpecialProjects\CLI\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Question\Question;
+use WPCOMSpecialProjects\CLI\Helper\AutocompleteTrait;
+
+/**
+ * Deletes a WordPress.com deployment webhook.
+ */
+#[AsCommand( name: 'wpcom:site:deployment:webhook:delete' )]
+final class WPCOM_Site_Deployment_Webhook_Delete extends Command {
+	use AutocompleteTrait;
+
+	/**
+	 * WPCOM site definition.
+	 *
+	 * @var \stdClass|null
+	 */
+	private ?\stdClass $site = null;
+
+	/**
+	 * Code deployment ID.
+	 *
+	 * @var string|null
+	 */
+	private ?string $deployment_id = null;
+
+	/**
+	 * Webhook ID.
+	 *
+	 * @var string|null
+	 */
+	private ?string $webhook_id = null;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function configure(): void {
+		$this->setDescription( 'Deletes a WordPress.com deployment webhook.' )
+			->setHelp( 'Use this command to remove a deployment webhook from a WPCOM code deployment.' );
+
+		$this->addArgument( 'site', InputArgument::REQUIRED, 'Domain or WPCOM ID of the site.' )
+			->addArgument( 'deployment_id', InputArgument::OPTIONAL, 'The code deployment ID. If omitted, the command auto-selects from deployments for the site.' )
+			->addArgument( 'webhook_id', InputArgument::OPTIONAL, 'The webhook ID. If omitted, the command auto-selects from webhooks for the deployment.' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function initialize( InputInterface $input, OutputInterface $output ): void {
+		$this->site = get_wpcom_site_input( $input, fn() => $this->prompt_site_input( $input, $output ) );
+		$input->setArgument( 'site', $this->site );
+
+		$this->deployment_id = maybe_get_string_input( $input, 'deployment_id' );
+		if ( is_null( $this->deployment_id ) ) {
+			$this->deployment_id = $this->resolve_deployment_id( $input, $output );
+		}
+		$input->setArgument( 'deployment_id', $this->deployment_id );
+
+		$this->webhook_id = maybe_get_string_input( $input, 'webhook_id' );
+		if ( is_null( $this->webhook_id ) ) {
+			$this->webhook_id = $this->resolve_webhook_id( $input, $output );
+		}
+		$input->setArgument( 'webhook_id', $this->webhook_id );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function interact( InputInterface $input, OutputInterface $output ): void {
+		$question = new ConfirmationQuestion(
+			"<question>Are you sure you want to delete webhook {$this->webhook_id} from site {$this->site->name} (ID {$this->site->ID}) deployment {$this->deployment_id}? [y/N]</question> ",
+			false
+		);
+		if ( true !== $this->ask_question( $input, $output, $question ) ) {
+			$output->writeln( '<comment>Command aborted by user.</comment>' );
+			exit( 2 );
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( InputInterface $input, OutputInterface $output ): int {
+		$result = delete_wpcom_site_code_deployment_webhook( (string) $this->site->ID, $this->deployment_id, $this->webhook_id );
+		if ( true !== $result ) {
+			$output->writeln( '<error>Failed to delete deployment webhook.</error>' );
+			return Command::FAILURE;
+		}
+
+		$output->writeln( '<fg=green;options=bold>Deployment webhook deleted successfully.</>' );
+		return Command::SUCCESS;
+	}
+
+	/**
+	 * Prompts the user for a site.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  string|null
+	 */
+	private function prompt_site_input( InputInterface $input, OutputInterface $output ): ?string {
+		$question = new Question( '<question>Enter the domain or WPCOM site ID:</question> ' );
+		if ( ! $input->getOption( 'no-autocomplete' ) ) {
+			$question->setAutocompleterValues(
+				\array_map(
+					static fn( string $url ) => \parse_url( $url, PHP_URL_HOST ),
+					\array_column( get_wpcom_sites( array( 'fields' => 'ID,URL' ) ) ?? array(), 'URL' )
+				)
+			);
+		}
+
+		return $this->ask_question( $input, $output, $question );
+	}
+
+	/**
+	 * Prompts for the deployment ID.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  string|null
+	 */
+	private function prompt_deployment_id_input( InputInterface $input, OutputInterface $output ): ?string {
+		$question = new Question( '<question>Enter the code deployment ID:</question> ' );
+		return $this->ask_question( $input, $output, $question );
+	}
+
+	/**
+	 * Resolves the deployment ID for the selected site.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @throws  \InvalidArgumentException If no code deployments are found or they cannot be retrieved.
+	 *
+	 * @return  string
+	 */
+	private function resolve_deployment_id( InputInterface $input, OutputInterface $output ): string {
+		$deployments = get_wpcom_site_code_deployments( (string) $this->site->ID );
+		if ( \is_null( $deployments ) ) {
+			throw new \InvalidArgumentException( 'Failed to retrieve code deployments for this site.' );
+		}
+
+		if ( empty( $deployments ) ) {
+			throw new \InvalidArgumentException( 'No code deployments found for this site.' );
+		}
+
+		if ( 1 === count( $deployments ) ) {
+			$deployment = reset( $deployments );
+			$output->writeln( "<comment>Using site deployment {$deployment->id} ({$deployment->repository_name}).</comment>" );
+			return (string) $deployment->id;
+		}
+
+		$choices      = array();
+		$choice_to_id = array();
+		foreach ( $deployments as $deployment ) {
+			$choice                  = sprintf(
+				'%s (ID %s%s)',
+				$deployment->repository_name ?? 'deployment',
+				$deployment->id,
+				isset( $deployment->branch_name ) ? ", branch {$deployment->branch_name}" : ''
+			);
+			$choices[]               = $choice;
+			$choice_to_id[ $choice ] = (string) $deployment->id;
+		}
+
+		$question = new ChoiceQuestion( '<question>Select the code deployment to update:</question> ', $choices, 0 );
+		$question->setErrorMessage( 'Deployment %s is invalid.' );
+		$selected_choice = $this->ask_question( $input, $output, $question );
+
+		return $choice_to_id[ $selected_choice ];
+	}
+
+	/**
+	 * Prompts for webhook ID.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  string|null
+	 */
+	private function prompt_webhook_id_input( InputInterface $input, OutputInterface $output ): ?string {
+		$question = new Question( '<question>Enter the webhook ID:</question> ' );
+		return $this->ask_question( $input, $output, $question );
+	}
+
+	/**
+	 * Resolves the webhook ID for the selected deployment.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @throws  \InvalidArgumentException If no webhooks are found or they cannot be retrieved.
+	 *
+	 * @return  string
+	 */
+	private function resolve_webhook_id( InputInterface $input, OutputInterface $output ): string {
+		$webhooks = get_wpcom_site_code_deployment_webhooks( (string) $this->site->ID, $this->deployment_id );
+		if ( \is_null( $webhooks ) ) {
+			throw new \InvalidArgumentException( 'Failed to retrieve deployment webhooks for this site deployment.' );
+		}
+
+		if ( empty( $webhooks ) ) {
+			throw new \InvalidArgumentException( 'No deployment webhooks found for this site deployment.' );
+		}
+
+		if ( 1 === count( $webhooks ) ) {
+			$webhook = reset( $webhooks );
+			$output->writeln( "<comment>Using deployment webhook {$webhook->id}.</comment>" );
+			return (string) $webhook->id;
+		}
+
+		$choices      = array();
+		$choice_to_id = array();
+		foreach ( $webhooks as $webhook ) {
+			$choice                  = sprintf(
+				'%s (ID %s)',
+				$webhook->url ?? 'webhook',
+				$webhook->id
+			);
+			$choices[]               = $choice;
+			$choice_to_id[ $choice ] = (string) $webhook->id;
+		}
+
+		$question = new ChoiceQuestion( '<question>Select the deployment webhook to delete:</question> ', $choices, 0 );
+		$question->setErrorMessage( 'Webhook %s is invalid.' );
+		$selected_choice = $this->ask_question( $input, $output, $question );
+
+		return $choice_to_id[ $selected_choice ];
+	}
+
+	/**
+	 * Asks a Symfony console question with the question helper.
+	 *
+	 * @param   InputInterface  $input    The input object.
+	 * @param   OutputInterface $output   The output object.
+	 * @param   Question        $question The question to ask.
+	 *
+	 * @throws  \RuntimeException If the Symfony question helper is unavailable.
+	 *
+	 * @return  mixed
+	 */
+	private function ask_question( InputInterface $input, OutputInterface $output, Question $question ): mixed {
+		$question_helper = $this->getHelper( 'question' );
+		if ( ! $question_helper instanceof \Symfony\Component\Console\Helper\QuestionHelper ) {
+			throw new \RuntimeException( 'Question helper is unavailable.' );
+		}
+
+		return $question_helper->ask( $input, $output, $question );
+	}
+}

--- a/commands/WPCOM_Site_Deployment_Webhook_List.php
+++ b/commands/WPCOM_Site_Deployment_Webhook_List.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace WPCOMSpecialProjects\CLI\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use WPCOMSpecialProjects\CLI\Helper\AutocompleteTrait;
+
+/**
+ * Lists deployment webhooks for a WordPress.com site deployment.
+ */
+#[AsCommand( name: 'wpcom:site:deployment:webhook:list' )]
+final class WPCOM_Site_Deployment_Webhook_List extends Command {
+	use AutocompleteTrait;
+
+	/**
+	 * WPCOM site definition to list webhooks for.
+	 *
+	 * @var \stdClass|null
+	 */
+	private ?\stdClass $site = null;
+
+	/**
+	 * Code deployment ID.
+	 *
+	 * @var string|null
+	 */
+	private ?string $deployment_id = null;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function configure(): void {
+		$this->setDescription( 'Lists deployment webhooks for a WordPress.com code deployment.' )
+			->setHelp( 'Use this command to list webhooks configured for a WPCOM code deployment.' );
+
+		$this->addArgument( 'site', InputArgument::REQUIRED, 'Domain or WPCOM ID of the site.' )
+			->addArgument( 'deployment_id', InputArgument::OPTIONAL, 'The code deployment ID. If omitted, the command auto-selects from deployments for the site.' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function initialize( InputInterface $input, OutputInterface $output ): void {
+		$this->site = get_wpcom_site_input( $input, fn() => $this->prompt_site_input( $input, $output ) );
+		$input->setArgument( 'site', $this->site );
+
+		$this->deployment_id = maybe_get_string_input( $input, 'deployment_id' );
+		if ( is_null( $this->deployment_id ) ) {
+			$this->deployment_id = $this->resolve_deployment_id( $input, $output );
+		}
+		$input->setArgument( 'deployment_id', $this->deployment_id );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( InputInterface $input, OutputInterface $output ): int {
+		$webhooks = get_wpcom_site_code_deployment_webhooks( (string) $this->site->ID, $this->deployment_id );
+		if ( \is_null( $webhooks ) ) {
+			$output->writeln( '<error>Failed to list deployment webhooks.</error>' );
+			return Command::FAILURE;
+		}
+
+		if ( empty( $webhooks ) ) {
+			$output->writeln( '<comment>No deployment webhooks are configured for this deployment.</comment>' );
+			return Command::SUCCESS;
+		}
+
+		output_table(
+			$output,
+			array_map(
+				static fn( \stdClass $webhook ) => array(
+					$webhook->id ?? '',
+					$webhook->url ?? '',
+					is_array( $webhook->events ?? null ) ? implode( ',', $webhook->events ) : ( $webhook->events ?? '' ),
+					$webhook->active ?? '',
+				),
+				$webhooks
+			),
+			array( 'Webhook ID', 'URL', 'Events', 'Active' ),
+			'WPCOM deployment webhooks'
+		);
+
+		return Command::SUCCESS;
+	}
+
+	/**
+	 * Prompts the user for a site.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  string|null
+	 */
+	private function prompt_site_input( InputInterface $input, OutputInterface $output ): ?string {
+		$question = new Question( '<question>Enter the domain or WPCOM site ID:</question> ' );
+		if ( ! $input->getOption( 'no-autocomplete' ) ) {
+			$question->setAutocompleterValues(
+				\array_map(
+					static fn( string $url ) => \parse_url( $url, PHP_URL_HOST ),
+					\array_column( get_wpcom_sites( array( 'fields' => 'ID,URL' ) ) ?? array(), 'URL' )
+				)
+			);
+		}
+
+		return $this->ask_question( $input, $output, $question );
+	}
+
+	/**
+	 * Prompts for the deployment ID.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  string|null
+	 */
+	private function prompt_deployment_id_input( InputInterface $input, OutputInterface $output ): ?string {
+		$question = new Question( '<question>Enter the code deployment ID:</question> ' );
+		return $this->ask_question( $input, $output, $question );
+	}
+
+	/**
+	 * Resolves the deployment ID for the selected site.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @throws  \InvalidArgumentException If no code deployments are found or they cannot be retrieved.
+	 *
+	 * @return  string
+	 */
+	private function resolve_deployment_id( InputInterface $input, OutputInterface $output ): string {
+		$deployments = get_wpcom_site_code_deployments( (string) $this->site->ID );
+		if ( \is_null( $deployments ) ) {
+			throw new \InvalidArgumentException( 'Failed to retrieve code deployments for this site.' );
+		}
+
+		if ( empty( $deployments ) ) {
+			throw new \InvalidArgumentException( 'No code deployments found for this site.' );
+		}
+
+		if ( 1 === count( $deployments ) ) {
+			$deployment = reset( $deployments );
+			$output->writeln( "<comment>Using site deployment {$deployment->id} ({$deployment->repository_name}).</comment>" );
+			return (string) $deployment->id;
+		}
+
+		$choices      = array();
+		$choice_to_id = array();
+		foreach ( $deployments as $deployment ) {
+			$choice                  = sprintf(
+				'%s (ID %s%s)',
+				$deployment->repository_name ?? 'deployment',
+				$deployment->id,
+				isset( $deployment->branch_name ) ? ", branch {$deployment->branch_name}" : ''
+			);
+			$choices[]               = $choice;
+			$choice_to_id[ $choice ] = (string) $deployment->id;
+		}
+
+		$question = new ChoiceQuestion( '<question>Select the code deployment to inspect:</question> ', $choices, 0 );
+		$question->setErrorMessage( 'Deployment %s is invalid.' );
+		$selected_choice = $this->ask_question( $input, $output, $question );
+
+		return $choice_to_id[ $selected_choice ];
+	}
+
+	/**
+	 * Asks a Symfony console question with the question helper.
+	 *
+	 * @param   InputInterface  $input    The input object.
+	 * @param   OutputInterface $output   The output object.
+	 * @param   Question        $question The question to ask.
+	 *
+	 * @throws  \RuntimeException If the Symfony question helper is unavailable.
+	 *
+	 * @return  mixed
+	 */
+	private function ask_question( InputInterface $input, OutputInterface $output, Question $question ): mixed {
+		$question_helper = $this->getHelper( 'question' );
+		if ( ! $question_helper instanceof \Symfony\Component\Console\Helper\QuestionHelper ) {
+			throw new \RuntimeException( 'Question helper is unavailable.' );
+		}
+
+		return $question_helper->ask( $input, $output, $question );
+	}
+}

--- a/commands/WPCOM_Site_Deployment_Webhook_Secret_Sync.php
+++ b/commands/WPCOM_Site_Deployment_Webhook_Secret_Sync.php
@@ -6,7 +6,6 @@ use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
 use WPCOMSpecialProjects\CLI\Helper\AutocompleteTrait;
@@ -47,20 +46,6 @@ final class WPCOM_Site_Deployment_Webhook_Secret_Sync extends Command {
 	private ?string $secret = null;
 
 	/**
-	 * Webhook URL.
-	 *
-	 * @var string|null
-	 */
-	private ?string $url = null;
-
-	/**
-	 * Comma-separated event list.
-	 *
-	 * @var string|null
-	 */
-	private ?string $events = null;
-
-	/**
 	 * {@inheritDoc}
 	 */
 	protected function configure(): void {
@@ -71,9 +56,6 @@ final class WPCOM_Site_Deployment_Webhook_Secret_Sync extends Command {
 			->addArgument( 'deployment_id', InputArgument::REQUIRED, 'The code deployment ID.' )
 			->addArgument( 'webhook_id', InputArgument::REQUIRED, 'The webhook ID.' )
 			->addArgument( 'secret', InputArgument::REQUIRED, 'The one-time webhook secret returned by WPCOM on create.' );
-
-		$this->addOption( 'url', null, InputOption::VALUE_REQUIRED, 'Webhook destination URL.', get_wpcom_site_code_deployment_webhook_default_url() )
-			->addOption( 'events', null, InputOption::VALUE_REQUIRED, 'Comma-separated webhook events.', get_wpcom_site_code_deployment_webhook_default_events() );
 	}
 
 	/**
@@ -91,25 +73,31 @@ final class WPCOM_Site_Deployment_Webhook_Secret_Sync extends Command {
 
 		$this->secret = get_string_input( $input, 'secret' );
 		$input->setArgument( 'secret', $this->secret );
-
-		$this->url = get_string_input( $input, 'url', fn() => $this->prompt_url_input( $input, $output ) );
-		$input->setOption( 'url', $this->url );
-
-		$this->events = get_string_input( $input, 'events', fn() => $this->prompt_events_input( $input, $output ) );
-		$input->setOption( 'events', $this->events );
 	}
 
 	/**
 	 * {@inheritDoc}
 	 */
 	protected function execute( InputInterface $input, OutputInterface $output ): int {
-		$events        = normalize_wpcom_site_code_deployment_webhook_events( $this->events );
+		$webhook = get_wpcom_site_code_deployment_webhook( (string) $this->site->ID, $this->deployment_id, $this->webhook_id );
+		if ( \is_null( $webhook ) ) {
+			$output->writeln( '<error>Failed to fetch the specified deployment webhook from WPCOM. Aborting secret sync.</error>' );
+			return Command::FAILURE;
+		}
+
+		$canonical_url    = $webhook->url ?? null;
+		$canonical_events = normalize_wpcom_site_code_deployment_webhook_events( $webhook->events ?? null );
+		if ( \is_null( $canonical_url ) || '' === trim( $canonical_url ) || empty( $canonical_events ) ) {
+			$output->writeln( '<error>Webhook metadata from WPCOM is incomplete. Aborting secret sync.</error>' );
+			return Command::FAILURE;
+		}
+
 		$sync_succeeds = true === sync_wpcom_site_code_deployment_webhook_secret(
 			(string) $this->site->ID,
 			$this->deployment_id,
 			$this->webhook_id,
-			$this->url,
-			$events,
+			$canonical_url,
+			$canonical_events,
 			$this->secret
 		);
 
@@ -118,6 +106,8 @@ final class WPCOM_Site_Deployment_Webhook_Secret_Sync extends Command {
 			return Command::FAILURE;
 		}
 
+		$output->writeln( "<comment>Using canonical WPCOM webhook URL: $canonical_url</comment>", OutputInterface::VERBOSITY_VERBOSE );
+		$output->writeln( '<comment>Using canonical WPCOM webhook events: ' . implode( ',', $canonical_events ) . '</comment>', OutputInterface::VERBOSITY_VERBOSE );
 		$output->writeln( '<fg=green;options=bold>Webhook secret synced to OpsOasis successfully.</>' );
 		return Command::SUCCESS;
 	}
@@ -141,38 +131,6 @@ final class WPCOM_Site_Deployment_Webhook_Secret_Sync extends Command {
 			);
 		}
 
-		return $this->ask_question( $input, $output, $question );
-	}
-
-	/**
-	 * Prompts for the webhook destination URL.
-	 *
-	 * @param   InputInterface  $input  The input object.
-	 * @param   OutputInterface $output The output object.
-	 *
-	 * @return  string|null
-	 */
-	private function prompt_url_input( InputInterface $input, OutputInterface $output ): ?string {
-		$question = new Question(
-			'<question>Enter the webhook destination URL:</question> ',
-			get_wpcom_site_code_deployment_webhook_default_url()
-		);
-		return $this->ask_question( $input, $output, $question );
-	}
-
-	/**
-	 * Prompts for the events to subscribe to.
-	 *
-	 * @param   InputInterface  $input  The input object.
-	 * @param   OutputInterface $output The output object.
-	 *
-	 * @return  string|null
-	 */
-	private function prompt_events_input( InputInterface $input, OutputInterface $output ): ?string {
-		$question = new Question(
-			'<question>Enter comma-separated webhook events:</question> ',
-			get_wpcom_site_code_deployment_webhook_default_events()
-		);
 		return $this->ask_question( $input, $output, $question );
 	}
 

--- a/commands/WPCOM_Site_Deployment_Webhook_Secret_Sync.php
+++ b/commands/WPCOM_Site_Deployment_Webhook_Secret_Sync.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace WPCOMSpecialProjects\CLI\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use WPCOMSpecialProjects\CLI\Helper\AutocompleteTrait;
+
+/**
+ * Syncs a WordPress.com deployment webhook secret to OpsOasis.
+ */
+#[AsCommand( name: 'wpcom:site:deployment:webhook:sync-secret' )]
+final class WPCOM_Site_Deployment_Webhook_Secret_Sync extends Command {
+	use AutocompleteTrait;
+
+	/**
+	 * WPCOM site definition.
+	 *
+	 * @var \stdClass|null
+	 */
+	private ?\stdClass $site = null;
+
+	/**
+	 * Code deployment ID.
+	 *
+	 * @var string|null
+	 */
+	private ?string $deployment_id = null;
+
+	/**
+	 * Webhook ID.
+	 *
+	 * @var string|null
+	 */
+	private ?string $webhook_id = null;
+
+	/**
+	 * Webhook secret.
+	 *
+	 * @var string|null
+	 */
+	private ?string $secret = null;
+
+	/**
+	 * Webhook URL.
+	 *
+	 * @var string|null
+	 */
+	private ?string $url = null;
+
+	/**
+	 * Comma-separated event list.
+	 *
+	 * @var string|null
+	 */
+	private ?string $events = null;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function configure(): void {
+		$this->setDescription( 'Syncs an existing WPCOM deployment webhook secret to OpsOasis.' )
+			->setHelp( 'Use this command to persist a webhook secret in OpsOasis when automatic sync fails or is skipped.' );
+
+		$this->addArgument( 'site', InputArgument::REQUIRED, 'Domain or WPCOM ID of the site.' )
+			->addArgument( 'deployment_id', InputArgument::REQUIRED, 'The code deployment ID.' )
+			->addArgument( 'webhook_id', InputArgument::REQUIRED, 'The webhook ID.' )
+			->addArgument( 'secret', InputArgument::REQUIRED, 'The one-time webhook secret returned by WPCOM on create.' );
+
+		$this->addOption( 'url', null, InputOption::VALUE_REQUIRED, 'Webhook destination URL.', get_wpcom_site_code_deployment_webhook_default_url() )
+			->addOption( 'events', null, InputOption::VALUE_REQUIRED, 'Comma-separated webhook events.', get_wpcom_site_code_deployment_webhook_default_events() );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function initialize( InputInterface $input, OutputInterface $output ): void {
+		$this->site = get_wpcom_site_input( $input, fn() => $this->prompt_site_input( $input, $output ) );
+		$input->setArgument( 'site', $this->site );
+
+		$this->deployment_id = get_string_input( $input, 'deployment_id' );
+		$input->setArgument( 'deployment_id', $this->deployment_id );
+
+		$this->webhook_id = get_string_input( $input, 'webhook_id' );
+		$input->setArgument( 'webhook_id', $this->webhook_id );
+
+		$this->secret = get_string_input( $input, 'secret' );
+		$input->setArgument( 'secret', $this->secret );
+
+		$this->url = get_string_input( $input, 'url', fn() => $this->prompt_url_input( $input, $output ) );
+		$input->setOption( 'url', $this->url );
+
+		$this->events = get_string_input( $input, 'events', fn() => $this->prompt_events_input( $input, $output ) );
+		$input->setOption( 'events', $this->events );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( InputInterface $input, OutputInterface $output ): int {
+		$events        = normalize_wpcom_site_code_deployment_webhook_events( $this->events );
+		$sync_succeeds = true === sync_wpcom_site_code_deployment_webhook_secret(
+			(string) $this->site->ID,
+			$this->deployment_id,
+			$this->webhook_id,
+			$this->url,
+			$events,
+			$this->secret
+		);
+
+		if ( ! $sync_succeeds ) {
+			$output->writeln( '<error>Failed to sync webhook secret to OpsOasis.</error>' );
+			return Command::FAILURE;
+		}
+
+		$output->writeln( '<fg=green;options=bold>Webhook secret synced to OpsOasis successfully.</>' );
+		return Command::SUCCESS;
+	}
+
+	/**
+	 * Prompts the user for a site.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  string|null
+	 */
+	private function prompt_site_input( InputInterface $input, OutputInterface $output ): ?string {
+		$question = new Question( '<question>Enter the domain or WPCOM site ID:</question> ' );
+		if ( ! $input->getOption( 'no-autocomplete' ) ) {
+			$question->setAutocompleterValues(
+				\array_map(
+					static fn( string $url ) => \parse_url( $url, PHP_URL_HOST ),
+					\array_column( get_wpcom_sites( array( 'fields' => 'ID,URL' ) ) ?? array(), 'URL' )
+				)
+			);
+		}
+
+		return $this->ask_question( $input, $output, $question );
+	}
+
+	/**
+	 * Prompts for the webhook destination URL.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  string|null
+	 */
+	private function prompt_url_input( InputInterface $input, OutputInterface $output ): ?string {
+		$question = new Question(
+			'<question>Enter the webhook destination URL:</question> ',
+			get_wpcom_site_code_deployment_webhook_default_url()
+		);
+		return $this->ask_question( $input, $output, $question );
+	}
+
+	/**
+	 * Prompts for the events to subscribe to.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  string|null
+	 */
+	private function prompt_events_input( InputInterface $input, OutputInterface $output ): ?string {
+		$question = new Question(
+			'<question>Enter comma-separated webhook events:</question> ',
+			get_wpcom_site_code_deployment_webhook_default_events()
+		);
+		return $this->ask_question( $input, $output, $question );
+	}
+
+	/**
+	 * Asks a Symfony console question with the question helper.
+	 *
+	 * @param   InputInterface  $input    The input object.
+	 * @param   OutputInterface $output   The output object.
+	 * @param   Question        $question The question to ask.
+	 *
+	 * @throws  \RuntimeException If the Symfony question helper is unavailable.
+	 *
+	 * @return  mixed
+	 */
+	private function ask_question( InputInterface $input, OutputInterface $output, Question $question ): mixed {
+		$question_helper = $this->getHelper( 'question' );
+		if ( ! $question_helper instanceof \Symfony\Component\Console\Helper\QuestionHelper ) {
+			throw new \RuntimeException( 'Question helper is unavailable.' );
+		}
+
+		return $question_helper->ask( $input, $output, $question );
+	}
+}

--- a/commands/WPCOM_Site_Repository_Connect.php
+++ b/commands/WPCOM_Site_Repository_Connect.php
@@ -133,6 +133,27 @@ final class WPCOM_Site_Repository_Connect extends Command {
 		$webhook = get_wpcom_site_code_deployment_webhook_from_response( $webhook_response );
 		$secret  = get_wpcom_site_code_deployment_webhook_secret_from_response( $webhook_response );
 		if ( \is_null( $secret ) || '' === trim( $secret ) ) {
+			$delete_response = null;
+			try {
+				$delete_result = delete_wpcom_site_code_deployment_webhook(
+					(string) $this->site->ID,
+					(string) $code_deployment->id,
+					(string) $webhook->id,
+					$delete_response
+				);
+				if ( true === $delete_result ) {
+					$output->writeln( "<comment>Deleted orphaned deployment webhook {$webhook->id} because WPCOM did not return a secret.</comment>" );
+				} else {
+					$output->writeln(
+						'<comment>Failed to delete orphaned deployment webhook after missing secret response: '
+						. ( is_null( $delete_response ) ? 'null' : encode_json_content( $delete_response ) )
+						. '</comment>'
+					);
+				}
+			} catch ( \Throwable $e ) {
+				$output->writeln( '<comment>Failed to delete orphaned deployment webhook after missing secret response: ' . $e->getMessage() . '</comment>' );
+			}
+
 			$output->writeln( '<error>Webhook was created but no secret was returned. Cannot configure OpsOasis verification.</error>' );
 			return Command::FAILURE;
 		}

--- a/commands/WPCOM_Site_Repository_Connect.php
+++ b/commands/WPCOM_Site_Repository_Connect.php
@@ -64,8 +64,8 @@ final class WPCOM_Site_Repository_Connect extends Command {
 	 * {@inheritDoc}
 	 */
 	protected function configure(): void {
-		$this->setDescription( 'Connects a WordPress.com site to a GitHub repository for deployments.' )
-			->setHelp( 'Use this command to connect a WordPress.com site to a GitHub repository for deployments.' );
+		$this->setDescription( 'Connects a WordPress.com site to a GitHub repository for deployments and configures deployment webhooks.' )
+			->setHelp( 'Use this command to connect a WordPress.com site to a GitHub repository for deployments, create a deployment webhook, and sync the webhook secret to OpsOasis.' );
 
 		$this->addArgument( 'site', InputArgument::REQUIRED, 'Domain or WPCOM ID of the site to connect the repository to.' )
 			->addArgument( 'repository', InputArgument::REQUIRED, 'The slug of the GitHub repository to connect.' );
@@ -99,7 +99,7 @@ final class WPCOM_Site_Repository_Connect extends Command {
 	 */
 	protected function interact( InputInterface $input, OutputInterface $output ): void {
 		$question = new ConfirmationQuestion( "<question>Are you sure you want to connect the WPCOM site `{$this->site->name}` (ID {$this->site->ID}, URL {$this->site->URL}) to the GitHub repository `{$this->gh_repository->full_name}`? [y/N]</question> ", false );
-		if ( true !== $this->getHelper( 'question' )->ask( $input, $output, $question ) ) {
+		if ( true !== $this->ask_question( $input, $output, $question ) ) {
 			$output->writeln( '<comment>Command aborted by user.</comment>' );
 			exit( 2 );
 		}
@@ -116,6 +116,80 @@ final class WPCOM_Site_Repository_Connect extends Command {
 			$output->writeln( '<error>Failed to connect the site with the repository.</error>' );
 			return Command::FAILURE;
 		}
+
+		$webhook_url        = get_wpcom_site_code_deployment_webhook_default_url();
+		$webhook_events_csv = get_wpcom_site_code_deployment_webhook_default_events();
+		$webhook_response   = create_wpcom_site_code_deployment_webhook(
+			(string) $this->site->ID,
+			(string) $code_deployment->id,
+			$webhook_url,
+			$webhook_events_csv
+		);
+		if ( \is_null( $webhook_response ) ) {
+			$output->writeln( '<error>Failed to create the WordPress.com deployment webhook.</error>' );
+			return Command::FAILURE;
+		}
+
+		$webhook = get_wpcom_site_code_deployment_webhook_from_response( $webhook_response );
+		$secret  = get_wpcom_site_code_deployment_webhook_secret_from_response( $webhook_response );
+		if ( \is_null( $secret ) || '' === trim( $secret ) ) {
+			$output->writeln( '<error>Webhook was created but no secret was returned. Cannot configure OpsOasis verification.</error>' );
+			return Command::FAILURE;
+		}
+
+		$webhook_events = normalize_wpcom_site_code_deployment_webhook_events( $webhook->events ?? $webhook_events_csv );
+
+		$secret_sync_succeeded = true === sync_wpcom_site_code_deployment_webhook_secret(
+			(string) $this->site->ID,
+			(string) $code_deployment->id,
+			(string) $webhook->id,
+			$webhook->url ?? $webhook_url,
+			$webhook_events,
+			$secret
+		);
+		if ( ! $secret_sync_succeeded ) {
+			$output->writeln( '<error>Deployment webhook was created, but syncing the webhook secret to OpsOasis failed.</error>' );
+			$output->writeln( '<comment>Store this secret immediately in OpsOasis to avoid signature verification failures:</comment>' );
+			$output->writeln(
+				encode_json_content(
+					array(
+						'site_id'       => (int) $this->site->ID,
+						'deployment_id' => (string) $code_deployment->id,
+						'webhook_id'    => (string) $webhook->id,
+						'url'           => $webhook->url ?? $webhook_url,
+						'events'        => $webhook_events,
+						'secret'        => $secret,
+					)
+				)
+			);
+			$sync_secret_command = sprintf(
+				'team51 --dev %s %s %s %s %s --url=%s --events=%s',
+				WPCOM_Site_Deployment_Webhook_Secret_Sync::getDefaultName(),
+				escapeshellarg( (string) $this->site->ID ),
+				escapeshellarg( (string) $code_deployment->id ),
+				escapeshellarg( (string) $webhook->id ),
+				escapeshellarg( $secret ),
+				escapeshellarg( (string) ( $webhook->url ?? $webhook_url ) ),
+				escapeshellarg( implode( ',', $webhook_events ) )
+			);
+			$output->writeln( "<comment>Copy/paste to retry sync:</comment>\n$sync_secret_command" );
+			return Command::FAILURE;
+		}
+
+		output_table(
+			$output,
+			array(
+				array(
+					(string) $this->site->ID,
+					(string) $code_deployment->id,
+					(string) $webhook->id,
+					is_array( $webhook->events ?? null ) ? implode( ',', $webhook->events ) : ( $webhook->events ?? $webhook_events_csv ),
+					$secret_sync_succeeded ? 'yes' : 'no',
+				),
+			),
+			array( 'Site ID', 'Deployment ID', 'Webhook ID', 'Events', 'Secret sync succeeded' ),
+			'WPCOM deployment webhook'
+		);
 
 		$output->writeln( "<fg=green;options=bold>Site `{$this->site->name}` connected to repository `{$this->gh_repository->full_name}` successfully.</>" );
 
@@ -163,7 +237,7 @@ final class WPCOM_Site_Repository_Connect extends Command {
 			);
 		}
 
-		return $this->getHelper( 'question' )->ask( $input, $output, $question );
+		return $this->ask_question( $input, $output, $question );
 	}
 
 	/**
@@ -180,7 +254,7 @@ final class WPCOM_Site_Repository_Connect extends Command {
 			$question->setAutocompleterValues( array_column( get_github_repositories() ?? array(), 'name' ) );
 		}
 
-		return $this->getHelper( 'question' )->ask( $input, $output, $question );
+		return $this->ask_question( $input, $output, $question );
 	}
 
 	/**
@@ -197,7 +271,7 @@ final class WPCOM_Site_Repository_Connect extends Command {
 			$question->setAutocompleterValues( array_column( get_github_repository_branches( $this->gh_repository->name ) ?? array(), 'name' ) );
 		}
 
-		return $this->getHelper( 'question' )->ask( $input, $output, $question );
+		return $this->ask_question( $input, $output, $question );
 	}
 
 	/**
@@ -210,7 +284,27 @@ final class WPCOM_Site_Repository_Connect extends Command {
 	 */
 	private function prompt_target_dir_input( InputInterface $input, OutputInterface $output ): ?string {
 		$question = new Question( '<question>Enter the target directory to deploy to [/wp-content/]:</question> ', '/wp-content/' );
-		return $this->getHelper( 'question' )->ask( $input, $output, $question );
+		return $this->ask_question( $input, $output, $question );
+	}
+
+	/**
+	 * Asks a Symfony console question with the question helper.
+	 *
+	 * @param   InputInterface  $input    The input object.
+	 * @param   OutputInterface $output   The output object.
+	 * @param   Question        $question The question to ask.
+	 *
+	 * @throws  \RuntimeException If the Symfony question helper is unavailable.
+	 *
+	 * @return  mixed
+	 */
+	private function ask_question( InputInterface $input, OutputInterface $output, Question $question ): mixed {
+		$question_helper = $this->getHelper( 'question' );
+		if ( ! $question_helper instanceof \Symfony\Component\Console\Helper\QuestionHelper ) {
+			throw new \RuntimeException( 'Question helper is unavailable.' );
+		}
+
+		return $question_helper->ask( $input, $output, $question );
 	}
 
 	// endregion

--- a/commands/WPCOM_Site_Repository_Connect.php
+++ b/commands/WPCOM_Site_Repository_Connect.php
@@ -184,14 +184,12 @@ final class WPCOM_Site_Repository_Connect extends Command {
 				)
 			);
 			$sync_secret_command = sprintf(
-				'team51 --dev %s %s %s %s %s --url=%s --events=%s',
+				'team51 --dev %s %s %s %s %s',
 				WPCOM_Site_Deployment_Webhook_Secret_Sync::getDefaultName(),
 				escapeshellarg( (string) $this->site->ID ),
 				escapeshellarg( (string) $code_deployment->id ),
 				escapeshellarg( (string) $webhook->id ),
-				escapeshellarg( $secret ),
-				escapeshellarg( (string) ( $webhook->url ?? $webhook_url ) ),
-				escapeshellarg( implode( ',', $webhook_events ) )
+				escapeshellarg( $secret )
 			);
 			$output->writeln( "<comment>Copy/paste to retry sync:</comment>\n$sync_secret_command" );
 			return Command::FAILURE;

--- a/includes/api-helper.php
+++ b/includes/api-helper.php
@@ -81,8 +81,9 @@ final class API_Helper {
 	 * @return  stdClass|stdClass[]|true|null
 	 */
 	public static function make_opsoasis_request( string $endpoint, string $method = 'GET', mixed $body = null ): stdClass|array|true|null {
+		$base_url = rtrim( self::get_request_base_url(), '/' ) . '/';
 		$endpoint = ltrim( $endpoint, '/' );
-		return self::make_request( self::get_request_base_url() . $endpoint, $method, $body );
+		return self::make_request( $base_url . $endpoint, $method, $body );
 	}
 
 	/**
@@ -109,7 +110,8 @@ final class API_Helper {
 	 * @return  string
 	 */
 	protected static function get_request_base_url(): string {
-		return getenv( 'TEAM51_OPSOASIS_BASE_URL' ) ?: 'https://opsoasis.wpspecialprojects.com/wp-json/wpcomsp/';
+		$base_url = getenv( 'TEAM51_OPSOASIS_BASE_URL' ) ?: 'https://opsoasis.wpspecialprojects.com/wp-json/wpcomsp/';
+		return rtrim( $base_url, '/' ) . '/';
 	}
 
 	/**

--- a/includes/api-helper.php
+++ b/includes/api-helper.php
@@ -72,6 +72,20 @@ final class API_Helper {
 	}
 
 	/**
+	 * Calls a given OpsOasis endpoint and returns the response.
+	 *
+	 * @param   string $endpoint The endpoint to call relative to /wp-json/wpcomsp/.
+	 * @param   string $method   The HTTP method to use. One of 'GET', 'POST', 'PUT', 'DELETE'.
+	 * @param   mixed  $body     The body to send with the request.
+	 *
+	 * @return  stdClass|stdClass[]|true|null
+	 */
+	public static function make_opsoasis_request( string $endpoint, string $method = 'GET', mixed $body = null ): stdClass|array|true|null {
+		$endpoint = ltrim( $endpoint, '/' );
+		return self::make_request( self::get_request_base_url() . $endpoint, $method, $body );
+	}
+
+	/**
 	 * Calls a given WordPress.org endpoint and returns the response.
 	 *
 	 * @param   string $endpoint The endpoint to call.
@@ -123,7 +137,10 @@ final class API_Helper {
 		if ( ! str_starts_with( (string) $result['headers']['http_code'], '2' ) ) {
 			if ( 500 === $result['headers']['http_code'] && str_contains( $result['body'], 'site_already_exists' ) ) {
 				console_writeln( "❌ API error ({$result['headers']['http_code']} $endpoint): " . $result['body'] );
-				return (object) array( 'code' => 'site_already_exists', 'message' => 'A site with this name already exists' );
+				return (object) array(
+					'code'    => 'site_already_exists',
+					'message' => 'A site with this name already exists',
+				);
 			}
 
 			console_writeln( "❌ API error ({$result['headers']['http_code']} $endpoint): " . $result['body'] );

--- a/includes/functions-wpcom.php
+++ b/includes/functions-wpcom.php
@@ -548,7 +548,21 @@ function wait_until_jetpack_token_regenerated( string $site_id_or_url, OutputInt
  * @return  string
  */
 function get_wpcom_site_code_deployment_webhook_default_url(): string {
-	return getenv( 'TEAM51_WPCOM_DEPLOYMENT_WEBHOOK_URL' ) ?: 'https://opsoasis.wpspecialprojects.com/wp-json/wpcomsp/webhooks/v1/wpcom-deployments';
+	$webhook_url_override = getenv( 'TEAM51_WPCOM_DEPLOYMENT_WEBHOOK_URL' );
+	if ( false !== $webhook_url_override && '' !== trim( $webhook_url_override ) ) {
+		return $webhook_url_override;
+	}
+
+	$opsoasis_base_url = getenv( 'TEAM51_OPSOASIS_BASE_URL' ) ?: getenv( 'OPSOASIS_BASE_URL' ) ?: 'https://opsoasis.wpspecialprojects.com/wp-json/wpcomsp/';
+	$components        = parse_url( $opsoasis_base_url );
+	$origin            = sprintf(
+		'%s://%s%s',
+		$components['scheme'] ?? 'https',
+		$components['host'] ?? 'opsoasis.wpspecialprojects.com',
+		isset( $components['port'] ) ? ':' . $components['port'] : ''
+	);
+
+	return rtrim( $origin, '/' ) . '/wp-json/wpcomsp/webhooks/v1/wpcom-deployments';
 }
 
 /**
@@ -622,6 +636,30 @@ function create_wpcom_site_code_deployment_webhook( string $site_id_or_url, stri
  */
 function get_wpcom_site_code_deployment_webhooks( string $site_id_or_url, string $deployment_id ): ?array {
 	return API_Helper::make_wpcom_request( "sites/$site_id_or_url/code-deployments/$deployment_id/webhooks" )?->records;
+}
+
+/**
+ * Returns a deployment webhook for a WordPress.com code deployment by webhook ID.
+ *
+ * @param   string $site_id_or_url The ID or URL of the WordPress.com site.
+ * @param   string $deployment_id  The ID of the code deployment.
+ * @param   string $webhook_id     The ID of the webhook.
+ *
+ * @return  stdClass|null
+ */
+function get_wpcom_site_code_deployment_webhook( string $site_id_or_url, string $deployment_id, string $webhook_id ): ?stdClass {
+	$webhooks = get_wpcom_site_code_deployment_webhooks( $site_id_or_url, $deployment_id );
+	if ( is_null( $webhooks ) ) {
+		return null;
+	}
+
+	foreach ( $webhooks as $webhook ) {
+		if ( isset( $webhook->id ) && (string) $webhook->id === $webhook_id ) {
+			return $webhook;
+		}
+	}
+
+	return null;
 }
 
 /**
@@ -736,8 +774,26 @@ function sync_wpcom_site_code_deployment_webhook_secret( string $site_id, string
 		)
 	);
 
+	if ( is_null( $sync_response ) ) {
+		return null;
+	}
+
 	// OpsOasis may return either an empty success body (true) or a success object.
-	return is_null( $sync_response ) ? null : true;
+	if ( true === $sync_response ) {
+		return true;
+	}
+
+	if ( is_object( $sync_response ) ) {
+		$success     = $sync_response->success ?? null;
+		$status_code = $sync_response->status_code ?? null;
+		$error       = $sync_response->error ?? null;
+
+		if ( true === $success && ( is_null( $status_code ) || ( (int) $status_code >= 200 && (int) $status_code < 300 ) ) && is_null( $error ) ) {
+			return true;
+		}
+	}
+
+	return null;
 }
 
 /**

--- a/includes/functions-wpcom.php
+++ b/includes/functions-wpcom.php
@@ -543,6 +543,227 @@ function wait_until_jetpack_token_regenerated( string $site_id_or_url, OutputInt
 }
 
 /**
+ * Returns the default OpsOasis webhook receiver URL for WPCOM deployment status updates.
+ *
+ * @return  string
+ */
+function get_wpcom_site_code_deployment_webhook_default_url(): string {
+	return getenv( 'TEAM51_WPCOM_DEPLOYMENT_WEBHOOK_URL' ) ?: 'https://opsoasis.wpspecialprojects.com/wp-json/wpcomsp/webhooks/v1/wpcom-deployments';
+}
+
+/**
+ * Returns the default lifecycle events used when creating WPCOM deployment webhooks.
+ *
+ * @return  string
+ */
+function get_wpcom_site_code_deployment_webhook_default_events(): string {
+	return 'completed,failed,cancelled';
+}
+
+/**
+ * Normalizes webhook events input into a string array.
+ *
+ * @param   string|array|null $events Events as CSV string or an array.
+ *
+ * @return  string[]
+ */
+function normalize_wpcom_site_code_deployment_webhook_events( string|array|null $events ): array {
+	if ( is_array( $events ) ) {
+		return array_values( array_filter( array_map( static fn( mixed $event ) => trim( (string) $event ), $events ) ) );
+	}
+
+	$events_csv = trim( (string) $events );
+	if ( '' === $events_csv ) {
+		$events_csv = get_wpcom_site_code_deployment_webhook_default_events();
+	}
+
+	return array_values( array_filter( array_map( 'trim', explode( ',', $events_csv ) ) ) );
+}
+
+/**
+ * Returns the default OpsOasis endpoint used to persist WPCOM deployment webhook secrets.
+ *
+ * @return  string
+ */
+function get_wpcom_site_code_deployment_webhook_secret_sync_endpoint(): string {
+	return getenv( 'TEAM51_WPCOM_DEPLOYMENT_WEBHOOK_SECRET_SYNC_ENDPOINT' ) ?: 'webhooks/v1/wpcom-deployments/secrets';
+}
+
+/**
+ * Creates a new deployment webhook for a WordPress.com code deployment.
+ *
+ * @param   string      $site_id_or_url The ID or URL of the WordPress.com site to create the webhook for.
+ * @param   string      $deployment_id  The ID of the code deployment.
+ * @param   string      $url            The webhook receiver URL.
+ * @param   string|null $events         Optional. Comma-separated deployment lifecycle events.
+ *
+ * @return  stdClass|null
+ */
+function create_wpcom_site_code_deployment_webhook( string $site_id_or_url, string $deployment_id, string $url, ?string $events = null ): ?stdClass {
+	return API_Helper::make_wpcom_request(
+		"sites/$site_id_or_url/code-deployments/$deployment_id/webhooks",
+		'POST',
+		array_filter(
+			array(
+				'url'    => $url,
+				'events' => $events,
+			)
+		)
+	);
+}
+
+/**
+ * Returns the list of deployment webhooks for a WordPress.com code deployment.
+ *
+ * @param   string $site_id_or_url The ID or URL of the WordPress.com site.
+ * @param   string $deployment_id  The ID of the code deployment.
+ *
+ * @return  stdClass[]|null
+ */
+function get_wpcom_site_code_deployment_webhooks( string $site_id_or_url, string $deployment_id ): ?array {
+	return API_Helper::make_wpcom_request( "sites/$site_id_or_url/code-deployments/$deployment_id/webhooks" )?->records;
+}
+
+/**
+ * Updates a deployment webhook for a WordPress.com code deployment.
+ *
+ * @param   string      $site_id_or_url The ID or URL of the WordPress.com site.
+ * @param   string      $deployment_id  The ID of the code deployment.
+ * @param   string      $webhook_id     The ID of the webhook to update.
+ * @param   string      $url            The webhook receiver URL.
+ * @param   string|null $events         Optional. Comma-separated deployment lifecycle events.
+ *
+ * @return  stdClass|null
+ */
+function update_wpcom_site_code_deployment_webhook( string $site_id_or_url, string $deployment_id, string $webhook_id, string $url, ?string $events = null ): ?stdClass {
+	return API_Helper::make_wpcom_request(
+		"sites/$site_id_or_url/code-deployments/$deployment_id/webhooks/$webhook_id",
+		'PUT',
+		array_filter(
+			array(
+				'url'    => $url,
+				'events' => $events,
+			)
+		)
+	);
+}
+
+/**
+ * Deletes a deployment webhook for a WordPress.com code deployment.
+ *
+ * @param   string $site_id_or_url The ID or URL of the WordPress.com site.
+ * @param   string $deployment_id  The ID of the code deployment.
+ * @param   string $webhook_id     The ID of the webhook to delete.
+ * @param   mixed  $raw_response   Optional. The raw API response payload.
+ *
+ * @return  true|null
+ */
+function delete_wpcom_site_code_deployment_webhook( string $site_id_or_url, string $deployment_id, string $webhook_id, mixed &$raw_response = null ): ?true {
+	$delete_response = API_Helper::make_wpcom_request( "sites/$site_id_or_url/code-deployments/$deployment_id/webhooks/$webhook_id", 'DELETE' );
+	$raw_response    = $delete_response;
+
+	if ( is_null( $delete_response ) ) {
+		return null;
+	}
+
+	// WPCOM proxy can return either an empty success body (true) or a success object.
+	if ( true === $delete_response ) {
+		return true;
+	}
+
+	if ( is_object( $delete_response ) ) {
+		$success     = $delete_response->success ?? null;
+		$status_code = $delete_response->status_code ?? null;
+		$error       = $delete_response->error ?? null;
+
+		if ( true === $success && ( is_null( $status_code ) || ( (int) $status_code >= 200 && (int) $status_code < 300 ) ) && is_null( $error ) ) {
+			return true;
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Triggers a test delivery for a deployment webhook.
+ *
+ * @param   string $site_id_or_url The ID or URL of the WordPress.com site.
+ * @param   string $deployment_id  The ID of the code deployment.
+ * @param   string $webhook_id     The ID of the webhook to test.
+ *
+ * @return  stdClass|null
+ */
+function test_wpcom_site_code_deployment_webhook( string $site_id_or_url, string $deployment_id, string $webhook_id ): ?stdClass {
+	return API_Helper::make_wpcom_request( "sites/$site_id_or_url/code-deployments/$deployment_id/webhooks/$webhook_id/test", 'POST' );
+}
+
+/**
+ * Returns the deliveries of a deployment webhook.
+ *
+ * @param   string $site_id_or_url The ID or URL of the WordPress.com site.
+ * @param   string $deployment_id  The ID of the code deployment.
+ * @param   string $webhook_id     The ID of the webhook to inspect.
+ *
+ * @return  stdClass[]|null
+ */
+function get_wpcom_site_code_deployment_webhook_deliveries( string $site_id_or_url, string $deployment_id, string $webhook_id ): ?array {
+	return API_Helper::make_wpcom_request( "sites/$site_id_or_url/code-deployments/$deployment_id/webhooks/$webhook_id/deliveries" )?->records;
+}
+
+/**
+ * Attempts to persist a deployment webhook secret in OpsOasis so incoming webhook signatures can be verified.
+ *
+ * @param   string $site_id       The WPCOM site ID.
+ * @param   string $deployment_id The code deployment ID.
+ * @param   string $webhook_id    The webhook ID.
+ * @param   string $url           The webhook receiver URL.
+ * @param   array  $events        The webhook events subscribed for delivery.
+ * @param   string $secret        The webhook secret returned by WordPress.com.
+ *
+ * @return  true|null
+ */
+function sync_wpcom_site_code_deployment_webhook_secret( string $site_id, string $deployment_id, string $webhook_id, string $url, array $events, string $secret ): ?true {
+	$sync_response = API_Helper::make_opsoasis_request(
+		get_wpcom_site_code_deployment_webhook_secret_sync_endpoint(),
+		'POST',
+		array(
+			'site_id'       => is_numeric( $site_id ) ? (int) $site_id : $site_id,
+			'deployment_id' => $deployment_id,
+			'webhook_id'    => $webhook_id,
+			'url'           => $url,
+			'events'        => array_values( $events ),
+			'secret'        => $secret,
+		)
+	);
+
+	// OpsOasis may return either an empty success body (true) or a success object.
+	return is_null( $sync_response ) ? null : true;
+}
+
+/**
+ * Extracts the deployment webhook object from a WPCOM deployment webhook API response.
+ *
+ * @param   stdClass $response The webhook response payload.
+ *
+ * @return  stdClass
+ */
+function get_wpcom_site_code_deployment_webhook_from_response( stdClass $response ): stdClass {
+	return $response->webhook ?? $response;
+}
+
+/**
+ * Extracts a deployment webhook secret from a WPCOM deployment webhook API response.
+ *
+ * @param   stdClass $response The webhook response payload.
+ *
+ * @return  string|null
+ */
+function get_wpcom_site_code_deployment_webhook_secret_from_response( stdClass $response ): ?string {
+	$webhook = get_wpcom_site_code_deployment_webhook_from_response( $response );
+	return $webhook->secret ?? $response->secret ?? null;
+}
+
+/**
  * Connects a WordPress.com site to a GitHub repository for code deployments.
  *
  * @param   string     $site_id_or_url         The ID or URL of the WordPress.com site to connect to the GitHub repository.
@@ -657,6 +878,8 @@ function run_wpcom_site_wp_cli_command( string $site_id_or_url, string $wp_cli_c
  * @param   InputInterface $input         The console input.
  * @param   callable|null  $no_input_func The function to call if no input is given.
  * @param   string         $name          The name of the value to grab.
+ *
+ * @throws  InvalidArgumentException If the provided site does not resolve to a valid WPCOM site.
  *
  * @return  stdClass
  */

--- a/mcp/Team51McpTools.php
+++ b/mcp/Team51McpTools.php
@@ -653,7 +653,7 @@ final class Team51McpTools {
 			);
 		}
 
-		return array(
+		$result = array(
 			'success'               => true,
 			'site_id_or_url'        => $site_id_or_url,
 			'deployment_id'         => $deployment_id,
@@ -661,15 +661,20 @@ final class Team51McpTools {
 			'events'                => $webhook_events,
 			'secret_sync_attempted' => $sync_secret,
 			'secret_sync_succeeded' => $sync_succeeded,
-			'manual_sync_payload'   => array(
+		);
+
+		if ( ! $sync_secret || true !== $sync_succeeded ) {
+			$result['manual_sync_payload'] = array(
 				'site_id'       => (int) $site_id,
 				'deployment_id' => $deployment_id,
 				'webhook_id'    => (string) $webhook->id,
 				'url'           => $webhook_url,
 				'events'        => $webhook_events,
 				'secret'        => $secret,
-			),
-		);
+			);
+		}
+
+		return $result;
 	}
 
 	/**

--- a/mcp/Team51McpTools.php
+++ b/mcp/Team51McpTools.php
@@ -584,6 +584,205 @@ final class Team51McpTools {
 		return (array) $result;
 	}
 
+	/**
+	 * Create a deployment webhook for a WordPress.com code deployment and optionally
+	 * sync its one-time secret to OpsOasis.
+	 *
+	 * @param string $site_id_or_url The domain name or WPCOM site ID.
+	 * @param string $deployment_id  The code deployment ID.
+	 * @param string $url            Optional webhook destination URL.
+	 * @param string $events         Optional comma-separated webhook events.
+	 * @param bool   $sync_secret    Whether to immediately sync the webhook secret to OpsOasis.
+	 */
+	#[McpTool(
+		name: 'wpcom_create_deployment_webhook',
+		annotations: new ToolAnnotations(
+			title: 'Create WPCOM Deployment Webhook',
+			readOnlyHint: false,
+			destructiveHint: false,
+			idempotentHint: false,
+			openWorldHint: true,
+		)
+	)]
+	public function wpcom_create_deployment_webhook(
+		string $site_id_or_url,
+		string $deployment_id,
+		string $url = '',
+		string $events = '',
+		bool $sync_secret = true
+	): array {
+		$identity_error = self::ensure_identity();
+		if ( $identity_error ) {
+			return $identity_error;
+		}
+
+		$url             = '' !== trim( $url ) ? $url : get_wpcom_site_code_deployment_webhook_default_url();
+		$events          = '' !== trim( $events ) ? $events : get_wpcom_site_code_deployment_webhook_default_events();
+		$webhook_response = create_wpcom_site_code_deployment_webhook( $site_id_or_url, $deployment_id, $url, $events );
+		if ( null === $webhook_response ) {
+			return array( 'error' => 'Failed to create WPCOM deployment webhook.' );
+		}
+
+		$webhook = get_wpcom_site_code_deployment_webhook_from_response( $webhook_response );
+		$secret  = get_wpcom_site_code_deployment_webhook_secret_from_response( $webhook_response );
+		if ( null === $secret || '' === trim( $secret ) ) {
+			return array(
+				'error'    => 'Webhook was created but no secret was returned by WPCOM.',
+				'webhook'  => (array) $webhook,
+				'response' => (array) $webhook_response,
+			);
+		}
+
+		$webhook_url    = $webhook->url ?? $url;
+		$webhook_events = normalize_wpcom_site_code_deployment_webhook_events( $webhook->events ?? $events );
+		$sync_succeeded = null;
+		if ( $sync_secret ) {
+			$sync_succeeded = true === sync_wpcom_site_code_deployment_webhook_secret(
+				(string) $site_id_or_url,
+				$deployment_id,
+				(string) $webhook->id,
+				$webhook_url,
+				$webhook_events,
+				$secret
+			);
+		}
+
+		return array(
+			'success'               => true,
+			'site_id_or_url'        => $site_id_or_url,
+			'deployment_id'         => $deployment_id,
+			'webhook'               => (array) $webhook,
+			'events'                => $webhook_events,
+			'secret_sync_attempted' => $sync_secret,
+			'secret_sync_succeeded' => $sync_succeeded,
+			'manual_sync_payload'   => array(
+				'site_id'       => is_numeric( (string) $site_id_or_url ) ? (int) $site_id_or_url : $site_id_or_url,
+				'deployment_id' => $deployment_id,
+				'webhook_id'    => (string) $webhook->id,
+				'url'           => $webhook_url,
+				'events'        => $webhook_events,
+				'secret'        => $secret,
+			),
+		);
+	}
+
+	/**
+	 * List deployment webhooks configured for a WordPress.com code deployment.
+	 *
+	 * @param string $site_id_or_url The domain name or WPCOM site ID.
+	 * @param string $deployment_id  The code deployment ID.
+	 */
+	#[McpTool( name: 'wpcom_list_deployment_webhooks' )]
+	public function wpcom_list_deployment_webhooks( string $site_id_or_url, string $deployment_id ): array {
+		$identity_error = self::ensure_identity();
+		if ( $identity_error ) {
+			return $identity_error;
+		}
+
+		$webhooks = get_wpcom_site_code_deployment_webhooks( $site_id_or_url, $deployment_id );
+		if ( null === $webhooks ) {
+			return array( 'error' => 'Failed to list WPCOM deployment webhooks.' );
+		}
+
+		return array(
+			'count'    => count( $webhooks ),
+			'webhooks' => array_map(
+				static fn( $w ) => (array) $w,
+				$webhooks
+			),
+		);
+	}
+
+	/**
+	 * Delete a deployment webhook from a WordPress.com code deployment.
+	 *
+	 * @param string $site_id_or_url The domain name or WPCOM site ID.
+	 * @param string $deployment_id  The code deployment ID.
+	 * @param string $webhook_id     The webhook ID.
+	 */
+	#[McpTool(
+		name: 'wpcom_delete_deployment_webhook',
+		annotations: new ToolAnnotations(
+			title: 'Delete WPCOM Deployment Webhook',
+			readOnlyHint: false,
+			destructiveHint: true,
+			idempotentHint: true,
+			openWorldHint: true,
+		)
+	)]
+	public function wpcom_delete_deployment_webhook( string $site_id_or_url, string $deployment_id, string $webhook_id ): array {
+		$identity_error = self::ensure_identity();
+		if ( $identity_error ) {
+			return $identity_error;
+		}
+
+		$raw_response = null;
+		$result       = delete_wpcom_site_code_deployment_webhook( $site_id_or_url, $deployment_id, $webhook_id, $raw_response );
+		if ( true !== $result ) {
+			return array(
+				'error'        => 'Failed to delete WPCOM deployment webhook.',
+				'raw_response' => is_object( $raw_response ) ? (array) $raw_response : $raw_response,
+			);
+		}
+
+		return array(
+			'success'      => true,
+			'webhook_id'   => $webhook_id,
+			'raw_response' => is_object( $raw_response ) ? (array) $raw_response : $raw_response,
+		);
+	}
+
+	/**
+	 * Persist a WPCOM deployment webhook secret in OpsOasis.
+	 *
+	 * @param string $site_id       The WPCOM site ID.
+	 * @param string $deployment_id The code deployment ID.
+	 * @param string $webhook_id    The webhook ID.
+	 * @param string $secret        The one-time webhook secret returned by WPCOM.
+	 * @param string $url           Optional webhook destination URL.
+	 * @param string $events        Optional comma-separated webhook events.
+	 */
+	#[McpTool(
+		name: 'wpcom_sync_deployment_webhook_secret',
+		annotations: new ToolAnnotations(
+			title: 'Sync WPCOM Deployment Webhook Secret',
+			readOnlyHint: false,
+			destructiveHint: false,
+			idempotentHint: true,
+			openWorldHint: true,
+		)
+	)]
+	public function wpcom_sync_deployment_webhook_secret(
+		string $site_id,
+		string $deployment_id,
+		string $webhook_id,
+		string $secret,
+		string $url = '',
+		string $events = ''
+	): array {
+		$identity_error = self::ensure_identity();
+		if ( $identity_error ) {
+			return $identity_error;
+		}
+
+		$url            = '' !== trim( $url ) ? $url : get_wpcom_site_code_deployment_webhook_default_url();
+		$events         = '' !== trim( $events ) ? $events : get_wpcom_site_code_deployment_webhook_default_events();
+		$events_list    = normalize_wpcom_site_code_deployment_webhook_events( $events );
+		$sync_succeeded = true === sync_wpcom_site_code_deployment_webhook_secret( $site_id, $deployment_id, $webhook_id, $url, $events_list, $secret );
+		if ( ! $sync_succeeded ) {
+			return array( 'error' => 'Failed to sync WPCOM deployment webhook secret to OpsOasis.' );
+		}
+
+		return array(
+			'success'       => true,
+			'site_id'       => is_numeric( $site_id ) ? (int) $site_id : $site_id,
+			'deployment_id' => $deployment_id,
+			'webhook_id'    => $webhook_id,
+			'url'           => $url,
+			'events'        => $events_list,
+		);
+	}
+
 	// endregion
 
 	// region PRESSABLE TOOLS
@@ -1525,7 +1724,56 @@ final class Team51McpTools {
 			return array( 'error' => 'Failed to connect WPCOM site repository.' );
 		}
 
-		$result = array( 'deployment' => (array) $deployment );
+		$webhook_events_csv = get_wpcom_site_code_deployment_webhook_default_events();
+		$webhook_response   = create_wpcom_site_code_deployment_webhook(
+			(string) $site_id_or_url,
+			(string) $deployment->id,
+			get_wpcom_site_code_deployment_webhook_default_url(),
+			$webhook_events_csv
+		);
+		if ( null === $webhook_response ) {
+			return array(
+				'error'      => 'Repository was connected but deployment webhook creation failed.',
+				'deployment' => (array) $deployment,
+			);
+		}
+
+		$webhook = get_wpcom_site_code_deployment_webhook_from_response( $webhook_response );
+		$secret  = get_wpcom_site_code_deployment_webhook_secret_from_response( $webhook_response );
+		if ( null === $secret || '' === trim( $secret ) ) {
+			return array(
+				'error'      => 'Deployment webhook was created but no secret was returned by WPCOM.',
+				'deployment' => (array) $deployment,
+				'webhook'    => (array) $webhook,
+			);
+		}
+
+		$webhook_events        = normalize_wpcom_site_code_deployment_webhook_events( $webhook->events ?? $webhook_events_csv );
+		$secret_sync_succeeded = true === sync_wpcom_site_code_deployment_webhook_secret(
+			(string) $site_id_or_url,
+			(string) $deployment->id,
+			(string) $webhook->id,
+			$webhook->url ?? get_wpcom_site_code_deployment_webhook_default_url(),
+			$webhook_events,
+			$secret
+		);
+
+		$result = array(
+			'deployment'            => (array) $deployment,
+			'webhook'               => (array) $webhook,
+			'webhook_events'        => $webhook_events,
+			'secret_sync_succeeded' => $secret_sync_succeeded,
+		);
+		if ( ! $secret_sync_succeeded ) {
+			$result['manual_sync_payload'] = array(
+				'site_id'       => is_numeric( (string) $site_id_or_url ) ? (int) $site_id_or_url : $site_id_or_url,
+				'deployment_id' => (string) $deployment->id,
+				'webhook_id'    => (string) $webhook->id,
+				'url'           => $webhook->url ?? get_wpcom_site_code_deployment_webhook_default_url(),
+				'events'        => $webhook_events,
+				'secret'        => $secret,
+			);
+		}
 		if ( $deploy ) {
 			$run = create_wpcom_site_code_deployment_run( $site_id_or_url, $deployment->id );
 			$result['deployment_run'] = $run ? (array) $run : array( 'error' => 'Failed to trigger deployment run.' );

--- a/mcp/Team51McpTools.php
+++ b/mcp/Team51McpTools.php
@@ -618,6 +618,12 @@ final class Team51McpTools {
 
 		$url             = '' !== trim( $url ) ? $url : get_wpcom_site_code_deployment_webhook_default_url();
 		$events          = '' !== trim( $events ) ? $events : get_wpcom_site_code_deployment_webhook_default_events();
+		$site            = get_wpcom_site( $site_id_or_url );
+		if ( null === $site || ! isset( $site->ID ) ) {
+			return array( 'error' => "Failed to fetch WPCOM site: $site_id_or_url" );
+		}
+
+		$site_id          = (string) $site->ID;
 		$webhook_response = create_wpcom_site_code_deployment_webhook( $site_id_or_url, $deployment_id, $url, $events );
 		if ( null === $webhook_response ) {
 			return array( 'error' => 'Failed to create WPCOM deployment webhook.' );
@@ -638,7 +644,7 @@ final class Team51McpTools {
 		$sync_succeeded = null;
 		if ( $sync_secret ) {
 			$sync_succeeded = true === sync_wpcom_site_code_deployment_webhook_secret(
-				(string) $site_id_or_url,
+				$site_id,
 				$deployment_id,
 				(string) $webhook->id,
 				$webhook_url,
@@ -656,7 +662,7 @@ final class Team51McpTools {
 			'secret_sync_attempted' => $sync_secret,
 			'secret_sync_succeeded' => $sync_succeeded,
 			'manual_sync_payload'   => array(
-				'site_id'       => is_numeric( (string) $site_id_or_url ) ? (int) $site_id_or_url : $site_id_or_url,
+				'site_id'       => (int) $site_id,
 				'deployment_id' => $deployment_id,
 				'webhook_id'    => (string) $webhook->id,
 				'url'           => $webhook_url,
@@ -1719,6 +1725,12 @@ final class Team51McpTools {
 			return array( 'error' => "GitHub repository not found: $repository" );
 		}
 
+		$site = get_wpcom_site( $site_id_or_url );
+		if ( null === $site || ! isset( $site->ID ) ) {
+			return array( 'error' => "Failed to fetch WPCOM site: $site_id_or_url" );
+		}
+
+		$site_id    = (string) $site->ID;
 		$deployment = create_wpcom_site_code_deployment( $site_id_or_url, $gh_repository->id, $branch, $target_dir );
 		if ( null === $deployment ) {
 			return array( 'error' => 'Failed to connect WPCOM site repository.' );
@@ -1750,7 +1762,7 @@ final class Team51McpTools {
 
 		$webhook_events        = normalize_wpcom_site_code_deployment_webhook_events( $webhook->events ?? $webhook_events_csv );
 		$secret_sync_succeeded = true === sync_wpcom_site_code_deployment_webhook_secret(
-			(string) $site_id_or_url,
+			$site_id,
 			(string) $deployment->id,
 			(string) $webhook->id,
 			$webhook->url ?? get_wpcom_site_code_deployment_webhook_default_url(),
@@ -1766,7 +1778,7 @@ final class Team51McpTools {
 		);
 		if ( ! $secret_sync_succeeded ) {
 			$result['manual_sync_payload'] = array(
-				'site_id'       => is_numeric( (string) $site_id_or_url ) ? (int) $site_id_or_url : $site_id_or_url,
+				'site_id'       => (int) $site_id,
 				'deployment_id' => (string) $deployment->id,
 				'webhook_id'    => (string) $webhook->id,
 				'url'           => $webhook->url ?? get_wpcom_site_code_deployment_webhook_default_url(),


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add WordPress.com deployment webhook support to `team51-cli`:
  * New WPCOM helper functions for webhook create/list/update/delete/test/deliveries.
  * New OpsOasis request helper and webhook secret sync flow.
* Update `wpcom:connect-site-repository` to automatically:
  * Create a deployment webhook.
  * Capture the one-time secret.
  * Sync the secret to OpsOasis and show a manual sync payload/command when sync fails.
* Add new standalone webhook CLI commands:
  * `wpcom:site:deployment:webhook:create`
  * `wpcom:site:deployment:webhook:list`
  * `wpcom:site:deployment:webhook:delete`
  * `wpcom:site:deployment:webhook:sync-secret`
* Improve UX and reliability:
  * Allow deployment auto-selection from site when `deployment_id` is omitted.
  * Ensure `wpcom:create-site` and `wpcom:clone-site` correctly fail when repo connect/webhook setup fails.
  * Normalize object-based API success responses (e.g. `{ "success": true }`) for sync/delete helpers.
* Extend MCP support for webhook workflows:
  * Add MCP tools for webhook create/list/delete/sync-secret.
  * Update MCP `wpcom_connect_site_repository` to mirror CLI webhook + secret sync behavior.
* Update README MCP/tooling docs and webhook usage examples.

#### Testing instructions

* Verify webhook create/list/delete commands:
  * `team51 --dev wpcom:site:deployment:webhook:create <site> [deployment_id]`
  * `team51 --dev wpcom:site:deployment:webhook:list <site> [deployment_id]`
  * `team51 --dev wpcom:site:deployment:webhook:delete <site> [deployment_id] [webhook_id]`
* Verify manual sync fallback:
  * Run create with a forced sync failure scenario and execute printed retry command:
  * `team51 --dev wpcom:site:deployment:webhook:sync-secret <site> <deployment_id> <webhook_id> <secret> --url=... --events=...`
* Verify connect flow creates webhook + syncs secret before deploy:
  * `team51 --dev wpcom:connect-site-repository <site> <repo> --branch=trunk --target_dir=/wp-content/ --deploy`
* Verify create/clone propagate connect failures:
  * `team51 --dev wpcom:create-site <name> --repository=<repo>`
  * `team51 --dev wpcom:clone-site <site> --branch=develop`
  * Confirm command returns failure when webhook creation/sync fails.
* Verify MCP webhook tools:
  * `wpcom_create_deployment_webhook`
  * `wpcom_list_deployment_webhooks`
  * `wpcom_delete_deployment_webhook`
  * `wpcom_sync_deployment_webhook_secret`
  * and `wpcom_connect_site_repository` returns webhook + secret sync metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added deployment webhook management for WordPress.com sites: create, list, delete, and secret sync; added DeployHQ service tooling.
  * Added four new MCP tools for webhook operations and secret management.

* **Bug Fixes**
  * Improved error handling during site creation with GitHub Deployment integration.

* **Documentation**
  * Tool count increased to 43; added comprehensive deployment webhook docs and updated usage content; minor content reflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->