### PR TITLE
Add plugin download commands for Pressable/WPCOM and expose via MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,12 @@ claude mcp add team51 -- team51 --mcp
 
 ### Available Tools
 
-The MCP server exposes 43 tools across all services:
+The MCP server exposes 45 tools across all services:
 
 | Service | Read Tools | Write Tools |
 |---------|-----------|-------------|
-| **WPCOM** | `wpcom_list_sites`, `wpcom_get_site`, `wpcom_list_site_plugins`, `wpcom_list_site_stickers`, `wpcom_list_sites_with_sticker`, `wpcom_get_site_stats`, `wpcom_list_site_users`, `wpcom_list_deployment_webhooks` | `wpcom_add_sticker`, `wpcom_remove_sticker`, `wpcom_update_site`, `wpcom_rotate_sftp_password`, `wpcom_create_deployment_webhook`, `wpcom_delete_deployment_webhook`, `wpcom_sync_deployment_webhook_secret` |
-| **Pressable** | `pressable_list_sites`, `pressable_get_site`, `pressable_get_php_errors`, `pressable_list_collaborators`, `pressable_list_sftp_users`, `pressable_list_site_domains` | `pressable_create_site_note`, `pressable_add_collaborator`, `pressable_remove_collaborator`, `pressable_add_domain`, `pressable_rotate_sftp_password` |
+| **WPCOM** | `wpcom_list_sites`, `wpcom_get_site`, `wpcom_list_site_plugins`, `wpcom_list_site_stickers`, `wpcom_list_sites_with_sticker`, `wpcom_get_site_stats`, `wpcom_list_site_users`, `wpcom_list_deployment_webhooks`, `wpcom_download_site_plugins` | `wpcom_add_sticker`, `wpcom_remove_sticker`, `wpcom_update_site`, `wpcom_rotate_sftp_password`, `wpcom_create_deployment_webhook`, `wpcom_delete_deployment_webhook`, `wpcom_sync_deployment_webhook_secret` |
+| **Pressable** | `pressable_list_sites`, `pressable_get_site`, `pressable_get_php_errors`, `pressable_list_collaborators`, `pressable_list_sftp_users`, `pressable_list_site_domains`, `pressable_download_site_plugins` | `pressable_create_site_note`, `pressable_add_collaborator`, `pressable_remove_collaborator`, `pressable_add_domain`, `pressable_rotate_sftp_password` |
 | **GitHub** | `github_list_repositories`, `github_get_repository`, `github_list_branches`, `github_list_secrets`, `github_list_workflow_runs` | `github_set_topics`, `github_create_branch`, `github_set_secret`, `github_create_issue` |
 | **Jetpack** | `jetpack_list_modules`, `jetpack_list_site_modules` | `jetpack_update_module_settings` |
 | **DeployHQ** | `deployhq_list_projects`, `deployhq_get_project`, `deployhq_list_project_servers` | `deployhq_rotate_private_key`, `deployhq_connect_repository` |
@@ -143,6 +143,18 @@ team51 wpcom:site:deployment:webhook:delete <site> [deployment_id] <webhook_id>
 
 # Manual secret sync fallback (if automatic sync fails)
 team51 wpcom:site:deployment:webhook:sync-secret <site> <deployment_id> <webhook_id> <secret>
+```
+
+### Download site plugins
+
+You can download installed plugins from a Pressable or WPCOM site as a `.tar.gz` archive:
+
+```bash
+# Downloads only wp-content/plugins (does not include mu-plugins)
+team51 pressable:download-site-plugins <site> [--destination=/path/to/plugins.tar.gz]
+
+# Downloads only wp-content/plugins (does not include mu-plugins)
+team51 wpcom:download-site-plugins <site> [--destination=/path/to/plugins.tar.gz]
 ```
 
 ### Conventions around defaults

--- a/README.md
+++ b/README.md
@@ -97,12 +97,12 @@ claude mcp add team51 -- team51 --mcp
 
 ### Available Tools
 
-The MCP server exposes 45 tools across all services:
+The MCP server currently exposes 66 tools across all services. The table below shows a subset of commonly used tools:
 
 | Service | Read Tools | Write Tools |
 |---------|-----------|-------------|
-| **WPCOM** | `wpcom_list_sites`, `wpcom_get_site`, `wpcom_list_site_plugins`, `wpcom_list_site_stickers`, `wpcom_list_sites_with_sticker`, `wpcom_get_site_stats`, `wpcom_list_site_users`, `wpcom_list_deployment_webhooks`, `wpcom_download_site_plugins` | `wpcom_add_sticker`, `wpcom_remove_sticker`, `wpcom_update_site`, `wpcom_rotate_sftp_password`, `wpcom_create_deployment_webhook`, `wpcom_delete_deployment_webhook`, `wpcom_sync_deployment_webhook_secret` |
-| **Pressable** | `pressable_list_sites`, `pressable_get_site`, `pressable_get_php_errors`, `pressable_list_collaborators`, `pressable_list_sftp_users`, `pressable_list_site_domains`, `pressable_download_site_plugins` | `pressable_create_site_note`, `pressable_add_collaborator`, `pressable_remove_collaborator`, `pressable_add_domain`, `pressable_rotate_sftp_password` |
+| **WPCOM** | `wpcom_list_sites`, `wpcom_get_site`, `wpcom_list_site_plugins`, `wpcom_list_site_stickers`, `wpcom_list_sites_with_sticker`, `wpcom_get_site_stats`, `wpcom_list_site_users`, `wpcom_list_deployment_webhooks` | `wpcom_add_sticker`, `wpcom_remove_sticker`, `wpcom_update_site`, `wpcom_rotate_sftp_password`, `wpcom_create_deployment_webhook`, `wpcom_delete_deployment_webhook`, `wpcom_sync_deployment_webhook_secret`, `wpcom_download_site_plugins` |
+| **Pressable** | `pressable_list_sites`, `pressable_get_site`, `pressable_get_php_errors`, `pressable_list_collaborators`, `pressable_list_sftp_users`, `pressable_list_site_domains` | `pressable_create_site_note`, `pressable_add_collaborator`, `pressable_remove_collaborator`, `pressable_add_domain`, `pressable_rotate_sftp_password`, `pressable_download_site_plugins` |
 | **GitHub** | `github_list_repositories`, `github_get_repository`, `github_list_branches`, `github_list_secrets`, `github_list_workflow_runs` | `github_set_topics`, `github_create_branch`, `github_set_secret`, `github_create_issue` |
 | **Jetpack** | `jetpack_list_modules`, `jetpack_list_site_modules` | `jetpack_update_module_settings` |
 | **DeployHQ** | `deployhq_list_projects`, `deployhq_get_project`, `deployhq_list_project_servers` | `deployhq_rotate_private_key`, `deployhq_connect_repository` |

--- a/commands/Pressable_Site_Plugins_Download.php
+++ b/commands/Pressable_Site_Plugins_Download.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WPCOMSpecialProjects\CLI\Command;
 
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -71,11 +73,13 @@ final class Pressable_Site_Plugins_Download extends Command {
 		$timestamp            = \gmdate( 'Y-m-d-H-i-s' );
 		$archive_filename     = "team51-pressable-plugins-$site_slug-$timestamp.tar.gz";
 		$remote_archive_paths = array(
-			"htdocs/wp-content/$archive_filename",
-			"/htdocs/wp-content/$archive_filename",
+			"/tmp/$archive_filename",
+			"tmp/$archive_filename",
 		);
 		$remote_cleanup_error = false;
 		$archive_created      = false;
+		$download_successful  = false;
+		$download_valid       = false;
 
 		$archive_ssh = \Pressable_Connection_Helper::get_ssh_connection( (string) $this->site->id );
 		if ( \is_null( $archive_ssh ) ) {
@@ -87,10 +91,10 @@ final class Pressable_Site_Plugins_Download extends Command {
 			$archive_ssh->setTimeout( 0 );
 
 			$archive_command = 'if [ -d htdocs/wp-content/plugins ]; then '
-				. 'archive_path=' . escapeshellarg( "htdocs/wp-content/$archive_filename" ) . '; '
+				. 'if [ -d /tmp ]; then archive_path=' . escapeshellarg( "/tmp/$archive_filename" ) . '; else archive_path=' . escapeshellarg( "tmp/$archive_filename" ) . '; fi; '
 				. 'tar -czf "$archive_path" -C htdocs/wp-content plugins; '
 				. 'elif [ -d /htdocs/wp-content/plugins ]; then '
-				. 'archive_path=' . escapeshellarg( "/htdocs/wp-content/$archive_filename" ) . '; '
+				. 'if [ -d /tmp ]; then archive_path=' . escapeshellarg( "/tmp/$archive_filename" ) . '; else archive_path=' . escapeshellarg( "tmp/$archive_filename" ) . '; fi; '
 				. 'tar -czf "$archive_path" -C /htdocs/wp-content plugins; '
 				. 'else '
 				. 'false; '
@@ -108,36 +112,24 @@ final class Pressable_Site_Plugins_Download extends Command {
 		$archive_created = true;
 
 		$sftp = \Pressable_Connection_Helper::get_sftp_connection( (string) $this->site->id );
-		if ( \is_null( $sftp ) ) {
-			$output->writeln( '<error>Failed to connect to the site via SFTP.</error>' );
-			return Command::FAILURE;
-		}
+		if ( ! \is_null( $sftp ) ) {
+			try {
+				$sftp->setTimeout( 0 );
 
-		try {
-			$sftp->setTimeout( 0 );
-
-			$download_successful = false;
-			foreach ( $remote_archive_paths as $sftp_path ) {
-				if ( $sftp->get( $sftp_path, $this->destination ) ) {
-					$download_successful = true;
-					break;
+				foreach ( $remote_archive_paths as $sftp_path ) {
+					if ( $sftp->get( $sftp_path, $this->destination ) ) {
+						$download_successful = true;
+						break;
+					}
 				}
-			}
 
-			if ( ! $download_successful ) {
-				$output->writeln( '<error>Failed to download the plugin archive via SFTP.</error>' );
-				return Command::FAILURE;
+				$download_valid = $download_successful && \is_file( $this->destination ) && 0 < \filesize( $this->destination );
+			} finally {
+				$sftp->disconnect();
 			}
-
-			if ( ! \is_file( $this->destination ) || 0 === \filesize( $this->destination ) ) {
-				$output->writeln( '<error>Downloaded archive appears invalid or empty.</error>' );
-				return Command::FAILURE;
-			}
-		} finally {
-			$sftp->disconnect();
 		}
 
-		if ( $archive_created ) {
+		if ( $archive_created ) { // Always cleanup after archive creation.
 			$cleanup_ssh = \Pressable_Connection_Helper::get_ssh_connection( (string) $this->site->id );
 			if ( \is_null( $cleanup_ssh ) ) {
 				$remote_cleanup_error = true;
@@ -159,8 +151,24 @@ final class Pressable_Site_Plugins_Download extends Command {
 			}
 		}
 
+		if ( \is_null( $sftp ) ) {
+			$output->writeln( '<error>Failed to connect to the site via SFTP.</error>' );
+			return Command::FAILURE;
+		}
+
+		if ( ! $download_successful ) {
+			$output->writeln( '<error>Failed to download the plugin archive via SFTP.</error>' );
+			return Command::FAILURE;
+		}
+
+		if ( ! $download_valid ) {
+			$output->writeln( '<error>Downloaded archive appears invalid or empty.</error>' );
+			return Command::FAILURE;
+		}
+
 		if ( $remote_cleanup_error ) {
-			$output->writeln( '<comment>Plugin archive downloaded, but failed to clean up the temporary remote archive.</comment>' );
+			$output->writeln( '<error>Plugin archive downloaded, but failed to clean up the temporary remote archive.</error>' );
+			return Command::FAILURE;
 		}
 
 		$output->writeln( '<fg=green;options=bold>Plugins downloaded successfully.</>' );

--- a/commands/Pressable_Site_Plugins_Download.php
+++ b/commands/Pressable_Site_Plugins_Download.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace WPCOMSpecialProjects\CLI\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use WPCOMSpecialProjects\CLI\Helper\AutocompleteTrait;
+
+/**
+ * Downloads all regular plugins from a Pressable site.
+ */
+#[AsCommand( name: 'pressable:download-site-plugins' )]
+final class Pressable_Site_Plugins_Download extends Command {
+	use AutocompleteTrait;
+
+	// region FIELDS AND CONSTANTS
+
+	/**
+	 * Pressable site definition to download plugins from.
+	 *
+	 * @var \stdClass|null
+	 */
+	private ?\stdClass $site = null;
+
+	/**
+	 * Local path to save the archive to.
+	 *
+	 * @var string|null
+	 */
+	private ?string $destination = null;
+
+	// endregion
+
+	// region INHERITED METHODS
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function configure(): void {
+		$this->setDescription( 'Download plugins from a Pressable site.' )
+			->setHelp( 'Use this command to download all plugins from wp-content/plugins on a Pressable site.' );
+
+		$this->addArgument( 'site', InputArgument::REQUIRED, 'Domain or Pressable site ID to download plugins from.' )
+			->addOption( 'destination', null, InputOption::VALUE_REQUIRED, 'The destination path where the plugin archive will be saved.' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function initialize( InputInterface $input, OutputInterface $output ): void {
+		$this->site = get_pressable_site_input( $input, fn() => $this->prompt_site_input( $input, $output ) );
+		$input->setArgument( 'site', $this->site );
+
+		$this->destination = get_string_input( $input, 'destination', fn() => $this->prompt_destination_input( $input, $output ) );
+		$input->setOption( 'destination', $this->destination );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( InputInterface $input, OutputInterface $output ): int {
+		$output->writeln( "<fg=magenta;options=bold>Downloading plugins from Pressable site {$this->site->displayName} (ID {$this->site->id}, URL {$this->site->url}) to {$this->destination}.</>" );
+
+		$site_slug            = slugify( (string) $this->site->name );
+		$timestamp            = \gmdate( 'Y-m-d-H-i-s' );
+		$archive_filename     = "team51-pressable-plugins-$site_slug-$timestamp.tar.gz";
+		$remote_archive_paths = array(
+			"htdocs/wp-content/$archive_filename",
+			"/htdocs/wp-content/$archive_filename",
+		);
+		$remote_cleanup_error = false;
+		$archive_created      = false;
+
+		$archive_ssh = \Pressable_Connection_Helper::get_ssh_connection( (string) $this->site->id );
+		if ( \is_null( $archive_ssh ) ) {
+			$output->writeln( '<error>Failed to connect to the site via SSH.</error>' );
+			return Command::FAILURE;
+		}
+
+		try {
+			$archive_ssh->setTimeout( 0 );
+
+			$archive_command = 'if [ -d htdocs/wp-content/plugins ]; then '
+				. 'archive_path=' . escapeshellarg( "htdocs/wp-content/$archive_filename" ) . '; '
+				. 'tar -czf "$archive_path" -C htdocs/wp-content plugins; '
+				. 'elif [ -d /htdocs/wp-content/plugins ]; then '
+				. 'archive_path=' . escapeshellarg( "/htdocs/wp-content/$archive_filename" ) . '; '
+				. 'tar -czf "$archive_path" -C /htdocs/wp-content plugins; '
+				. 'else '
+				. 'false; '
+				. 'fi; '
+				. 'exit $? 2>&1';
+			$archive_ssh->exec( $archive_command );
+			if ( 0 !== $archive_ssh->getExitStatus() ) {
+				$output->writeln( '<error>Failed to create the remote plugin archive from wp-content/plugins.</error>' );
+				return Command::FAILURE;
+			}
+		} finally {
+			$archive_ssh->disconnect();
+		}
+
+		$archive_created = true;
+
+		$sftp = \Pressable_Connection_Helper::get_sftp_connection( (string) $this->site->id );
+		if ( \is_null( $sftp ) ) {
+			$output->writeln( '<error>Failed to connect to the site via SFTP.</error>' );
+			return Command::FAILURE;
+		}
+
+		try {
+			$sftp->setTimeout( 0 );
+
+			$download_successful = false;
+			foreach ( $remote_archive_paths as $sftp_path ) {
+				if ( $sftp->get( $sftp_path, $this->destination ) ) {
+					$download_successful = true;
+					break;
+				}
+			}
+
+			if ( ! $download_successful ) {
+				$output->writeln( '<error>Failed to download the plugin archive via SFTP.</error>' );
+				return Command::FAILURE;
+			}
+
+			if ( ! \is_file( $this->destination ) || 0 === \filesize( $this->destination ) ) {
+				$output->writeln( '<error>Downloaded archive appears invalid or empty.</error>' );
+				return Command::FAILURE;
+			}
+		} finally {
+			$sftp->disconnect();
+		}
+
+		if ( $archive_created ) {
+			$cleanup_ssh = \Pressable_Connection_Helper::get_ssh_connection( (string) $this->site->id );
+			if ( \is_null( $cleanup_ssh ) ) {
+				$remote_cleanup_error = true;
+			} else {
+				try {
+					$cleanup_ssh->setTimeout( 0 );
+					$cleanup_command = 'rm -f '
+						. escapeshellarg( $remote_archive_paths[0] )
+						. ' '
+						. escapeshellarg( $remote_archive_paths[1] )
+						. ' 2>&1';
+					$cleanup_ssh->exec( $cleanup_command );
+					if ( 0 !== $cleanup_ssh->getExitStatus() ) {
+						$remote_cleanup_error = true;
+					}
+				} finally {
+					$cleanup_ssh->disconnect();
+				}
+			}
+		}
+
+		if ( $remote_cleanup_error ) {
+			$output->writeln( '<comment>Plugin archive downloaded, but failed to clean up the temporary remote archive.</comment>' );
+		}
+
+		$output->writeln( '<fg=green;options=bold>Plugins downloaded successfully.</>' );
+		return Command::SUCCESS;
+	}
+
+	// endregion
+
+	// region HELPERS
+
+	/**
+	 * Prompts the user for a site.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  string|null
+	 */
+	private function prompt_site_input( InputInterface $input, OutputInterface $output ): ?string {
+		$question = new Question( '<question>Enter the domain or Pressable site ID to download plugins from:</question> ' );
+		if ( ! $input->getOption( 'no-autocomplete' ) ) {
+			$question->setAutocompleterValues( \array_column( get_pressable_sites( include_aliases: true ) ?? array(), 'url' ) );
+		}
+
+		/**
+		 * The Symfony question helper.
+		 *
+		 * @var QuestionHelper $question_helper
+		 */
+		$question_helper = $this->getHelper( 'question' );
+		return $question_helper->ask( $input, $output, $question );
+	}
+
+	/**
+	 * Prompts the user for destination path.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  string|null
+	 */
+	private function prompt_destination_input( InputInterface $input, OutputInterface $output ): ?string {
+		$site_slug = \is_null( $this->site ) ? 'unknown-site' : slugify( (string) $this->site->name );
+		$default   = get_user_folder_path( "Downloads/pressable-plugins-$site_slug-" . \gmdate( 'Y-m-d-H-i-s' ) . '.tar.gz' );
+		$question  = new Question( "<question>Please enter the path to save the plugins archive [$default]:</question> ", $default );
+
+		/**
+		 * The Symfony question helper.
+		 *
+		 * @var QuestionHelper $question_helper
+		 */
+		$question_helper = $this->getHelper( 'question' );
+		return $question_helper->ask( $input, $output, $question );
+	}
+
+	// endregion
+}

--- a/commands/WPCOM_Site_Plugins_Download.php
+++ b/commands/WPCOM_Site_Plugins_Download.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WPCOMSpecialProjects\CLI\Command;
 
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -71,11 +73,13 @@ final class WPCOM_Site_Plugins_Download extends Command {
 		$timestamp            = \gmdate( 'Y-m-d-H-i-s' );
 		$archive_filename     = "team51-wpcom-plugins-$site_slug-$timestamp.tar.gz";
 		$remote_archive_paths = array(
-			"htdocs/wp-content/$archive_filename",
-			"/htdocs/wp-content/$archive_filename",
+			"/tmp/$archive_filename",
+			"tmp/$archive_filename",
 		);
 		$remote_cleanup_error = false;
 		$archive_created      = false;
+		$download_successful  = false;
+		$download_valid       = false;
 
 		$archive_ssh = \WPCOM_Connection_Helper::get_ssh_connection( (string) $this->site->ID );
 		if ( \is_null( $archive_ssh ) ) {
@@ -87,10 +91,10 @@ final class WPCOM_Site_Plugins_Download extends Command {
 			$archive_ssh->setTimeout( 0 );
 
 			$archive_command = 'if [ -d htdocs/wp-content/plugins ]; then '
-				. 'archive_path=' . escapeshellarg( "htdocs/wp-content/$archive_filename" ) . '; '
+				. 'if [ -d /tmp ]; then archive_path=' . escapeshellarg( "/tmp/$archive_filename" ) . '; else archive_path=' . escapeshellarg( "tmp/$archive_filename" ) . '; fi; '
 				. 'tar -czf "$archive_path" -C htdocs/wp-content plugins; '
 				. 'elif [ -d /htdocs/wp-content/plugins ]; then '
-				. 'archive_path=' . escapeshellarg( "/htdocs/wp-content/$archive_filename" ) . '; '
+				. 'if [ -d /tmp ]; then archive_path=' . escapeshellarg( "/tmp/$archive_filename" ) . '; else archive_path=' . escapeshellarg( "tmp/$archive_filename" ) . '; fi; '
 				. 'tar -czf "$archive_path" -C /htdocs/wp-content plugins; '
 				. 'else '
 				. 'false; '
@@ -108,36 +112,24 @@ final class WPCOM_Site_Plugins_Download extends Command {
 		$archive_created = true;
 
 		$sftp = \WPCOM_Connection_Helper::get_sftp_connection( (string) $this->site->ID );
-		if ( \is_null( $sftp ) ) {
-			$output->writeln( '<error>Failed to connect to the site via SFTP.</error>' );
-			return Command::FAILURE;
-		}
+		if ( ! \is_null( $sftp ) ) {
+			try {
+				$sftp->setTimeout( 0 );
 
-		try {
-			$sftp->setTimeout( 0 );
-
-			$download_successful = false;
-			foreach ( $remote_archive_paths as $sftp_path ) {
-				if ( $sftp->get( $sftp_path, $this->destination ) ) {
-					$download_successful = true;
-					break;
+				foreach ( $remote_archive_paths as $sftp_path ) {
+					if ( $sftp->get( $sftp_path, $this->destination ) ) {
+						$download_successful = true;
+						break;
+					}
 				}
-			}
 
-			if ( ! $download_successful ) {
-				$output->writeln( '<error>Failed to download the plugin archive via SFTP.</error>' );
-				return Command::FAILURE;
+				$download_valid = $download_successful && \is_file( $this->destination ) && 0 < \filesize( $this->destination );
+			} finally {
+				$sftp->disconnect();
 			}
-
-			if ( ! \is_file( $this->destination ) || 0 === \filesize( $this->destination ) ) {
-				$output->writeln( '<error>Downloaded archive appears invalid or empty.</error>' );
-				return Command::FAILURE;
-			}
-		} finally {
-			$sftp->disconnect();
 		}
 
-		if ( $archive_created ) {
+		if ( $archive_created ) { // Always cleanup after archive creation.
 			$cleanup_ssh = \WPCOM_Connection_Helper::get_ssh_connection( (string) $this->site->ID );
 			if ( \is_null( $cleanup_ssh ) ) {
 				$remote_cleanup_error = true;
@@ -159,8 +151,24 @@ final class WPCOM_Site_Plugins_Download extends Command {
 			}
 		}
 
+		if ( \is_null( $sftp ) ) {
+			$output->writeln( '<error>Failed to connect to the site via SFTP.</error>' );
+			return Command::FAILURE;
+		}
+
+		if ( ! $download_successful ) {
+			$output->writeln( '<error>Failed to download the plugin archive via SFTP.</error>' );
+			return Command::FAILURE;
+		}
+
+		if ( ! $download_valid ) {
+			$output->writeln( '<error>Downloaded archive appears invalid or empty.</error>' );
+			return Command::FAILURE;
+		}
+
 		if ( $remote_cleanup_error ) {
-			$output->writeln( '<comment>Plugin archive downloaded, but failed to clean up the temporary remote archive.</comment>' );
+			$output->writeln( '<error>Plugin archive downloaded, but failed to clean up the temporary remote archive.</error>' );
+			return Command::FAILURE;
 		}
 
 		$output->writeln( '<fg=green;options=bold>Plugins downloaded successfully.</>' );

--- a/commands/WPCOM_Site_Plugins_Download.php
+++ b/commands/WPCOM_Site_Plugins_Download.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace WPCOMSpecialProjects\CLI\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use WPCOMSpecialProjects\CLI\Helper\AutocompleteTrait;
+
+/**
+ * Downloads all regular plugins from a WPCOM site.
+ */
+#[AsCommand( name: 'wpcom:download-site-plugins' )]
+final class WPCOM_Site_Plugins_Download extends Command {
+	use AutocompleteTrait;
+
+	// region FIELDS AND CONSTANTS
+
+	/**
+	 * WPCOM site definition to download plugins from.
+	 *
+	 * @var \stdClass|null
+	 */
+	private ?\stdClass $site = null;
+
+	/**
+	 * Local path to save the archive to.
+	 *
+	 * @var string|null
+	 */
+	private ?string $destination = null;
+
+	// endregion
+
+	// region INHERITED METHODS
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function configure(): void {
+		$this->setDescription( 'Download plugins from a WPCOM site.' )
+			->setHelp( 'Use this command to download all plugins from wp-content/plugins on a WPCOM site.' );
+
+		$this->addArgument( 'site', InputArgument::REQUIRED, 'Domain or WPCOM site ID to download plugins from.' )
+			->addOption( 'destination', null, InputOption::VALUE_REQUIRED, 'The destination path where the plugin archive will be saved.' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function initialize( InputInterface $input, OutputInterface $output ): void {
+		$this->site = get_wpcom_site_input( $input, fn() => $this->prompt_site_input( $input, $output ) );
+		$input->setArgument( 'site', $this->site );
+
+		$this->destination = get_string_input( $input, 'destination', fn() => $this->prompt_destination_input( $input, $output ) );
+		$input->setOption( 'destination', $this->destination );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( InputInterface $input, OutputInterface $output ): int {
+		$output->writeln( "<fg=magenta;options=bold>Downloading plugins from WPCOM site {$this->site->name} (ID {$this->site->ID}, URL {$this->site->URL}) to {$this->destination}.</>" );
+
+		$site_slug            = slugify( (string) $this->site->name );
+		$timestamp            = \gmdate( 'Y-m-d-H-i-s' );
+		$archive_filename     = "team51-wpcom-plugins-$site_slug-$timestamp.tar.gz";
+		$remote_archive_paths = array(
+			"htdocs/wp-content/$archive_filename",
+			"/htdocs/wp-content/$archive_filename",
+		);
+		$remote_cleanup_error = false;
+		$archive_created      = false;
+
+		$archive_ssh = \WPCOM_Connection_Helper::get_ssh_connection( (string) $this->site->ID );
+		if ( \is_null( $archive_ssh ) ) {
+			$output->writeln( '<error>Failed to connect to the site via SSH.</error>' );
+			return Command::FAILURE;
+		}
+
+		try {
+			$archive_ssh->setTimeout( 0 );
+
+			$archive_command = 'if [ -d htdocs/wp-content/plugins ]; then '
+				. 'archive_path=' . escapeshellarg( "htdocs/wp-content/$archive_filename" ) . '; '
+				. 'tar -czf "$archive_path" -C htdocs/wp-content plugins; '
+				. 'elif [ -d /htdocs/wp-content/plugins ]; then '
+				. 'archive_path=' . escapeshellarg( "/htdocs/wp-content/$archive_filename" ) . '; '
+				. 'tar -czf "$archive_path" -C /htdocs/wp-content plugins; '
+				. 'else '
+				. 'false; '
+				. 'fi; '
+				. 'exit $? 2>&1';
+			$archive_ssh->exec( $archive_command );
+			if ( 0 !== $archive_ssh->getExitStatus() ) {
+				$output->writeln( '<error>Failed to create the remote plugin archive from wp-content/plugins.</error>' );
+				return Command::FAILURE;
+			}
+		} finally {
+			$archive_ssh->disconnect();
+		}
+
+		$archive_created = true;
+
+		$sftp = \WPCOM_Connection_Helper::get_sftp_connection( (string) $this->site->ID );
+		if ( \is_null( $sftp ) ) {
+			$output->writeln( '<error>Failed to connect to the site via SFTP.</error>' );
+			return Command::FAILURE;
+		}
+
+		try {
+			$sftp->setTimeout( 0 );
+
+			$download_successful = false;
+			foreach ( $remote_archive_paths as $sftp_path ) {
+				if ( $sftp->get( $sftp_path, $this->destination ) ) {
+					$download_successful = true;
+					break;
+				}
+			}
+
+			if ( ! $download_successful ) {
+				$output->writeln( '<error>Failed to download the plugin archive via SFTP.</error>' );
+				return Command::FAILURE;
+			}
+
+			if ( ! \is_file( $this->destination ) || 0 === \filesize( $this->destination ) ) {
+				$output->writeln( '<error>Downloaded archive appears invalid or empty.</error>' );
+				return Command::FAILURE;
+			}
+		} finally {
+			$sftp->disconnect();
+		}
+
+		if ( $archive_created ) {
+			$cleanup_ssh = \WPCOM_Connection_Helper::get_ssh_connection( (string) $this->site->ID );
+			if ( \is_null( $cleanup_ssh ) ) {
+				$remote_cleanup_error = true;
+			} else {
+				try {
+					$cleanup_ssh->setTimeout( 0 );
+					$cleanup_command = 'rm -f '
+						. escapeshellarg( $remote_archive_paths[0] )
+						. ' '
+						. escapeshellarg( $remote_archive_paths[1] )
+						. ' 2>&1';
+					$cleanup_ssh->exec( $cleanup_command );
+					if ( 0 !== $cleanup_ssh->getExitStatus() ) {
+						$remote_cleanup_error = true;
+					}
+				} finally {
+					$cleanup_ssh->disconnect();
+				}
+			}
+		}
+
+		if ( $remote_cleanup_error ) {
+			$output->writeln( '<comment>Plugin archive downloaded, but failed to clean up the temporary remote archive.</comment>' );
+		}
+
+		$output->writeln( '<fg=green;options=bold>Plugins downloaded successfully.</>' );
+		return Command::SUCCESS;
+	}
+
+	// endregion
+
+	// region HELPERS
+
+	/**
+	 * Prompts the user for a site.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  string|null
+	 */
+	private function prompt_site_input( InputInterface $input, OutputInterface $output ): ?string {
+		$question = new Question( '<question>Enter the domain or WPCOM site ID to download plugins from:</question> ' );
+		if ( ! $input->getOption( 'no-autocomplete' ) ) {
+			$question->setAutocompleterValues(
+				\array_map(
+					static fn( string $url ) => \parse_url( $url, PHP_URL_HOST ),
+					\array_column( get_wpcom_sites( array( 'fields' => 'ID,URL' ) ) ?? array(), 'URL' )
+				)
+			);
+		}
+
+		/**
+		 * The Symfony question helper.
+		 *
+		 * @var QuestionHelper $question_helper
+		 */
+		$question_helper = $this->getHelper( 'question' );
+		return $question_helper->ask( $input, $output, $question );
+	}
+
+	/**
+	 * Prompts the user for destination path.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  string|null
+	 */
+	private function prompt_destination_input( InputInterface $input, OutputInterface $output ): ?string {
+		$site_slug = \is_null( $this->site ) ? 'unknown-site' : slugify( (string) $this->site->name );
+		$default   = get_user_folder_path( "Downloads/wpcom-plugins-$site_slug-" . \gmdate( 'Y-m-d-H-i-s' ) . '.tar.gz' );
+		$question  = new Question( "<question>Please enter the path to save the plugins archive [$default]:</question> ", $default );
+
+		/**
+		 * The Symfony question helper.
+		 *
+		 * @var QuestionHelper $question_helper
+		 */
+		$question_helper = $this->getHelper( 'question' );
+		return $question_helper->ask( $input, $output, $question );
+	}
+
+	// endregion
+}

--- a/mcp/Team51McpTools.php
+++ b/mcp/Team51McpTools.php
@@ -2281,6 +2281,84 @@ final class Team51McpTools {
 		);
 	}
 
+	/**
+	 * Download all regular plugins (excluding mu-plugins) from a Pressable site.
+	 *
+	 * @param string      $site_id_or_url Pressable site ID or domain.
+	 * @param string|null $destination    Optional local destination path for the .tar.gz file.
+	 */
+	#[McpTool(
+		name: 'pressable_download_site_plugins',
+		annotations: new ToolAnnotations(
+			title: 'Download Pressable Site Plugins',
+			readOnlyHint: false,
+			destructiveHint: false,
+			idempotentHint: false,
+			openWorldHint: true,
+		)
+	)]
+	public function pressable_download_site_plugins( string $site_id_or_url, ?string $destination = null ): array {
+		$identity_error = self::ensure_identity();
+		if ( $identity_error ) {
+			return $identity_error;
+		}
+
+		if ( null === $destination ) {
+			$destination = get_user_folder_path( 'Downloads/pressable-plugins-' . slugify( $site_id_or_url ) . '-' . \gmdate( 'Y-m-d-H-i-s' ) . '.tar.gz' );
+		}
+
+		$result = self::run_cli_command(
+			'pressable:download-site-plugins',
+			array(
+				$site_id_or_url,
+				'--destination',
+				$destination,
+			)
+		);
+
+		$result['destination'] = $destination;
+		return $result;
+	}
+
+	/**
+	 * Download all regular plugins (excluding mu-plugins) from a WPCOM site.
+	 *
+	 * @param string      $site_id_or_url WPCOM site ID or domain.
+	 * @param string|null $destination    Optional local destination path for the .tar.gz file.
+	 */
+	#[McpTool(
+		name: 'wpcom_download_site_plugins',
+		annotations: new ToolAnnotations(
+			title: 'Download WPCOM Site Plugins',
+			readOnlyHint: false,
+			destructiveHint: false,
+			idempotentHint: false,
+			openWorldHint: true,
+		)
+	)]
+	public function wpcom_download_site_plugins( string $site_id_or_url, ?string $destination = null ): array {
+		$identity_error = self::ensure_identity();
+		if ( $identity_error ) {
+			return $identity_error;
+		}
+
+		if ( null === $destination ) {
+			$destination = get_user_folder_path( 'Downloads/wpcom-plugins-' . slugify( $site_id_or_url ) . '-' . \gmdate( 'Y-m-d-H-i-s' ) . '.tar.gz' );
+		}
+
+		$result = self::run_cli_command(
+			'wpcom:download-site-plugins',
+			array(
+				$site_id_or_url,
+				'--destination',
+				$destination,
+			)
+		);
+
+		$result['destination'] = $destination;
+		return $result;
+	}
+
 	#[McpTool( name: 'cli_export_commands' )]
 	public function cli_export_commands( string $format = 'md', ?string $destination = null ): array {
 		$identity_error = self::ensure_identity();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add two new CLI commands to download plugin archives from site `wp-content/plugins` (excluding `mu-plugins`):
  * `pressable:download-site-plugins`
  * `wpcom:download-site-plugins`
* Implement robust remote archive/download flow using SSH + SFTP:
  * handle both `htdocs/...` and `/htdocs/...` path layouts
  * support long-running archive/download operations with no timeout
  * validate local archive presence and non-empty file size
  * clean up remote archive after download and report cleanup issues
* Remove `-d` short option for `--destination` on both commands to avoid collisions with `--dev` usage (e.g. `-dev` parsing issues).
* Expose both download operations via MCP tools:
  * `pressable_download_site_plugins`
  * `wpcom_download_site_plugins`
* Add MCP tool annotations/hints for both new MCP tools.
* Update `README.md` with:
  * new CLI usage section for plugin download commands
  * MCP tool table updates and tool count adjustment.

#### Testing instructions

* Validate command registration:
  * `team51 --dev pressable:download-site-plugins --help`
  * `team51 --dev wpcom:download-site-plugins --help`
* Test Pressable download without passing destination:
  * `team51 --dev pressable:download-site-plugins <site>`
  * confirm destination prompt appears and archive downloads successfully.
* Test WPCOM download without passing destination:
  * `team51 --dev wpcom:download-site-plugins <site>`
  * confirm destination prompt appears and archive downloads successfully.
* Test explicit destination for both commands:
  * `team51 --dev pressable:download-site-plugins <site> --destination /tmp/pressable-plugins.tar.gz`
  * `team51 --dev wpcom:download-site-plugins <site> --destination /tmp/wpcom-plugins.tar.gz`
* Verify archive contents:
  * archive includes `plugins/`
  * archive does **not** include `mu-plugins/`.
* MCP validation:
  * restart MCP server (`team51 --mcp`)
  * confirm new tools appear in Cursor MCP tool list
  * execute each MCP tool with a site and verify response includes `ok`, `exit_code`, `output`, and `destination`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Download all plugins from WPCOM sites with interactive prompts and custom destination paths.
  * Download all plugins from Pressable sites with secure remote transfer and detailed success/error messages.

* **Tools**
  * Added WPCOM and Pressable download tools to the available tools list.

* **Documentation**
  * New "Download site plugins" subsection with usage examples for both services.
* **Other**
  * Updated Available Tools count to 66.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->