### PR TITLE
Update to Agent Context thin layer

### DIFF
--- a/commands/GitHub_Repository_Create.php
+++ b/commands/GitHub_Repository_Create.php
@@ -464,13 +464,13 @@ final class GitHub_Repository_Create extends Command {
 			}
 
 			$context_clone_process = run_system_command(
-				array( 'git', 'clone', '--recurse-submodules', 'git@github.com:a8cteam51/a8csp-agent-context.git', $source_dir ),
+				array( 'git', 'clone', '--recurse-submodules', 'git@github.com:a8cteam51/a8csp-agent-context-thin.git', $source_dir ),
 				'.',
 				false
 			);
 
 			if ( ! $context_clone_process->isSuccessful() ) {
-				$output->writeln( '<error>Failed to clone `a8csp-agent-context` with submodules.</error>' );
+				$output->writeln( '<error>Failed to clone `a8csp-agent-context-thin` with submodules.</error>' );
 				return false;
 			}
 
@@ -525,7 +525,7 @@ final class GitHub_Repository_Create extends Command {
 			}
 
 			$git_commit_process = run_system_command(
-				array( 'git', 'commit', '-m', 'Sync agent context files from a8csp-agent-context' ),
+				array( 'git', 'commit', '-m', 'Sync agent context files from a8csp-agent-context-thin' ),
 				$destination_dir,
 				false
 			);


### PR DESCRIPTION
Update GitHub repository clone and commit messages to reference `a8csp-agent-context-thin` instead of `a8csp-agent-context`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated agent context synchronization repository reference with corresponding revisions to error messages and commit metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->