### PR TITLE
Add wpcom:create-site-wp-user command for self-serve site invites

### DIFF
--- a/commands/WPCOM_Site_WP_User_Create.php
+++ b/commands/WPCOM_Site_WP_User_Create.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace WPCOMSpecialProjects\CLI\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Question\Question;
+use WPCOMSpecialProjects\CLI\Helper\AutocompleteTrait;
+
+/**
+ * Sends a WordPress.com site invitation to your authenticated 1Password identity.
+ *
+ * The invitee email is sourced from OPSOASIS_WP_USERNAME (the Team51 1Password account email)
+ * so the caller can only ever invite themselves. If the OpsOasis user holds the `team51-contractor`
+ * AAM role, the invite is automatically flagged as an external collaborator on WordPress.com.
+ */
+#[AsCommand( name: 'wpcom:create-site-wp-user' )]
+final class WPCOM_Site_WP_User_Create extends Command {
+	use AutocompleteTrait;
+
+	private const ALLOWED_ROLES = array( 'contributor', 'author', 'editor', 'administrator' );
+
+	// region FIELDS AND CONSTANTS
+
+	/**
+	 * The WPCOM site object to invite the user to.
+	 *
+	 * @var \stdClass|null
+	 */
+	private ?\stdClass $site = null;
+
+	/**
+	 * The email address of the invitee — sourced from OPSOASIS_WP_USERNAME.
+	 *
+	 * @var string|null
+	 */
+	private ?string $email = null;
+
+	/**
+	 * The role to grant the invited user.
+	 *
+	 * @var string|null
+	 */
+	private ?string $role = null;
+
+	// endregion
+
+	// region INHERITED METHODS
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function configure(): void {
+		$this->setDescription( 'Invites your authenticated identity to a WordPress.com site as a non-admin user.' )
+			->setHelp( 'This command sends a WordPress.com invitation to the email associated with your Team51 1Password account (OPSOASIS_WP_USERNAME). Inviting any other email is intentionally not supported. Roles are limited to contributor, author, or editor.' );
+
+		$this->addArgument( 'site', InputArgument::OPTIONAL, 'The domain or numeric WPCOM ID of the site to invite yourself to.' )
+			->addOption( 'role', null, InputOption::VALUE_REQUIRED, 'The role to grant. One of: ' . implode( ', ', self::ALLOWED_ROLES ) . '.', 'editor' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function initialize( InputInterface $input, OutputInterface $output ): void {
+		if ( ! defined( 'OPSOASIS_WP_USERNAME' ) || empty( OPSOASIS_WP_USERNAME ) ) {
+			$output->writeln( '<error>OPSOASIS_WP_USERNAME is not set. The CLI identity must be loaded from 1Password before running this command.</error>' );
+			exit( Command::FAILURE );
+		}
+		$this->email = OPSOASIS_WP_USERNAME;
+
+		$this->site = get_wpcom_site_input( $input, fn() => $this->prompt_site_input( $input, $output ) );
+
+		$role = get_enum_input( $input, 'role', self::ALLOWED_ROLES, fn() => 'editor', 'editor' );
+		if ( ! in_array( $role, self::ALLOWED_ROLES, true ) ) {
+			$output->writeln( '<error>Invalid role. Must be one of: ' . implode( ', ', self::ALLOWED_ROLES ) . '.</error>' );
+			exit( Command::FAILURE );
+		}
+		$this->role = $role;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function interact( InputInterface $input, OutputInterface $output ): void {
+		$question = new ConfirmationQuestion(
+			"<question>Send a `{$this->role}` invitation to `{$this->email}` for `{$this->site->URL}` (ID {$this->site->ID})? [y/N]</question> ",
+			false
+		);
+
+		if ( true !== $this->getHelper( 'question' )->ask( $input, $output, $question ) ) {
+			$output->writeln( '<comment>Command aborted by user.</comment>' );
+			exit( 2 );
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( InputInterface $input, OutputInterface $output ): int {
+		$output->writeln( "<fg=magenta;options=bold>Inviting `{$this->email}` to `{$this->site->URL}` as `{$this->role}`.</>" );
+
+		$result = invite_wpcom_site_user( (string) $this->site->ID, $this->email, $this->role );
+		if ( \is_null( $result ) ) {
+			$output->writeln( '<error>Failed to send the invitation. Check the logs above for the WordPress.com error.</error>' );
+			return Command::FAILURE;
+		}
+
+		$sent = (array) ( $result->sent ?? array() );
+		if ( empty( $sent ) ) {
+			$output->writeln( '<error>WordPress.com accepted the request but returned no `sent` entries.</error>' );
+			return Command::FAILURE;
+		}
+
+		$output->writeln( "<fg=green;options=bold>Invitation sent to `{$this->email}` for `{$this->site->URL}`.</>" );
+		$output->writeln( '<comment>Check your inbox to accept the invitation.</comment>' );
+
+		return Command::SUCCESS;
+	}
+
+	// endregion
+
+	// region HELPERS
+
+	/**
+	 * Prompts the user for a site.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  string|null
+	 */
+	private function prompt_site_input( InputInterface $input, OutputInterface $output ): ?string {
+		$question = new Question( '<question>Enter the domain or WPCOM site ID to invite yourself to:</question> ' );
+		if ( ! $input->getOption( 'no-autocomplete' ) ) {
+			$question->setAutocompleterValues( array_column( get_wpcom_sites() ?? array(), 'URL' ) );
+		}
+
+		return $this->getHelper( 'question' )->ask( $input, $output, $question );
+	}
+
+	// endregion
+}

--- a/includes/functions-wpcom.php
+++ b/includes/functions-wpcom.php
@@ -286,6 +286,33 @@ function delete_wpcom_site_user( string $site_id_or_url, string $user_id_or_user
 }
 
 /**
+ * Sends a WordPress.com site invitation to a user by email address.
+ *
+ * @param   string      $site_id_or_url The site URL or WordPress.com site ID.
+ * @param   string      $email          The email address of the user to invite.
+ * @param   string      $role           The role to grant. One of 'contributor', 'author', 'editor'.
+ * @param   string|null $message        Optional. Message to include in the invitation email.
+ *
+ * @link    https://developer.wordpress.com/docs/api/1.1/post/sites/%24site/invites/new/
+ *
+ * @return  stdClass|null
+ */
+function invite_wpcom_site_user( string $site_id_or_url, string $email, string $role = 'editor', ?string $message = null ): ?stdClass {
+	return API_Helper::make_wpcom_request(
+		"site-invites/$site_id_or_url",
+		'POST',
+		array_filter(
+			array(
+				'email'   => $email,
+				'role'    => $role,
+				'message' => $message,
+			),
+			static fn( $value ) => null !== $value && '' !== $value
+		)
+	);
+}
+
+/**
  * Returns the list of stickers associated with a given WPCOM site.
  *
  * @param   string $site_id_or_domain The site URL or WordPress.com site ID.


### PR DESCRIPTION
## Summary
- New `wpcom:create-site-wp-user` command sends a WordPress.com site invite to your authenticated 1Password identity (`OPSOASIS_WP_USERNAME`); the invitee email is sourced server-side from your 1Password account so you can only invite yourself.
- Role accepted via `--role`: `contributor`, `author`, `editor`, `administrator`. Default `editor`.
- Backed by the new OpsOasis `POST /wpcom/v1/site-invites/{site}` endpoint — see companion PR in `a8cteam51/opsoasis`.

## Notes
- If the OpsOasis user has the `team51-contractor` AAM role, OpsOasis will automatically flag the resulting WPCom user as an external collaborator. The CLI does not see or send that flag — it's caller-derived on the server.
- Test this branch with `team51 --dev wpcom:create-site-wp-user <site>` to skip the trunk self-update.

## Test plan
- [ ] `team51 --dev wpcom:create-site-wp-user <site-domain>` sends an invitation email to the 1Password account email
- [ ] `--role=administrator` is accepted; an unsupported role (`subscriber`) is rejected
- [ ] Aborts cleanly if `OPSOASIS_WP_USERNAME` is not loaded
- [ ] When invoked by an OpsOasis user with the `team51-contractor` role, the resulting WPCom user is flagged "external collaborator"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added command-line tool to invite users to WordPress.com sites
  * Support for customizable user roles during invitation
  * Optional personalized invitation messages
  * Built-in validation and confirmation prompts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->