### PR TITLE
Harden 1Password CLI calls against transient failures

### DIFF
--- a/commands/Pressable_Site_Clone.php
+++ b/commands/Pressable_Site_Clone.php
@@ -216,7 +216,7 @@ final class Pressable_Site_Clone extends Command {
 		$ssh_connection = wait_on_pressable_site_ssh( $site_clone->id, $output );
 
 		// Run a few commands to set up the site.
-		run_app_command(
+		$rotate_status = run_app_command(
 			Pressable_Site_WP_User_Password_Rotate::getDefaultName(),
 			array(
 				'site'   => $site_clone->id,
@@ -283,6 +283,10 @@ final class Pressable_Site_Clone extends Command {
 		// Done last because it seems to cause issues sometimes with the connection breaking off.
 		run_pressable_site_wp_cli_command( $site_clone->id, "search-replace {$this->site->url} $site_clone->url" );
 		run_pressable_site_wp_cli_command( $site_clone->id, 'cache flush' );
+
+		if ( Command::SUCCESS !== $rotate_status ) {
+			$output->writeln( '<comment>⚠  Heads up: 1Password sync did not complete during this run. See the warning above for the password to record manually.</comment>' );
+		}
 
 		return Command::SUCCESS;
 	}

--- a/commands/Pressable_Site_Create.php
+++ b/commands/Pressable_Site_Create.php
@@ -136,7 +136,7 @@ final class Pressable_Site_Create extends Command {
 		wait_on_pressable_site_ssh( $site->id, $output )?->disconnect();
 
 		// Run a few commands to set up the site.
-		run_app_command(
+		$rotate_status = run_app_command(
 			Pressable_Site_WP_User_Password_Rotate::getDefaultName(),
 			array(
 				'site'   => $site->id,
@@ -169,6 +169,11 @@ final class Pressable_Site_Create extends Command {
 		}
 
 		$output->writeln( "<fg=green;options=bold>Site $this->name created successfully.</>" );
+
+		if ( Command::SUCCESS !== $rotate_status ) {
+			$output->writeln( '<comment>⚠  Heads up: 1Password sync did not complete during this run. See the warning above for the password to record manually.</comment>' );
+		}
+
 		return Command::SUCCESS;
 	}
 

--- a/commands/Pressable_Site_Domain_Add.php
+++ b/commands/Pressable_Site_Domain_Add.php
@@ -160,6 +160,7 @@ final class Pressable_Site_Domain_Add extends Command {
 					'tags'       => 'team51-cli',
 				)
 			);
+			$op_login_entries = $op_login_entries ?? array();
 			$output->writeln( \sprintf( '<comment>Found %d login entries in 1Password that require a URL update.</comment>', \count( $op_login_entries ) ), OutputInterface::VERBOSITY_DEBUG );
 
 			$this->site = get_pressable_site( $this->site->id ); // Refresh the site data. The displayName field is likely to have changed.

--- a/commands/Pressable_Site_WP_User_Password_Rotate.php
+++ b/commands/Pressable_Site_WP_User_Password_Rotate.php
@@ -137,6 +137,8 @@ final class Pressable_Site_WP_User_Password_Rotate extends Command {
 	 * @noinspection DisconnectedForeachInstructionInspection
 	 */
 	protected function execute( InputInterface $input, OutputInterface $output ): int {
+		$sync_failures = array();
+
 		foreach ( $this->sites as $site ) {
 			$output->writeln( "<fg=magenta;options=bold>Rotating the WP user password of $this->wp_user_email on $site->displayName (ID $site->id, URL $site->url).</>" );
 
@@ -153,15 +155,19 @@ final class Pressable_Site_WP_User_Password_Rotate extends Command {
 			// Update the 1Password password value.
 			$result = $this->update_1password_login( $output, $site, $credentials->password, $credentials->username );
 			if ( true !== $result ) {
-				$output->writeln( '<error>Failed to update 1Password entry.</error>' );
-				$output->writeln( "<info>If needed, please update the 1Password entry manually to: $credentials->password</info>" );
+				$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
+				$output->writeln( "<error>⚠  Password rotated on Pressable but NOT synced to 1Password for $site->displayName.</error>" );
+				$output->writeln( '<error>    Record this password before it scrolls off:</error>' );
+				$output->writeln( "<fg=yellow;options=bold>    $credentials->password</>" );
+				$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
+				$sync_failures[] = $site->displayName; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- 1Password API field, not ours.
 				continue;
 			}
 
 			$output->writeln( '<fg=green;options=bold>WP user password updated in 1Password.</>' );
 		}
 
-		return Command::SUCCESS;
+		return empty( $sync_failures ) ? Command::SUCCESS : Command::FAILURE;
 	}
 
 	// endregion

--- a/commands/WPCOM_Site_Clone.php
+++ b/commands/WPCOM_Site_Clone.php
@@ -171,7 +171,7 @@ final class WPCOM_Site_Clone extends Command {
 		}
 
 		// Run a few commands to set up the site.
-		run_app_command(
+		$rotate_status = run_app_command(
 			WPCOM_Site_WP_User_Password_Rotate::getDefaultName(),
 			array(
 				'site'   => $staging_site->id,
@@ -257,6 +257,11 @@ final class WPCOM_Site_Clone extends Command {
 		}
 
 		$output->writeln( "<fg=green;options=bold>Staging site created successfully at $staging_site_https_url.</>" );
+
+		if ( Command::SUCCESS !== $rotate_status ) {
+			$output->writeln( '<comment>⚠  Heads up: 1Password sync did not complete during this run. See the warning above for the password to record manually.</comment>' );
+		}
+
 		return Command::SUCCESS;
 	}
 

--- a/commands/WPCOM_Site_Create.php
+++ b/commands/WPCOM_Site_Create.php
@@ -146,7 +146,7 @@ final class WPCOM_Site_Create extends Command {
 		}
 
 		// Run a few commands to set up the site.
-		run_app_command(
+		$rotate_status = run_app_command(
 			WPCOM_Site_WP_User_Password_Rotate::getDefaultName(),
 			array(
 				'site'   => $transfer->blog_id,
@@ -177,6 +177,11 @@ final class WPCOM_Site_Create extends Command {
 		}
 
 		$output->writeln( "<fg=green;options=bold>Site $this->name created successfully.</>" );
+
+		if ( Command::SUCCESS !== $rotate_status ) {
+			$output->writeln( '<comment>⚠  Heads up: 1Password sync did not complete during this run. See the warning above for the password to record manually.</comment>' );
+		}
+
 		return Command::SUCCESS;
 	}
 

--- a/commands/WPCOM_Site_WP_User_Password_Rotate.php
+++ b/commands/WPCOM_Site_WP_User_Password_Rotate.php
@@ -133,6 +133,8 @@ final class WPCOM_Site_WP_User_Password_Rotate extends Command {
 	 * @noinspection DisconnectedForeachInstructionInspection
 	 */
 	protected function execute( InputInterface $input, OutputInterface $output ): int {
+		$sync_failures = array();
+
 		foreach ( $this->sites as $site ) {
 			if ( empty( $site->name ) ) {
 				$site->name = $site->URL;
@@ -157,15 +159,19 @@ final class WPCOM_Site_WP_User_Password_Rotate extends Command {
 			// Update the 1Password password value.
 			$result = $this->update_1password_login( $output, $site, $credentials->password, $credentials->username );
 			if ( true !== $result ) {
-				$output->writeln( '<error>Failed to update 1Password entry.</error>' );
-				$output->writeln( "<info>If needed, please update the 1Password entry manually to: $credentials->password</info>" );
+				$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
+				$output->writeln( "<error>⚠  Password rotated on WPCOM but NOT synced to 1Password for $site->name.</error>" );
+				$output->writeln( '<error>    Record this password before it scrolls off:</error>' );
+				$output->writeln( "<fg=yellow;options=bold>    $credentials->password</>" );
+				$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
+				$sync_failures[] = $site->name;
 				continue;
 			}
 
 			$output->writeln( '<fg=green;options=bold>WP user password updated in 1Password.</>' );
 		}
 
-		return Command::SUCCESS;
+		return empty( $sync_failures ) ? Command::SUCCESS : Command::FAILURE;
 	}
 
 	// endregion

--- a/includes/functions-1password.php
+++ b/includes/functions-1password.php
@@ -1,5 +1,8 @@
 <?php
 
+use Symfony\Component\Process\Exception\ProcessTimedOutException;
+use Symfony\Component\Process\Process;
+
 // region API
 
 /**
@@ -13,7 +16,8 @@
  */
 function list_1password_accounts( array $global_flags = array() ): ?array {
 	$command = _build_1password_command_string( 'op account list', array(), array(), $global_flags );
-	return decode_json_content( shell_exec( "$command --format json" ) );
+	$json    = _run_op_command( "$command --format json" );
+	return is_null( $json ) ? null : decode_json_content( $json );
 }
 
 /**
@@ -30,7 +34,8 @@ function list_1password_items( array $flags = array(), array $global_flags = arr
 	$flags   = array_intersect_key( $flags, array_flip( array( 'categories', 'tags', 'vault', 'favorite', 'include-archive' ) ) );
 	$command = _build_1password_command_string( 'op item list', $flags, array( 'categories', 'tags', 'vault' ), $global_flags );
 
-	return decode_json_content( shell_exec( "$command --format json" ) );
+	$json = _run_op_command( "$command --format json" );
+	return is_null( $json ) ? null : decode_json_content( $json );
 }
 
 /**
@@ -80,7 +85,8 @@ function create_1password_item( array $fields, array $flags, array $global_flags
 		$command .= " '$field=$value'";
 	}
 
-	return decode_json_content( shell_exec( "$command --format json" ) );
+	$json = _run_op_command( "$command --format json" );
+	return is_null( $json ) ? null : decode_json_content( $json );
 }
 
 /**
@@ -98,7 +104,8 @@ function get_1password_item( string $item_id, array $flags = array(), array $glo
 	$flags   = array_intersect_key( $flags, array_flip( array( 'fields', 'include-archive', 'otp', 'share-link', 'vault' ) ) );
 	$command = _build_1password_command_string( "op item get $item_id", $flags, array( 'fields', 'vault' ), $global_flags );
 
-	return decode_json_content( shell_exec( "$command --format json" ) );
+	$json = _run_op_command( "$command --format json" );
+	return is_null( $json ) ? null : decode_json_content( $json );
 }
 
 /**
@@ -125,7 +132,8 @@ function update_1password_item( string $item_id, array $fields, array $flags = a
 		$command .= " '$field=$new_value'";
 	}
 
-	return decode_json_content( shell_exec( "$command --format json" ) );
+	$json = _run_op_command( "$command --format json" );
+	return is_null( $json ) ? null : decode_json_content( $json );
 }
 
 /**
@@ -143,7 +151,62 @@ function delete_1password_item( string $item_id, array $flags = array(), array $
 	$flags   = array_intersect_key( $flags, array_flip( array( 'archive', 'vault' ) ) );
 	$command = _build_1password_command_string( "op item delete $item_id", $flags, array( 'vault' ), $global_flags );
 
-	shell_exec( $command );
+	_run_op_command( $command );
+}
+
+/**
+ * Runs an `op` (1Password CLI) shell command with type-safe output handling and
+ * a small retry loop for transient failures.
+ *
+ * Returns the command's STDOUT on success, or null on either an empty result or
+ * a non-zero exit. Auth/permission errors fail fast; transient errors (timeouts,
+ * connection refused, "temporarily unavailable") are retried up to 3 times with
+ * a 5-second pause between attempts.
+ *
+ * @param   string $command The fully-built `op` command string to execute.
+ *
+ * @internal
+ * @return  string|null
+ */
+function _run_op_command( string $command ): ?string {
+	for ( $attempt = 1; $attempt <= 3; $attempt++ ) {
+		$process = Process::fromShellCommandline( $command );
+		$process->setTimeout( 60 ); // op should never legitimately take longer.
+
+		try {
+			$process->run();
+		} catch ( ProcessTimedOutException $e ) {
+			// A wall-clock timeout is the same shape of failure as op reporting one internally — treat as transient.
+			if ( 3 === $attempt ) {
+				console_writeln( '❌ 1Password CLI timed out after 60s on all 3 attempts.' );
+				return null;
+			}
+			console_writeln( "<comment>1Password CLI exceeded the 60s timeout (attempt $attempt/3), retrying in 5s…</comment>" );
+			sleep( 5 );
+			continue;
+		}
+
+		if ( $process->isSuccessful() ) {
+			$stdout = $process->getOutput();
+			return '' === $stdout ? null : $stdout;
+		}
+
+		$stderr       = $process->getErrorOutput();
+		$is_transient = str_contains( $stderr, 'timed out' )
+			|| str_contains( $stderr, 'timeout' )
+			|| str_contains( $stderr, 'connection refused' )
+			|| str_contains( $stderr, 'temporarily unavailable' );
+
+		if ( ! $is_transient || 3 === $attempt ) {
+			console_writeln( "❌ 1Password CLI failed (exit {$process->getExitCode()}): " . trim( $stderr ) );
+			return null;
+		}
+
+		console_writeln( "<comment>1Password CLI hit a transient error (attempt $attempt/3), retrying in 5s…</comment>" );
+		sleep( 5 );
+	}
+
+	return null;
 }
 
 /**

--- a/load-identity.php
+++ b/load-identity.php
@@ -5,7 +5,7 @@
 
 // Set the OPSOASIS_WP_USERNAME to the Team51 1Password account email.
 $team51_op_account = array_filter(
-	list_1password_accounts(),
+	list_1password_accounts() ?? array(),
 	static fn( object $account ) => 'ZVYA3AB22BC37JPJZJNSGOPYEQ' === $account->account_uuid
 );
 $team51_op_account = empty( $team51_op_account ) ? null : reset( $team51_op_account );
@@ -24,7 +24,7 @@ if ( ! empty( getenv( 'TEAM51_OPSOASIS_APP_PASSWORD' ) ) ) {
 			)
 		);
 
-		foreach ( $team51_op_logins as $op_login ) {
+		foreach ( $team51_op_logins ?? array() as $op_login ) {
 			foreach ( $op_login->urls ?? array() as $url ) {
 				if ( 'opsoasis.wpspecialprojects.com' !== parse_url( $url->href, PHP_URL_HOST ) ) {
 					continue;


### PR DESCRIPTION
## Summary

- A transient `op` (1Password CLI) failure used to feed `NULL` into the strict-typed `decode_json_content()` and abort the CLI with a PHP fatal mid-provision — leaving a half-built Pressable site without Atlantis, DeployHQ, or an initial deploy.
- All `op` invocations now go through a new `_run_op_command()` in `includes/functions-1password.php` that uses `Symfony\Component\Process\Process` — stdout, stderr, and exit code are separable, so empty/non-zero results return `null` instead of crashing.
- The helper retries transient errors (`timed out`, `timeout`, `connection refused`, `temporarily unavailable`, wall-clock `ProcessTimedOutException`) up to 3× with a 5s pause; auth/permission errors fail fast.
- `pressable:rotate-site-wp-user-password` and `wpcom:rotate-site-wp-user-password` now print a red banner with the password in yellow when the 1P sync fails, and return `Command::FAILURE`.
- The four parents that trigger a rotate (`pressable:create-site`, `pressable:clone-site`, `wpcom:create-site`, `wpcom:clone-site`) capture the rotate exit code and append a heads-up to the final summary — but still run the downstream Atlantis install / DeployHQ project+server / initial deploy.
- Also guards three pre-existing `?array` consumers in `load-identity.php` and `Pressable_Site_Domain_Add.php` that would crash with `TypeError` on null (`array_filter(null,…)`, `foreach (null)`).

## Test plan

- [ ] **Helper unit exercise** — scratch PHP script calls `_run_op_command()` with stubs: happy path, hard failure, transient (`sh -c 'echo "... timed out" >&2; exit 1'`), auth-style (`sh -c 'echo "session expired" >&2; exit 1'`), empty stdout. Expect no `TypeError`, retries only on transient, auth fails fast.
- [ ] **PATH-hijack `op`** then `team51 --dev pressable:rotate-site-wp-user-password <test-site> --user concierge@wordpress.com`. Expect red banner + yellow password + non-zero exit, no PHP fatal.
- [ ] Happy-path regression: rotate against a real test site with `op` working. Unchanged output, exit 0, 1P entry updated.
- [ ] End-to-end with a stub on a throwaway `pressable:create-site` — site, repo, DeployHQ project+server, and initial deploy all complete; final line shows the yellow 1P heads-up.
- [ ] `op` binary missing entirely — clean `1Password CLI failed` message, no PHP fatal.
- [ ] PHPCS clean: `composer run lint:php`.