### PR TITLE
Add wpcom:atlantis-status command

### DIFF
--- a/commands/WPCOM_Atlantis_Status.php
+++ b/commands/WPCOM_Atlantis_Status.php
@@ -110,6 +110,13 @@ final class WPCOM_Atlantis_Status extends Command {
 	 */
 	private $stream = null;
 
+	/**
+	 * When true, only sites with Atlantis missing or any module not "on" are rendered.
+	 *
+	 * @var bool
+	 */
+	private bool $issues_only = false;
+
 	// endregion
 
 	// region INHERITED METHODS
@@ -123,6 +130,8 @@ final class WPCOM_Atlantis_Status extends Command {
 
 		$this->addOption( 'site', null, InputOption::VALUE_REQUIRED, 'Restrict the report to a single site, identified by its WPCOM ID or URL. Skips the full fleet fetch.' )
 			->addOption( 'module', null, InputOption::VALUE_REQUIRED, 'Restrict the report to a single module column. Accepted values: ' . \implode( ', ', self::KNOWN_MODULE_KEYS ) . '.' )
+			->addOption( 'prod', null, InputOption::VALUE_NONE, 'Exclude any site whose URL contains the substring "staging" (case-insensitive).' )
+			->addOption( 'issues-only', null, InputOption::VALUE_NONE, 'Only show sites where Atlantis is not installed or at least one module is not on.' )
 			->addOption( 'export', null, InputOption::VALUE_REQUIRED, 'If provided, the report will be saved to this file in addition to the terminal.' )
 			->addOption( 'export-format', null, InputOption::VALUE_REQUIRED, 'The format to export the report in. Accepted values are `json` and `csv`.', 'csv' )
 			->addOption( 'export-exclude', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Exclude columns from the export. Possible values depend on the active --module flag; defaults to `Site ID`, `Site URL`, `Atlantis Version`, plus one column per Atlantis module.' );
@@ -150,6 +159,8 @@ final class WPCOM_Atlantis_Status extends Command {
 			\array_map( fn( string $key ) => \ucfirst( $key ), $this->module_keys )
 		);
 
+		$this->issues_only = (bool) $input->getOption( 'issues-only' );
+
 		$this->format      = get_enum_input( $input, 'export-format', array( 'json', 'csv' ) );
 		$this->destination = maybe_get_string_input( $input, 'export', fn() => $this->prompt_destination_input( $input, $output ) );
 		if ( ! empty( $this->destination ) ) {
@@ -168,6 +179,16 @@ final class WPCOM_Atlantis_Status extends Command {
 		$this->sites = get_wpcom_jetpack_sites();
 		$output->writeln( '<comment>Successfully fetched ' . \count( $this->sites ) . ' Jetpack site(s).</comment>' );
 
+		if ( $input->getOption( 'prod' ) ) {
+			$before      = \count( $this->sites );
+			$this->sites = \array_filter(
+				$this->sites,
+				static fn( $site ) => false === \stripos( (string) ( $site->siteurl ?? '' ), 'staging' )
+			);
+			$excluded    = $before - \count( $this->sites );
+			$output->writeln( "<comment>Excluding $excluded staging site(s); querying " . \count( $this->sites ) . ' production site(s).</comment>' );
+		}
+
 		$this->statuses = get_wpcom_sites_atlantis_status_batch( \array_column( $this->sites, 'userblog_id' ), $this->errors );
 		maybe_output_wpcom_failed_sites_table( $output, $this->errors ?? array(), $this->sites, 'Sites that could NOT be queried for Atlantis status' );
 	}
@@ -183,6 +204,7 @@ final class WPCOM_Atlantis_Status extends Command {
 
 		$rows                  = array();
 		$installed_count       = 0;
+		$issue_count           = 0;
 		$module_enabled_counts = \array_fill_keys( $this->module_keys, 0 );
 
 		foreach ( $this->sites as $site_id => $site ) {
@@ -197,8 +219,11 @@ final class WPCOM_Atlantis_Status extends Command {
 				$row[ \ucfirst( $module_key ) ] = '—';
 			}
 
+			$has_issue = true; // Atlantis missing counts as an issue.
+
 			if ( \is_object( $status ) ) {
 				++$installed_count;
+				$has_issue = false;
 
 				$row['Atlantis Version'] = $status->plugin->version ?? 'unknown';
 
@@ -209,8 +234,20 @@ final class WPCOM_Atlantis_Status extends Command {
 						++$module_enabled_counts[ $module_key ];
 					} elseif ( false === $enabled ) {
 						$row[ \ucfirst( $module_key ) ] = 'off';
+						$has_issue                      = true;
+					} else {
+						// Module key absent from response — treat as an issue so it surfaces in --issues-only.
+						$has_issue = true;
 					}
 				}
+			}
+
+			if ( $has_issue ) {
+				++$issue_count;
+			}
+
+			if ( $this->issues_only && ! $has_issue ) {
+				continue;
 			}
 
 			$rows[] = $row;
@@ -221,13 +258,14 @@ final class WPCOM_Atlantis_Status extends Command {
 			$output,
 			array_map( 'array_values', $rows ),
 			$table_header,
-			'Atlantis status by site'
+			$this->issues_only ? 'Atlantis sites with issues' : 'Atlantis status by site'
 		);
 
 		$summary_output = array(
 			'REPORT SUMMARY'      => '',
 			'Total sites queried' => \count( $this->sites ),
 			'Sites with Atlantis' => $installed_count,
+			'Sites with issues'   => $issue_count,
 		);
 		foreach ( $module_enabled_counts as $module_key => $count ) {
 			$summary_output[ \ucfirst( $module_key ) . ' module ON' ] = $count;

--- a/commands/WPCOM_Atlantis_Status.php
+++ b/commands/WPCOM_Atlantis_Status.php
@@ -13,11 +13,12 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
 use WPCOMSpecialProjects\CLI\Helper\AutocompleteTrait;
 
 /**
- * Reports the status of the Atlantis plugin and its modules across all
+ * Reports the status of the Atlantis plugin and its modules across
  * Jetpack-connected sites.
  *
- * Proof-of-concept scope: surfaces plugin version and the Autoupdate Filter
- * module state per site. Sites without Atlantis return `not installed`.
+ * By default, reports every site and every module. Use `--site` to inspect a
+ * single site, or `--module` to narrow the report to one module column.
+ * Sites without Atlantis return `not installed`.
  */
 #[AsCommand( name: 'wpcom:atlantis-status' )]
 final class WPCOM_Atlantis_Status extends Command {
@@ -48,11 +49,38 @@ final class WPCOM_Atlantis_Status extends Command {
 	private ?array $errors = null;
 
 	/**
+	 * Module keys known to be reported by the Atlantis status endpoint.
+	 *
+	 * Ordered to control the column order in the report.
+	 *
+	 * @var string[]
+	 */
+	private const KNOWN_MODULE_KEYS = array( 'messages', 'colophon', 'tracking', 'autoupdates' );
+
+	/**
+	 * Module keys included in the current report.
+	 *
+	 * Either every key in KNOWN_MODULE_KEYS or a single key when --module is set.
+	 *
+	 * @var string[]
+	 */
+	private array $module_keys = self::KNOWN_MODULE_KEYS;
+
+	/**
+	 * The single site to report on, when --site is set.
+	 *
+	 * @var \stdClass|null
+	 */
+	private ?\stdClass $single_site = null;
+
+	/**
 	 * Columns included in the export and thus that can be excluded via options.
+	 *
+	 * Populated in initialize() once the module set is known.
 	 *
 	 * @var array
 	 */
-	private array $export_columns = array( 'Site ID', 'Site URL', 'Atlantis Version', 'Autoupdates' );
+	private array $export_columns = array();
 
 	/**
 	 * List of columns to exclude from the export.
@@ -90,18 +118,38 @@ final class WPCOM_Atlantis_Status extends Command {
 	 * {@inheritDoc}
 	 */
 	protected function configure(): void {
-		$this->setDescription( 'Reports Atlantis plugin and module status across all Jetpack-connected sites.' )
-			->setHelp( 'Calls the OpsOasis batch endpoint for `a8csp-atlantis/v1/status` on every Jetpack-connected site and prints a per-site report. Sites without Atlantis installed are reported as `not installed`.' );
+		$this->setDescription( 'Reports Atlantis plugin and module status across Jetpack-connected sites.' )
+			->setHelp( 'Calls the OpsOasis batch endpoint for `a8csp-atlantis/v1/status` and prints a per-site report. By default every connected site is queried; pass `--site` to inspect a single site. By default every Atlantis module is shown as its own column; pass `--module` to narrow to one. Sites without Atlantis installed are reported as `not installed`.' );
 
-		$this->addOption( 'export', null, InputOption::VALUE_REQUIRED, 'If provided, the report will be saved to this file in addition to the terminal.' )
+		$this->addOption( 'site', null, InputOption::VALUE_REQUIRED, 'Restrict the report to a single site, identified by its WPCOM ID or URL. Skips the full fleet fetch.' )
+			->addOption( 'module', null, InputOption::VALUE_REQUIRED, 'Restrict the report to a single module column. Accepted values: ' . \implode( ', ', self::KNOWN_MODULE_KEYS ) . '.' )
+			->addOption( 'export', null, InputOption::VALUE_REQUIRED, 'If provided, the report will be saved to this file in addition to the terminal.' )
 			->addOption( 'export-format', null, InputOption::VALUE_REQUIRED, 'The format to export the report in. Accepted values are `json` and `csv`.', 'csv' )
-			->addOption( 'export-exclude', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Exclude columns from the export. Possible values: `Site ID`, `Site URL`, `Atlantis Version`, `Autoupdates`.' );
+			->addOption( 'export-exclude', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Exclude columns from the export. Possible values depend on the active --module flag; defaults to `Site ID`, `Site URL`, `Atlantis Version`, plus one column per Atlantis module.' );
 	}
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * @throws \InvalidArgumentException If --module is set to a value outside KNOWN_MODULE_KEYS, or --site cannot be resolved.
 	 */
 	protected function initialize( InputInterface $input, OutputInterface $output ): void {
+		$module_option = $input->getOption( 'module' );
+		if ( ! \is_null( $module_option ) ) {
+			$module_option = \strtolower( (string) $module_option );
+			if ( ! \in_array( $module_option, self::KNOWN_MODULE_KEYS, true ) ) {
+				throw new \InvalidArgumentException(
+					"Unknown module '$module_option'. Accepted values: " . \implode( ', ', self::KNOWN_MODULE_KEYS ) . '.'
+				);
+			}
+			$this->module_keys = array( $module_option );
+		}
+
+		$this->export_columns = \array_merge(
+			array( 'Site ID', 'Site URL', 'Atlantis Version' ),
+			\array_map( fn( string $key ) => \ucfirst( $key ), $this->module_keys )
+		);
+
 		$this->format      = get_enum_input( $input, 'export-format', array( 'json', 'csv' ) );
 		$this->destination = maybe_get_string_input( $input, 'export', fn() => $this->prompt_destination_input( $input, $output ) );
 		if ( ! empty( $this->destination ) ) {
@@ -109,6 +157,12 @@ final class WPCOM_Atlantis_Status extends Command {
 			$input->setOption( 'export-exclude', $this->export_excluded_columns );
 
 			$this->stream = get_file_handle( $this->destination, $this->format );
+		}
+
+		$site_option = $input->getOption( 'site' );
+		if ( ! \is_null( $site_option ) ) {
+			$this->initialize_single_site( (string) $site_option, $output );
+			return;
 		}
 
 		$this->sites = get_wpcom_jetpack_sites();
@@ -122,11 +176,14 @@ final class WPCOM_Atlantis_Status extends Command {
 	 * {@inheritDoc}
 	 */
 	protected function execute( InputInterface $input, OutputInterface $output ): int {
-		$output->writeln( '<fg=magenta;options=bold>Reporting Atlantis status across connected sites.</>' );
+		$scope_label = \is_null( $this->single_site )
+			? 'across connected sites'
+			: "for site {$this->single_site->siteurl}";
+		$output->writeln( "<fg=magenta;options=bold>Reporting Atlantis status $scope_label.</>" );
 
-		$rows                       = array();
-		$installed_count            = 0;
-		$autoupdates_enabled_count  = 0;
+		$rows                  = array();
+		$installed_count       = 0;
+		$module_enabled_counts = \array_fill_keys( $this->module_keys, 0 );
 
 		foreach ( $this->sites as $site_id => $site ) {
 			$status = $this->statuses[ $site_id ] ?? null;
@@ -135,27 +192,31 @@ final class WPCOM_Atlantis_Status extends Command {
 				'Site ID'          => $site->userblog_id,
 				'Site URL'         => $site->siteurl,
 				'Atlantis Version' => 'not installed',
-				'Autoupdates'      => '—',
 			);
+			foreach ( $this->module_keys as $module_key ) {
+				$row[ \ucfirst( $module_key ) ] = '—';
+			}
 
 			if ( \is_object( $status ) ) {
 				++$installed_count;
 
 				$row['Atlantis Version'] = $status->plugin->version ?? 'unknown';
 
-				$autoupdates_enabled = $status->modules->autoupdates->enabled ?? null;
-				if ( true === $autoupdates_enabled ) {
-					$row['Autoupdates'] = 'on';
-					++$autoupdates_enabled_count;
-				} elseif ( false === $autoupdates_enabled ) {
-					$row['Autoupdates'] = 'off';
+				foreach ( $this->module_keys as $module_key ) {
+					$enabled = $status->modules->$module_key->enabled ?? null;
+					if ( true === $enabled ) {
+						$row[ \ucfirst( $module_key ) ] = 'on';
+						++$module_enabled_counts[ $module_key ];
+					} elseif ( false === $enabled ) {
+						$row[ \ucfirst( $module_key ) ] = 'off';
+					}
 				}
 			}
 
 			$rows[] = $row;
 		}
 
-		$table_header = array_keys( $rows[0] ?? array( 'Site ID' => '', 'Site URL' => '', 'Atlantis Version' => '', 'Autoupdates' => '' ) );
+		$table_header = array_keys( $rows[0] ?? \array_fill_keys( $this->export_columns, '' ) );
 		output_table(
 			$output,
 			array_map( 'array_values', $rows ),
@@ -164,12 +225,14 @@ final class WPCOM_Atlantis_Status extends Command {
 		);
 
 		$summary_output = array(
-			'REPORT SUMMARY'         => '',
-			'Total sites queried'    => \count( $this->sites ),
-			'Sites with Atlantis'    => $installed_count,
-			'Autoupdates module ON'  => $autoupdates_enabled_count,
-			'Sites that errored'     => \count( $this->errors ?? array() ),
+			'REPORT SUMMARY'      => '',
+			'Total sites queried' => \count( $this->sites ),
+			'Sites with Atlantis' => $installed_count,
 		);
+		foreach ( $module_enabled_counts as $module_key => $count ) {
+			$summary_output[ \ucfirst( $module_key ) . ' module ON' ] = $count;
+		}
+		$summary_output['Sites that errored'] = \count( $this->errors ?? array() );
 
 		foreach ( $summary_output as $key => $value ) {
 			$output->writeln( "<info>$key: $value</info>" );
@@ -190,6 +253,43 @@ final class WPCOM_Atlantis_Status extends Command {
 	// endregion
 
 	// region HELPERS
+
+	/**
+	 * Resolves a single site from $site_id_or_url, fetches its Atlantis status, and
+	 * populates $this->sites and $this->statuses for the single-site report path.
+	 *
+	 * @param   string          $site_id_or_url Site URL or WPCOM numeric ID.
+	 * @param   OutputInterface $output         Console output (for status messages).
+	 *
+	 * @throws \InvalidArgumentException If the site cannot be resolved or has no usable ID.
+	 *
+	 * @return  void
+	 */
+	private function initialize_single_site( string $site_id_or_url, OutputInterface $output ): void {
+		$site = get_wpcom_site( $site_id_or_url );
+		if ( ! \is_object( $site ) ) {
+			throw new \InvalidArgumentException( "Could not resolve site '$site_id_or_url'." );
+		}
+
+		$site_id = (int) ( $site->ID ?? $site->userblog_id ?? 0 );
+		if ( 0 === $site_id ) {
+			throw new \InvalidArgumentException( "Resolved site '$site_id_or_url' has no usable ID." );
+		}
+
+		// Normalise into the same shape get_wpcom_jetpack_sites() returns so the rest of execute() needs no branching.
+		$normalised_site              = clone $site;
+		$normalised_site->userblog_id = $site_id;
+		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- WPCOM API returns a `URL` property.
+		$normalised_site->siteurl = $site->URL ?? $site->siteurl ?? $site_id_or_url;
+
+		$this->single_site = $normalised_site;
+		$this->sites       = array( $site_id => $normalised_site );
+
+		$output->writeln( "<comment>Querying single site {$normalised_site->siteurl} (ID $site_id).</comment>" );
+
+		$this->statuses = get_wpcom_sites_atlantis_status_batch( array( $site_id ), $this->errors );
+		maybe_output_wpcom_failed_sites_table( $output, $this->errors ?? array(), $this->sites, 'Sites that could NOT be queried for Atlantis status' );
+	}
 
 	/**
 	 * Prompts the user for the destination to save the output to.

--- a/commands/WPCOM_Atlantis_Status.php
+++ b/commands/WPCOM_Atlantis_Status.php
@@ -1,0 +1,319 @@
+<?php
+
+namespace WPCOMSpecialProjects\CLI\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use WPCOMSpecialProjects\CLI\Helper\AutocompleteTrait;
+
+/**
+ * Reports the status of the Atlantis plugin and its modules across all
+ * Jetpack-connected sites.
+ *
+ * Proof-of-concept scope: surfaces plugin version and the Autoupdate Filter
+ * module state per site. Sites without Atlantis return `not installed`.
+ */
+#[AsCommand( name: 'wpcom:atlantis-status' )]
+final class WPCOM_Atlantis_Status extends Command {
+	use AutocompleteTrait;
+
+	// region FIELDS AND CONSTANTS
+
+	/**
+	 * The list of connected sites.
+	 *
+	 * @var array|null
+	 */
+	private ?array $sites = null;
+
+	/**
+	 * The per-site status payloads keyed by site ID. Sites that failed to
+	 * respond are absent from this map and present in $errors instead.
+	 *
+	 * @var array|null
+	 */
+	private ?array $statuses = null;
+
+	/**
+	 * Per-site errors from the batch call.
+	 *
+	 * @var array|null
+	 */
+	private ?array $errors = null;
+
+	/**
+	 * Columns included in the export and thus that can be excluded via options.
+	 *
+	 * @var array
+	 */
+	private array $export_columns = array( 'Site ID', 'Site URL', 'Atlantis Version', 'Autoupdates' );
+
+	/**
+	 * List of columns to exclude from the export.
+	 *
+	 * @var array|null
+	 */
+	private ?array $export_excluded_columns = null;
+
+	/**
+	 * The format to export the report in.
+	 *
+	 * @var string|null
+	 */
+	private ?string $format = null;
+
+	/**
+	 * The destination file path for the export.
+	 *
+	 * @var string|null
+	 */
+	private ?string $destination = null;
+
+	/**
+	 * The stream to write the export to.
+	 *
+	 * @var resource|null
+	 */
+	private $stream = null;
+
+	// endregion
+
+	// region INHERITED METHODS
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function configure(): void {
+		$this->setDescription( 'Reports Atlantis plugin and module status across all Jetpack-connected sites.' )
+			->setHelp( 'Calls the OpsOasis batch endpoint for `a8csp-atlantis/v1/status` on every Jetpack-connected site and prints a per-site report. Sites without Atlantis installed are reported as `not installed`.' );
+
+		$this->addOption( 'export', null, InputOption::VALUE_REQUIRED, 'If provided, the report will be saved to this file in addition to the terminal.' )
+			->addOption( 'export-format', null, InputOption::VALUE_REQUIRED, 'The format to export the report in. Accepted values are `json` and `csv`.', 'csv' )
+			->addOption( 'export-exclude', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Exclude columns from the export. Possible values: `Site ID`, `Site URL`, `Atlantis Version`, `Autoupdates`.' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function initialize( InputInterface $input, OutputInterface $output ): void {
+		$this->format      = get_enum_input( $input, 'export-format', array( 'json', 'csv' ) );
+		$this->destination = maybe_get_string_input( $input, 'export', fn() => $this->prompt_destination_input( $input, $output ) );
+		if ( ! empty( $this->destination ) ) {
+			$this->export_excluded_columns = $input->getOption( 'export-exclude' ) ?: $this->prompt_export_excluded_columns_input( $input, $output );
+			$input->setOption( 'export-exclude', $this->export_excluded_columns );
+
+			$this->stream = get_file_handle( $this->destination, $this->format );
+		}
+
+		$this->sites = get_wpcom_jetpack_sites();
+		$output->writeln( '<comment>Successfully fetched ' . \count( $this->sites ) . ' Jetpack site(s).</comment>' );
+
+		$this->statuses = get_wpcom_sites_atlantis_status_batch( \array_column( $this->sites, 'userblog_id' ), $this->errors );
+		maybe_output_wpcom_failed_sites_table( $output, $this->errors ?? array(), $this->sites, 'Sites that could NOT be queried for Atlantis status' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( InputInterface $input, OutputInterface $output ): int {
+		$output->writeln( '<fg=magenta;options=bold>Reporting Atlantis status across connected sites.</>' );
+
+		$rows                       = array();
+		$installed_count            = 0;
+		$autoupdates_enabled_count  = 0;
+
+		foreach ( $this->sites as $site_id => $site ) {
+			$status = $this->statuses[ $site_id ] ?? null;
+
+			$row = array(
+				'Site ID'          => $site->userblog_id,
+				'Site URL'         => $site->siteurl,
+				'Atlantis Version' => 'not installed',
+				'Autoupdates'      => '—',
+			);
+
+			if ( \is_object( $status ) ) {
+				++$installed_count;
+
+				$row['Atlantis Version'] = $status->plugin->version ?? 'unknown';
+
+				$autoupdates_enabled = $status->modules->autoupdates->enabled ?? null;
+				if ( true === $autoupdates_enabled ) {
+					$row['Autoupdates'] = 'on';
+					++$autoupdates_enabled_count;
+				} elseif ( false === $autoupdates_enabled ) {
+					$row['Autoupdates'] = 'off';
+				}
+			}
+
+			$rows[] = $row;
+		}
+
+		$table_header = array_keys( $rows[0] ?? array( 'Site ID' => '', 'Site URL' => '', 'Atlantis Version' => '', 'Autoupdates' => '' ) );
+		output_table(
+			$output,
+			array_map( 'array_values', $rows ),
+			$table_header,
+			'Atlantis status by site'
+		);
+
+		$summary_output = array(
+			'REPORT SUMMARY'         => '',
+			'Total sites queried'    => \count( $this->sites ),
+			'Sites with Atlantis'    => $installed_count,
+			'Autoupdates module ON'  => $autoupdates_enabled_count,
+			'Sites that errored'     => \count( $this->errors ?? array() ),
+		);
+
+		foreach ( $summary_output as $key => $value ) {
+			$output->writeln( "<info>$key: $value</info>" );
+		}
+
+		if ( ! \is_null( $this->stream ) ) {
+			$rows_for_export = array_map( 'array_values', $rows );
+			match ( $this->format ) {
+				'csv' => $this->create_csv( $table_header, $rows_for_export, $summary_output ),
+				'json' => $this->create_json( $table_header, $rows_for_export, $summary_output ),
+			};
+			$output->writeln( "<info>Output saved to $this->destination</info>" );
+		}
+
+		return Command::SUCCESS;
+	}
+
+	// endregion
+
+	// region HELPERS
+
+	/**
+	 * Prompts the user for the destination to save the output to.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  string|null
+	 */
+	private function prompt_destination_input( InputInterface $input, OutputInterface $output ): ?string {
+		$question = new ConfirmationQuestion( '<question>Would you like to save the output to a file? [y/N]</question> ', false );
+		if ( true === $this->getHelper( 'question' )->ask( $input, $output, $question ) ) {
+			$default  = get_user_folder_path( 'Downloads/wpcom-atlantis-status_' . gmdate( 'Y-m-d-H-i-s' ) . ".$this->format" );
+			$question = new Question( "<question>Please enter the path to the file you want to save the output to [$default]:</question> ", $default );
+			return $this->getHelper( 'question' )->ask( $input, $output, $question );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Prompts the user to maybe exclude columns from the exported file.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  array|null
+	 */
+	private function prompt_export_excluded_columns_input( InputInterface $input, OutputInterface $output ): ?array {
+		$question = new ConfirmationQuestion( '<question>Would you like to exclude any columns from the exported report? [y/N]</question> ', false );
+		if ( true === $this->getHelper( 'question' )->ask( $input, $output, $question ) ) {
+			$question = new ChoiceQuestion( '<question>Please select the columns you want to exclude from the exported file [' . $this->export_columns[0] . ']:</question> ', $this->export_columns );
+			$question->setMultiselect( true );
+
+			return $this->getHelper( 'question' )->ask( $input, $output, $question );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Creates a CSV file from the final report.
+	 *
+	 * @param   array $headers Header row.
+	 * @param   array $rows    Data rows.
+	 * @param   array $summary Summary lines.
+	 *
+	 * @return  void
+	 */
+	private function create_csv( array $headers, array $rows, array $summary ): void {
+		$filtered_data = $this->filter_export_columns( $headers, $rows );
+
+		\fputcsv( $this->stream, $filtered_data['headers'] );
+		foreach ( $filtered_data['rows'] as $fields ) {
+			\fputcsv( $this->stream, $fields );
+		}
+		foreach ( $summary as $key => $item ) {
+			\fputcsv( $this->stream, array( $key, $item ) );
+		}
+		\fclose( $this->stream );
+	}
+
+	/**
+	 * Creates a JSON file from the final report.
+	 *
+	 * @param   array $headers Header row.
+	 * @param   array $rows    Data rows.
+	 * @param   array $summary Summary lines.
+	 *
+	 * @return  void
+	 */
+	private function create_json( array $headers, array $rows, array $summary ): void {
+		$filtered_data = $this->filter_export_columns( $headers, $rows );
+
+		$filtered_data['rows'][] = $summary;
+		\fwrite( $this->stream, encode_json_content( $filtered_data['rows'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES ) );
+		\fclose( $this->stream );
+	}
+
+	/**
+	 * Filters out excluded columns from headers and rows.
+	 *
+	 * @param   array $headers Headers.
+	 * @param   array $rows    Rows.
+	 *
+	 * @return  array
+	 */
+	private function filter_export_columns( array $headers, array $rows ): array {
+		if ( empty( $this->export_excluded_columns ) ) {
+			return array(
+				'headers' => $headers,
+				'rows'    => $rows,
+			);
+		}
+
+		$header_compare = array_map(
+			static fn ( $column ) => strtoupper( preg_replace( '/\s+/', '', $column ) ),
+			$headers
+		);
+
+		$excluded_columns = array_map(
+			static fn ( $column ) => strtoupper( preg_replace( '/\s+/', '', $column ) ),
+			$this->export_excluded_columns
+		);
+
+		foreach ( $excluded_columns as $column ) {
+			$column_index = array_search( $column, $header_compare, true );
+			if ( false !== $column_index ) {
+				unset( $headers[ $column_index ] );
+				foreach ( $rows as &$row ) {
+					unset( $row[ $column_index ] );
+				}
+				unset( $row );
+			}
+		}
+
+		$headers = array_values( $headers );
+		$rows    = array_map( 'array_values', $rows );
+
+		return array(
+			'headers' => $headers,
+			'rows'    => $rows,
+		);
+	}
+
+	// endregion
+}

--- a/commands/WPCOM_Atlantis_Status.php
+++ b/commands/WPCOM_Atlantis_Status.php
@@ -117,6 +117,13 @@ final class WPCOM_Atlantis_Status extends Command {
 	 */
 	private bool $issues_only = false;
 
+	/**
+	 * When true, only sites with at least one stored custom message are rendered.
+	 *
+	 * @var bool
+	 */
+	private bool $with_messages_only = false;
+
 	// endregion
 
 	// region INHERITED METHODS
@@ -132,6 +139,7 @@ final class WPCOM_Atlantis_Status extends Command {
 			->addOption( 'module', null, InputOption::VALUE_REQUIRED, 'Restrict the report to a single module column. Accepted values: ' . \implode( ', ', self::KNOWN_MODULE_KEYS ) . '.' )
 			->addOption( 'prod', null, InputOption::VALUE_NEGATABLE, 'Exclude any site whose URL contains the substring "staging" (case-insensitive). Use --no-prod to suppress the prompt and include staging sites. When neither is set you will be prompted (unless --no-interaction).' )
 			->addOption( 'issues-only', null, InputOption::VALUE_NEGATABLE, 'Only show sites where Atlantis is not installed or at least one module is not on. Use --no-issues-only to suppress the prompt and show all sites. When neither is set you will be prompted (unless --no-interaction).' )
+			->addOption( 'with-messages-only', null, InputOption::VALUE_NONE, 'Only show sites that have at least one stored Atlantis custom message.' )
 			->addOption( 'export', null, InputOption::VALUE_REQUIRED, 'If provided, the report will be saved to this file in addition to the terminal.' )
 			->addOption( 'export-format', null, InputOption::VALUE_REQUIRED, 'The format to export the report in. Accepted values are `json` and `csv`.', 'csv' )
 			->addOption( 'export-exclude', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Exclude columns from the export. Possible values depend on the active --module flag; defaults to `Site ID`, `Site URL`, `Atlantis Version`, plus one column per Atlantis module.' );
@@ -155,7 +163,7 @@ final class WPCOM_Atlantis_Status extends Command {
 		}
 
 		$this->export_columns = \array_merge(
-			array( 'Site ID', 'Site URL', 'Atlantis Version' ),
+			array( 'Site ID', 'Site URL', 'Atlantis Version', 'Custom Msgs' ),
 			\array_map( fn( string $key ) => \ucfirst( $key ), $this->module_keys )
 		);
 
@@ -167,6 +175,8 @@ final class WPCOM_Atlantis_Status extends Command {
 
 			$this->stream = get_file_handle( $this->destination, $this->format );
 		}
+
+		$this->with_messages_only = (bool) $input->getOption( 'with-messages-only' );
 
 		$site_option = $input->getOption( 'site' );
 		if ( ! \is_null( $site_option ) ) {
@@ -205,10 +215,11 @@ final class WPCOM_Atlantis_Status extends Command {
 			: "for site {$this->single_site->siteurl}";
 		$output->writeln( "<fg=magenta;options=bold>Reporting Atlantis status $scope_label.</>" );
 
-		$rows                  = array();
-		$installed_count       = 0;
-		$issue_count           = 0;
-		$module_enabled_counts = \array_fill_keys( $this->module_keys, 0 );
+		$rows                      = array();
+		$installed_count           = 0;
+		$issue_count               = 0;
+		$sites_with_messages_count = 0;
+		$module_enabled_counts     = \array_fill_keys( $this->module_keys, 0 );
 
 		foreach ( $this->sites as $site_id => $site ) {
 			$status = $this->statuses[ $site_id ] ?? null;
@@ -217,18 +228,29 @@ final class WPCOM_Atlantis_Status extends Command {
 				'Site ID'          => $site->userblog_id,
 				'Site URL'         => $site->siteurl,
 				'Atlantis Version' => 'not installed',
+				'Custom Msgs'      => '—',
 			);
 			foreach ( $this->module_keys as $module_key ) {
 				$row[ \ucfirst( $module_key ) ] = '—';
 			}
 
-			$has_issue = true; // Atlantis missing counts as an issue.
+			$has_issue      = true; // Atlantis missing counts as an issue.
+			$messages_count = 0;
 
 			if ( \is_object( $status ) ) {
 				++$installed_count;
 				$has_issue = false;
 
 				$row['Atlantis Version'] = $status->plugin->version ?? 'unknown';
+
+				$count_raw = $status->modules->messages->count ?? null;
+				if ( \is_int( $count_raw ) || ( \is_string( $count_raw ) && \ctype_digit( $count_raw ) ) ) {
+					$messages_count     = (int) $count_raw;
+					$row['Custom Msgs'] = $messages_count;
+					if ( $messages_count > 0 ) {
+						++$sites_with_messages_count;
+					}
+				}
 
 				foreach ( $this->module_keys as $module_key ) {
 					$enabled = $status->modules->$module_key->enabled ?? null;
@@ -253,7 +275,18 @@ final class WPCOM_Atlantis_Status extends Command {
 				continue;
 			}
 
+			if ( $this->with_messages_only && $messages_count <= 0 ) {
+				continue;
+			}
+
 			$rows[] = $row;
+		}
+
+		$table_title = 'Atlantis status by site';
+		if ( $this->with_messages_only ) {
+			$table_title = 'Atlantis sites with custom messages';
+		} elseif ( $this->issues_only ) {
+			$table_title = 'Atlantis sites with issues';
 		}
 
 		$table_header = array_keys( $rows[0] ?? \array_fill_keys( $this->export_columns, '' ) );
@@ -261,14 +294,15 @@ final class WPCOM_Atlantis_Status extends Command {
 			$output,
 			array_map( 'array_values', $rows ),
 			$table_header,
-			$this->issues_only ? 'Atlantis sites with issues' : 'Atlantis status by site'
+			$table_title
 		);
 
 		$summary_output = array(
-			'REPORT SUMMARY'      => '',
-			'Total sites queried' => \count( $this->sites ),
-			'Sites with Atlantis' => $installed_count,
-			'Sites with issues'   => $issue_count,
+			'REPORT SUMMARY'             => '',
+			'Total sites queried'        => \count( $this->sites ),
+			'Sites with Atlantis'        => $installed_count,
+			'Sites with issues'          => $issue_count,
+			'Sites with custom messages' => $sites_with_messages_count,
 		);
 		foreach ( $module_enabled_counts as $module_key => $count ) {
 			$summary_output[ \ucfirst( $module_key ) . ' module ON' ] = $count;

--- a/commands/WPCOM_Atlantis_Status.php
+++ b/commands/WPCOM_Atlantis_Status.php
@@ -130,8 +130,8 @@ final class WPCOM_Atlantis_Status extends Command {
 
 		$this->addOption( 'site', null, InputOption::VALUE_REQUIRED, 'Restrict the report to a single site, identified by its WPCOM ID or URL. Skips the full fleet fetch.' )
 			->addOption( 'module', null, InputOption::VALUE_REQUIRED, 'Restrict the report to a single module column. Accepted values: ' . \implode( ', ', self::KNOWN_MODULE_KEYS ) . '.' )
-			->addOption( 'prod', null, InputOption::VALUE_NONE, 'Exclude any site whose URL contains the substring "staging" (case-insensitive).' )
-			->addOption( 'issues-only', null, InputOption::VALUE_NONE, 'Only show sites where Atlantis is not installed or at least one module is not on.' )
+			->addOption( 'prod', null, InputOption::VALUE_NEGATABLE, 'Exclude any site whose URL contains the substring "staging" (case-insensitive). Use --no-prod to suppress the prompt and include staging sites. When neither is set you will be prompted (unless --no-interaction).' )
+			->addOption( 'issues-only', null, InputOption::VALUE_NEGATABLE, 'Only show sites where Atlantis is not installed or at least one module is not on. Use --no-issues-only to suppress the prompt and show all sites. When neither is set you will be prompted (unless --no-interaction).' )
 			->addOption( 'export', null, InputOption::VALUE_REQUIRED, 'If provided, the report will be saved to this file in addition to the terminal.' )
 			->addOption( 'export-format', null, InputOption::VALUE_REQUIRED, 'The format to export the report in. Accepted values are `json` and `csv`.', 'csv' )
 			->addOption( 'export-exclude', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Exclude columns from the export. Possible values depend on the active --module flag; defaults to `Site ID`, `Site URL`, `Atlantis Version`, plus one column per Atlantis module.' );
@@ -159,8 +159,6 @@ final class WPCOM_Atlantis_Status extends Command {
 			\array_map( fn( string $key ) => \ucfirst( $key ), $this->module_keys )
 		);
 
-		$this->issues_only = (bool) $input->getOption( 'issues-only' );
-
 		$this->format      = get_enum_input( $input, 'export-format', array( 'json', 'csv' ) );
 		$this->destination = maybe_get_string_input( $input, 'export', fn() => $this->prompt_destination_input( $input, $output ) );
 		if ( ! empty( $this->destination ) ) {
@@ -172,14 +170,19 @@ final class WPCOM_Atlantis_Status extends Command {
 
 		$site_option = $input->getOption( 'site' );
 		if ( ! \is_null( $site_option ) ) {
+			// Single-site path: --prod and --issues-only are honoured if explicitly passed, but never prompted.
+			$this->issues_only = true === $input->getOption( 'issues-only' );
 			$this->initialize_single_site( (string) $site_option, $output );
 			return;
 		}
 
+		$prod_filter       = $this->resolve_boolean_flag( $input, $output, 'prod', 'Would you like to exclude staging sites (any URL containing "staging") from the report?' );
+		$this->issues_only = $this->resolve_boolean_flag( $input, $output, 'issues-only', 'Would you like to only show sites where Atlantis is missing or any module is not on?' );
+
 		$this->sites = get_wpcom_jetpack_sites();
 		$output->writeln( '<comment>Successfully fetched ' . \count( $this->sites ) . ' Jetpack site(s).</comment>' );
 
-		if ( $input->getOption( 'prod' ) ) {
+		if ( $prod_filter ) {
 			$before      = \count( $this->sites );
 			$this->sites = \array_filter(
 				$this->sites,
@@ -291,6 +294,34 @@ final class WPCOM_Atlantis_Status extends Command {
 	// endregion
 
 	// region HELPERS
+
+	/**
+	 * Resolves a VALUE_NEGATABLE boolean option, prompting the user when the option
+	 * is absent and the session is interactive.
+	 *
+	 * Explicit `--flag` or `--no-flag` always wins. In non-interactive mode an
+	 * absent option resolves to `false` (the safe default for these filters).
+	 *
+	 * @param   InputInterface  $input    The console input.
+	 * @param   OutputInterface $output   The console output.
+	 * @param   string          $name     The option name.
+	 * @param   string          $question The yes/no prompt text.
+	 *
+	 * @return  bool
+	 */
+	private function resolve_boolean_flag( InputInterface $input, OutputInterface $output, string $name, string $question ): bool {
+		$value = $input->getOption( $name );
+		if ( ! \is_null( $value ) ) {
+			return (bool) $value;
+		}
+
+		if ( ! $input->isInteractive() ) {
+			return false;
+		}
+
+		$confirm = new ConfirmationQuestion( "<question>$question [y/N]</question> ", false );
+		return (bool) $this->getHelper( 'question' )->ask( $input, $output, $confirm );
+	}
 
 	/**
 	 * Resolves a single site from $site_id_or_url, fetches its Atlantis status, and

--- a/commands/WPCOM_Atlantis_Status.php
+++ b/commands/WPCOM_Atlantis_Status.php
@@ -304,26 +304,45 @@ final class WPCOM_Atlantis_Status extends Command {
 	 * @return  void
 	 */
 	private function initialize_single_site( string $site_id_or_url, OutputInterface $output ): void {
-		$site = get_wpcom_site( $site_id_or_url );
-		if ( ! \is_object( $site ) ) {
-			throw new \InvalidArgumentException( "Could not resolve site '$site_id_or_url'." );
+		$lookup = $site_id_or_url;
+		if ( \str_contains( $lookup, 'http' ) ) {
+			$host = \parse_url( $lookup, PHP_URL_HOST );
+			if ( ! \is_string( $host ) || '' === $host ) {
+				throw new \InvalidArgumentException( "Invalid URL '$site_id_or_url'." );
+			}
+			$lookup = $host;
 		}
 
-		$site_id = (int) ( $site->ID ?? $site->userblog_id ?? 0 );
+		$sites = get_wpcom_jetpack_sites();
+		$output->writeln( '<comment>Fetched ' . \count( $sites ) . ' Jetpack site(s) to resolve --site.</comment>' );
+
+		$matched = null;
+		if ( \ctype_digit( $lookup ) ) {
+			$matched = $sites[ (int) $lookup ] ?? null;
+		} else {
+			$lookup_lc = \strtolower( $lookup );
+			foreach ( $sites as $site ) {
+				$candidate_host = \parse_url( (string) ( $site->siteurl ?? '' ), PHP_URL_HOST );
+				if ( \is_string( $candidate_host ) && \strtolower( $candidate_host ) === $lookup_lc ) {
+					$matched = $site;
+					break;
+				}
+			}
+		}
+
+		if ( null === $matched ) {
+			throw new \InvalidArgumentException( "Site '$site_id_or_url' is not in the connected Jetpack sites list." );
+		}
+
+		$site_id = (int) ( $matched->userblog_id ?? 0 );
 		if ( 0 === $site_id ) {
 			throw new \InvalidArgumentException( "Resolved site '$site_id_or_url' has no usable ID." );
 		}
 
-		// Normalise into the same shape get_wpcom_jetpack_sites() returns so the rest of execute() needs no branching.
-		$normalised_site              = clone $site;
-		$normalised_site->userblog_id = $site_id;
-		// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- WPCOM API returns a `URL` property.
-		$normalised_site->siteurl = $site->URL ?? $site->siteurl ?? $site_id_or_url;
+		$this->single_site = $matched;
+		$this->sites       = array( $site_id => $matched );
 
-		$this->single_site = $normalised_site;
-		$this->sites       = array( $site_id => $normalised_site );
-
-		$output->writeln( "<comment>Querying single site {$normalised_site->siteurl} (ID $site_id).</comment>" );
+		$output->writeln( "<comment>Querying single site {$matched->siteurl} (ID $site_id).</comment>" );
 
 		$this->statuses = get_wpcom_sites_atlantis_status_batch( array( $site_id ), $this->errors );
 		maybe_output_wpcom_failed_sites_table( $output, $this->errors ?? array(), $this->sites, 'Sites that could NOT be queried for Atlantis status' );

--- a/includes/functions-wpcom.php
+++ b/includes/functions-wpcom.php
@@ -147,6 +147,26 @@ function get_wpcom_site_plugins_batch( array $site_ids_or_urls, ?array &$errors 
 }
 
 /**
+ * Returns the Atlantis plugin and module status for a batch of WPCOM sites.
+ *
+ * Sites without Atlantis installed (or with the endpoint unreachable) are
+ * surfaced via $errors; the returned map only contains successful responses.
+ *
+ * @param   array      $site_ids_or_urls The list of site domains or numeric WPCOM IDs.
+ * @param   array|null $errors           The list of errors that occurred during the request.
+ *
+ * @return  array<int|string,stdClass>|null
+ */
+function get_wpcom_sites_atlantis_status_batch( array $site_ids_or_urls, ?array &$errors = null ): ?array {
+	$sites_status = API_Helper::make_wpcom_request( 'sites/batch/atlantis-status', 'POST', array( 'sites' => $site_ids_or_urls ) );
+	if ( is_null( $sites_status ) ) {
+		return null;
+	}
+
+	return parse_batch_response( $sites_status, $errors );
+}
+
+/**
  * Returns the stats for a WPCOM or Jetpack Connected site.
  *
  * @param   string      $site_id_or_url The site URL or WordPress.com site ID.


### PR DESCRIPTION
## Summary

- New command `wpcom:atlantis-status` reports the Atlantis plugin and module state across every Jetpack-connected site.
- Adds helper `get_wpcom_sites_atlantis_status_batch()` in `includes/functions-wpcom.php`, modeled on the sibling `get_wpcom_site_plugins_batch`.
- Optional CSV/JSON export (`--export`, `--export-format`, `--export-exclude`), mirroring `jetpack:plugin-search` conventions.

## Why

Unblocks fleet-wide reporting of Atlantis module enablement (the immediate ask is the Autoupdate Filter module across 1,000+ sites) without per-site WP-CLI access. Built on the same plumbing as `jetpack:plugin-search` — fetch Jetpack site list, batch-call OpsOasis, render.

## Flow

1. `get_wpcom_jetpack_sites()` → fleet list.
2. `get_wpcom_sites_atlantis_status_batch( $ids, $errors )` → POSTs `sites/batch/atlantis-status` on OpsOasis (companion PR [a8cteam51/opsoasis#177](https://github.com/a8cteam51/opsoasis/pull/177)), which fans `a8csp-atlantis/v1/status` out across each site (companion PR [a8cteam51/a8csp-atlantis#59](https://github.com/a8cteam51/a8csp-atlantis/pull/59)).
3. Per-site row printed:

   | Site ID | Site URL | Atlantis Version | Autoupdates |
   |---|---|---|---|

4. Sites without Atlantis → `not installed` / `—`. Transport failures surfaced via the standard `maybe_output_wpcom_failed_sites_table()`.
5. Summary footer: total sites queried, sites with Atlantis, Autoupdates module ON count, sites that errored.

## Scope notes

Proof-of-concept scope per discussion — surfaces only the Autoupdate Filter module column for the MVP, but the OpsOasis/Atlantis endpoints already return all four modules' status, so adding per-module columns or a `--module=` filter is a small follow-up.

Out of scope here:
- Per-site detail mode (`--site=...`).
- Module filter flag.
- Custom messages listing.
- Version filter / comparison.

## Test plan

- [ ] Run `composer install` on this branch.
- [ ] Confirm command is discoverable: `team51 list | grep atlantis-status`.
- [ ] With both companion PRs deployed (Atlantis to ≥1 test site, OpsOasis to its host), run `team51 wpcom:atlantis-status`. The test site row shows the Atlantis version and Autoupdates state; all other sites show `not installed`.
- [ ] Toggle the Autoupdate Filter module off on the test site; rerun and verify the column flips to `off`.
- [ ] Verify CSV export: `team51 wpcom:atlantis-status --export=/tmp/atlantis-status.csv --export-format=csv`.
- [ ] Verify JSON export: `team51 wpcom:atlantis-status --export=/tmp/atlantis-status.json --export-format=json`.
- [ ] Verify summary counts match what's in the table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command to check Atlantis plugin status and per-module states across Jetpack-connected sites or a single target.
  * Per-site table showing module ON/OFF and "not installed"; optional "issues only" filter and option to skip staging sites.
  * Exportable reports (CSV/JSON) with optional column exclusion (interactive) and appended summary.
  * Batch API helper to query Atlantis status for multiple sites and surface errors for reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/a8cteam51/team51-cli/pull/125?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->