### PR TITLE
Expose wpcom:atlantis-status via MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ claude mcp add team51 -- team51 --mcp
 
 ### Available Tools
 
-The MCP server currently exposes 66 tools across all services. The table below shows a subset of commonly used tools:
+The MCP server currently exposes 67 tools across all services. The table below shows a subset of commonly used tools:
 
 | Service | Read Tools | Write Tools |
 |---------|-----------|-------------|

--- a/commands/WPCOM_Atlantis_Status.php
+++ b/commands/WPCOM_Atlantis_Status.php
@@ -370,11 +370,11 @@ final class WPCOM_Atlantis_Status extends Command {
 	 */
 	private function initialize_single_site( string $site_id_or_url, OutputInterface $output ): void {
 		$lookup = $site_id_or_url;
-		if ( \str_contains( $lookup, 'http' ) ) {
-			$host = \parse_url( $lookup, PHP_URL_HOST );
-			if ( ! \is_string( $host ) || '' === $host ) {
-				throw new \InvalidArgumentException( "Invalid URL '$site_id_or_url'." );
-			}
+		$host   = \parse_url( $lookup, PHP_URL_HOST );
+		if ( ! \is_string( $host ) || '' === $host ) {
+			$host = \parse_url( 'https://' . \ltrim( $lookup, '/' ), PHP_URL_HOST );
+		}
+		if ( \is_string( $host ) && '' !== $host ) {
 			$lookup = $host;
 		}
 

--- a/mcp/Team51McpTools.php
+++ b/mcp/Team51McpTools.php
@@ -345,11 +345,11 @@ final class Team51McpTools {
 
 		if ( ! \is_null( $site_id_or_url ) ) {
 			$lookup = $site_id_or_url;
-			if ( \str_contains( $lookup, 'http' ) ) {
-				$host = \parse_url( $lookup, PHP_URL_HOST );
-				if ( ! \is_string( $host ) || '' === $host ) {
-					return array( 'error' => "Invalid URL '$site_id_or_url'." );
-				}
+			$host   = \parse_url( $lookup, PHP_URL_HOST );
+			if ( ! \is_string( $host ) || '' === $host ) {
+				$host = \parse_url( 'https://' . \ltrim( $lookup, '/' ), PHP_URL_HOST );
+			}
+			if ( \is_string( $host ) && '' !== $host ) {
 				$lookup = $host;
 			}
 

--- a/mcp/Team51McpTools.php
+++ b/mcp/Team51McpTools.php
@@ -297,6 +297,179 @@ final class Team51McpTools {
 	}
 
 	/**
+	 * Report the status of the Atlantis plugin and its modules across
+	 * Jetpack-connected WordPress.com sites.
+	 *
+	 * When `$site_id_or_url` is provided, returns the status for that single
+	 * site only and `$exclude_staging` is ignored. Otherwise queries the full
+	 * Jetpack-connected fleet. Sites without Atlantis are reported with
+	 * `atlantis_installed: false`.
+	 *
+	 * @param string|null $site_id_or_url     Optional. Single site URL or WPCOM numeric ID.
+	 * @param string|null $module             Optional. Restrict the report to a single module column. One of: messages, colophon, tracking, autoupdates.
+	 * @param bool        $exclude_staging    Exclude sites whose URL contains "staging" (case-insensitive). Ignored in single-site mode.
+	 * @param bool        $issues_only        Only return sites where Atlantis is not installed or at least one module is not on.
+	 * @param bool        $with_messages_only Only return sites that have at least one stored Atlantis custom message.
+	 */
+	#[McpTool( name: 'wpcom_get_atlantis_status' )]
+	public function wpcom_get_atlantis_status(
+		?string $site_id_or_url = null,
+		?string $module = null,
+		bool $exclude_staging = false,
+		bool $issues_only = false,
+		bool $with_messages_only = false
+	): array {
+		$identity_error = self::ensure_identity();
+		if ( $identity_error ) {
+			return $identity_error;
+		}
+
+		// Keep this list in sync with WPCOM_Atlantis_Status::KNOWN_MODULE_KEYS.
+		$known_modules = array( 'messages', 'colophon', 'tracking', 'autoupdates' );
+
+		$module_keys = $known_modules;
+		if ( ! \is_null( $module ) ) {
+			$module = \strtolower( $module );
+			if ( ! \in_array( $module, $known_modules, true ) ) {
+				return array(
+					'error' => "Unknown module '$module'. Accepted values: " . \implode( ', ', $known_modules ) . '.',
+				);
+			}
+			$module_keys = array( $module );
+		}
+
+		$sites = get_wpcom_jetpack_sites();
+		if ( null === $sites ) {
+			return array( 'error' => 'Failed to fetch Jetpack-connected sites.' );
+		}
+
+		if ( ! \is_null( $site_id_or_url ) ) {
+			$lookup = $site_id_or_url;
+			if ( \str_contains( $lookup, 'http' ) ) {
+				$host = \parse_url( $lookup, PHP_URL_HOST );
+				if ( ! \is_string( $host ) || '' === $host ) {
+					return array( 'error' => "Invalid URL '$site_id_or_url'." );
+				}
+				$lookup = $host;
+			}
+
+			$matched = null;
+			if ( \ctype_digit( $lookup ) ) {
+				$matched = $sites[ (int) $lookup ] ?? null;
+			} else {
+				$lookup_lc = \strtolower( $lookup );
+				foreach ( $sites as $site ) {
+					$candidate_host = \parse_url( (string) ( $site->siteurl ?? '' ), PHP_URL_HOST );
+					if ( \is_string( $candidate_host ) && \strtolower( $candidate_host ) === $lookup_lc ) {
+						$matched = $site;
+						break;
+					}
+				}
+			}
+
+			if ( null === $matched ) {
+				return array( 'error' => "Site '$site_id_or_url' is not in the connected Jetpack sites list." );
+			}
+
+			$site_id = (int) ( $matched->userblog_id ?? 0 );
+			if ( 0 === $site_id ) {
+				return array( 'error' => "Resolved site '$site_id_or_url' has no usable ID." );
+			}
+
+			$sites = array( $site_id => $matched );
+		} elseif ( $exclude_staging ) {
+			$sites = \array_filter(
+				$sites,
+				static fn( $site ) => false === \stripos( (string) ( $site->siteurl ?? '' ), 'staging' )
+			);
+		}
+
+		$errors   = array();
+		$statuses = get_wpcom_sites_atlantis_status_batch( \array_column( $sites, 'userblog_id' ), $errors );
+		if ( null === $statuses ) {
+			return array( 'error' => 'Failed to fetch Atlantis status batch.' );
+		}
+
+		$rows                      = array();
+		$installed_count           = 0;
+		$issue_count               = 0;
+		$sites_with_messages_count = 0;
+		$module_enabled_counts     = \array_fill_keys( $module_keys, 0 );
+
+		foreach ( $sites as $site_id => $site ) {
+			$status = $statuses[ $site_id ] ?? null;
+
+			$row = array(
+				'site_id'               => (int) $site->userblog_id,
+				'site_url'              => $site->siteurl ?? null,
+				'atlantis_installed'    => false,
+				'atlantis_version'      => null,
+				'custom_messages_count' => null,
+				'modules'               => \array_fill_keys( $module_keys, null ),
+			);
+
+			$has_issue      = true;
+			$messages_count = 0;
+
+			if ( \is_object( $status ) ) {
+				++$installed_count;
+				$has_issue                 = false;
+				$row['atlantis_installed'] = true;
+				$row['atlantis_version']   = $status->plugin->version ?? 'unknown';
+
+				$count_raw = $status->modules->messages->count ?? null;
+				if ( \is_int( $count_raw ) || ( \is_string( $count_raw ) && \ctype_digit( $count_raw ) ) ) {
+					$messages_count               = (int) $count_raw;
+					$row['custom_messages_count'] = $messages_count;
+					if ( $messages_count > 0 ) {
+						++$sites_with_messages_count;
+					}
+				}
+
+				foreach ( $module_keys as $module_key ) {
+					$enabled = $status->modules->$module_key->enabled ?? null;
+					if ( true === $enabled ) {
+						$row['modules'][ $module_key ] = 'on';
+						++$module_enabled_counts[ $module_key ];
+					} elseif ( false === $enabled ) {
+						$row['modules'][ $module_key ] = 'off';
+						$has_issue                     = true;
+					} else {
+						$has_issue = true;
+					}
+				}
+			}
+
+			if ( $has_issue ) {
+				++$issue_count;
+			}
+
+			if ( $issues_only && ! $has_issue ) {
+				continue;
+			}
+			if ( $with_messages_only && $messages_count <= 0 ) {
+				continue;
+			}
+
+			$rows[] = $row;
+		}
+
+		return array(
+			'count'   => count( $rows ),
+			'sites'   => $rows,
+			'errors'  => $errors,
+			'summary' => array(
+				'total_sites_queried' => count( $sites ),
+				'sites_with_atlantis' => $installed_count,
+				'sites_with_issues'   => $issue_count,
+				'sites_with_messages' => $sites_with_messages_count,
+				'modules_on'          => $module_enabled_counts,
+				'errors_count'        => count( $errors ),
+			),
+		);
+	}
+
+	/**
 	 * List plugins installed on a specific WordPress.com or Jetpack-connected site.
 	 *
 	 * @param string $site_id_or_domain The domain name or WPCOM site ID.


### PR DESCRIPTION
## Summary
- Adds `wpcom_get_atlantis_status` tool to the MCP server (`mcp/Team51McpTools.php`), wrapping the existing `get_wpcom_sites_atlantis_status_batch()` helper.
- Supports the same modes as the CLI command: single-site lookup (`site_id_or_url`), single-module filter (`module`), staging exclusion (`exclude_staging`), and `issues_only` / `with_messages_only` filters.
- Read-only tool — no `ToolAnnotations` needed. Returns `{count, sites, errors, summary}` with per-site `{site_id, site_url, atlantis_installed, atlantis_version, custom_messages_count, modules}`.
- Bumps README MCP tool count from 66 to 67.

## Test plan
- [ ] Restart MCP server (`team51 --mcp`) and confirm `wpcom_get_atlantis_status` appears in the MCP client tool list.
- [ ] Call with no args — returns full fleet, summary counts match `team51 wpcom:atlantis-status`.
- [ ] Call with `site_id_or_url` (URL form and numeric ID form) — returns single row.
- [ ] Call with `module: "colophon"` — `modules` map on each row contains only the `colophon` key.
- [ ] Call with `exclude_staging: true` — staging sites are filtered out.
- [ ] Call with `issues_only: true` and `with_messages_only: true` — filters behave like the CLI flags.
- [ ] Pass an invalid `module` value — returns a clear error payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tool to report Atlantis plugin/module status across connected WordPress.com sites, with single-site and multi-site queries, issue/message filters, and per-site summaries.

* **Improvements**
  * Improved single-site lookup to better recognize and match site identifiers supplied as URLs or hostnames.

* **Documentation**
  * README updated to reflect the current total of 67 available tools.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/a8cteam51/team51-cli/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->