### PR TITLE
Fix for CreateRepo

### DIFF
--- a/commands/GitHub_Repository_Create.php
+++ b/commands/GitHub_Repository_Create.php
@@ -210,7 +210,7 @@ final class GitHub_Repository_Create extends Command {
 		if ( ! \is_null( $this->classification ) ) {
 			$topics[] = $this->classification;
 		}
-		set_github_repository_topics( $repository->name, $topics );
+		set_github_repository_topics( $this->name, $topics );
 
 		// Check if the selected no code theme is child theme.
 		if ( 'no-code-project' === $this->type && ! empty( $this->no_code_theme ) ) {


### PR DESCRIPTION
This was part of PR https://github.com/a8cteam51/team51-cli/pull/127, but I just realize I forgot to `git commit` it. Apologies.

It fixes an error that was triggering when manually selecting a classification tag.