### PR TITLE
Switch Pressable deployments to native Git API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Glad you asked.
 
-This is a small utility written by some fine folks at Automattic.com. It automates and standardizes provisioning new WordPress sites (on Pressable.com), connecting them to code repositories (on GitHub.com) and configuring deploy automation (via DeployHQ.com). It does a few other things, but that's the gist.
+This is a small utility written by some fine folks at Automattic.com. It automates and standardizes provisioning new WordPress sites (on Pressable.com), connecting them to code repositories (on GitHub.com) and configuring deploy automation. New sites connect directly via native Git deployments (the Pressable Git API for Pressable sites, WordPress.com code deployments for WPCOM sites); DeployHQ.com is retained only for legacy projects that have not yet been migrated. It does a few other things, but that's the gist.
 
 ## How do I use this?
 
@@ -144,6 +144,22 @@ team51 wpcom:site:deployment:webhook:delete <site> [deployment_id] <webhook_id>
 # Manual secret sync fallback (if automatic sync fails)
 team51 wpcom:site:deployment:webhook:sync-secret <site> <deployment_id> <webhook_id> <secret>
 ```
+
+### Pressable GitHub deployments
+
+New Pressable sites connect to GitHub via Pressable's native Git API instead of DeployHQ. `pressable:create-site` and `pressable:clone-site` use this automatically; you can also connect an existing site manually:
+
+```bash
+# Connect a Pressable site to a GitHub repository and trigger an initial deploy.
+# OpsOasis stores the GitHub access token on the site server-side, so no token is passed here.
+# Deploys from the repository root to the site's `wp-content/` by default.
+team51 pressable:connect-site-repository <site> <repository> [--branch=trunk] [--destination-path=wp-content/] [--repository-subdirectory=...]
+
+# Queue an additional deploy after connecting (the connection already triggers an initial deploy).
+team51 pressable:connect-site-repository <site> <repository> --deploy
+```
+
+Existing DeployHQ-backed Pressable sites are unaffected and continue to deploy through DeployHQ until migrated separately.
 
 ### Download site plugins
 

--- a/commands/Pressable_Site_Clone.php
+++ b/commands/Pressable_Site_Clone.php
@@ -37,21 +37,14 @@ final class Pressable_Site_Clone extends Command {
 	private ?string $site_root_name = null;
 
 	/**
-	 * The DeployHQ project for the given site.
+	 * The Git deployment configuration of the parent site.
 	 *
 	 * @var \stdClass|null
 	 */
-	private ?\stdClass $deployhq_project = null;
+	private ?\stdClass $parent_git_config = null;
 
 	/**
-	 * The DeployHQ project server for the given site.
-	 *
-	 * @var \stdClass|null
-	 */
-	private ?\stdClass $site_deployhq_project_server = null;
-
-	/**
-	 * The GitHub repository connected to the DeployHQ project.
+	 * The GitHub repository connected to the parent site.
 	 *
 	 * @var \stdClass|null
 	 */
@@ -126,9 +119,9 @@ final class Pressable_Site_Clone extends Command {
 			$this->site_root_name = $site_root_name;
 		}
 
-		$deployhq_config = get_pressable_site_deployhq_config( $this->site->id );
-		if ( \is_null( $deployhq_config ) ) {
-			$output->writeln( '<error>Unable to find a DeployHQ project for the site.</error>' );
+		$git_config = get_pressable_site_git_config( $this->site->id );
+		if ( \is_null( $git_config ) || empty( $git_config->connected ) || empty( $git_config->repository ) ) {
+			$output->writeln( '<error>Unable to find a connected GitHub repository for the site.</error>' );
 
 			$question = new ConfirmationQuestion( '<question>Do you want to continue anyway? [y/N]</question> ', false );
 			if ( true !== $this->getHelper( 'question' )->ask( $input, $output, $question ) ) {
@@ -136,18 +129,13 @@ final class Pressable_Site_Clone extends Command {
 				exit( 1 );
 			}
 		} else {
-			$this->deployhq_project = $deployhq_config->project;
-			$output->writeln( "<comment>Found DeployHQ project {$this->deployhq_project->name} (permalink {$this->deployhq_project->permalink}) for the given site.</comment>", OutputInterface::VERBOSITY_VERBOSE );
+			$this->parent_git_config = $git_config;
+			$output->writeln( "<comment>Found connected repository {$git_config->repository} (branch {$git_config->branch}) for the given site.</comment>", OutputInterface::VERBOSITY_VERBOSE );
 
-			$this->site_deployhq_project_server = $deployhq_config->server;
-			if ( \is_null( $this->site_deployhq_project_server ) ) {
-				$output->writeln( '<error>Failed to get the DeployHQ project server connected to the site. Aborting!</error>' );
-				exit( 1 );
-			}
-
-			$this->gh_repository = get_github_repository_from_deployhq_project( $this->deployhq_project->permalink );
+			$gh_repo_url         = parse_github_remote_repository_url( $git_config->repository );
+			$this->gh_repository = \is_null( $gh_repo_url ) ? null : get_github_repository( $gh_repo_url->repo );
 			if ( \is_null( $this->gh_repository ) ) {
-				$output->writeln( '<error>Failed to get the GitHub repository connected to the project or invalid connected repository. Aborting!</error>' );
+				$output->writeln( '<error>Failed to get the GitHub repository connected to the site or invalid connected repository. Aborting!</error>' );
 				exit( 1 );
 			}
 
@@ -269,15 +257,21 @@ final class Pressable_Site_Clone extends Command {
 		}
 		$ssh_connection?->disconnect();
 
-		// Create a DeployHQ server for the site.
-		if ( ! \is_null( $this->deployhq_project ) ) {
-			create_deployhq_project_server_for_pressable_site(
-				$site_clone,
-				$this->deployhq_project,
-				'Development' . ( 'development' !== $this->label ? "-$this->label" : '' ),
-				$this->gh_repo_branch,
-				$this->site_deployhq_project_server->branch,
-			);
+		// Connect the cloned site to the GitHub repository on the development branch via the Pressable Git API.
+		if ( ! \is_null( $this->parent_git_config ) ) {
+			$clone_git_config = get_pressable_site_git_config( $site_clone->id );
+			if ( ! \is_null( $clone_git_config ) && ! empty( $clone_git_config->connected ) ) {
+				// The clone inherited the parent's repository connection; just point it at the development branch.
+				$update = update_pressable_site_git_config( $site_clone->id, array( 'branch' => $this->gh_repo_branch ) );
+				if ( \is_null( $update ) ) {
+					$output->writeln( '<error>Failed to update the cloned site Git branch. You may need to connect it manually via `team51 pressable:connect-site-repository`.</error>' );
+				}
+			} else {
+				$connect = connect_pressable_site_repository_for_site( $site_clone, $this->gh_repository, $this->gh_repo_branch );
+				if ( \is_null( $connect ) ) {
+					$output->writeln( '<error>Failed to connect the cloned site repository. You may need to connect it manually via `team51 pressable:connect-site-repository`.</error>' );
+				}
+			}
 		}
 
 		// Done last because it seems to cause issues sometimes with the connection breaking off.

--- a/commands/Pressable_Site_Create.php
+++ b/commands/Pressable_Site_Create.php
@@ -102,7 +102,7 @@ final class Pressable_Site_Create extends Command {
 	 */
 	protected function interact( InputInterface $input, OutputInterface $output ): void {
 		$template_text = 'project' === $this->project_template ? 'using the `project` template' : 'using the `no-code-project` template';
-		$repo_query    = $this->gh_repository ? "and to connect it to the `{$this->gh_repository->full_name}` repository via DeployHQ {$template_text}" : 'without connecting it to a GitHub repository';
+		$repo_query    = $this->gh_repository ? "and to connect it to the `{$this->gh_repository->full_name}` repository via the Pressable Git API {$template_text}" : 'without connecting it to a GitHub repository';
 		$question      = new ConfirmationQuestion( "<question>Are you sure you want to create a new Pressable site named `$this->name` in the $this->datacenter datacenter $repo_query? [y/N]</question> ", false );
 		if ( true !== $this->getHelper( 'question' )->ask( $input, $output, $question ) ) {
 			$output->writeln( '<comment>Command aborted by user.</comment>' );
@@ -117,7 +117,7 @@ final class Pressable_Site_Create extends Command {
 	 */
 	protected function execute( InputInterface $input, OutputInterface $output ): int {
 		$template_text = 'project' === $this->project_template ? 'using the `project` template' : 'using the `no-code-project` template';
-		$repo_text     = $this->gh_repository ? "and connecting it to the `{$this->gh_repository->full_name}` repository via DeployHQ {$template_text}" : 'without connecting it to a GitHub repository';
+		$repo_text     = $this->gh_repository ? "and connecting it to the `{$this->gh_repository->full_name}` repository via the Pressable Git API {$template_text}" : 'without connecting it to a GitHub repository';
 		$output->writeln( "<fg=magenta;options=bold>Creating new Pressable site named `$this->name` in the $this->datacenter datacenter $repo_text.</>" );
 
 		// Create the site and wait for it to be deployed.
@@ -148,23 +148,15 @@ final class Pressable_Site_Create extends Command {
 			'plugin install https://github.com/a8cteam51/a8csp-atlantis/releases/latest/download/a8csp-atlantis.zip --activate',
 		);
 
-		// Create a DeployHQ project and server for the site.
+		// Connect the GitHub repository to the site via the Pressable Git API and trigger an initial deploy.
 		if ( ! \is_null( $this->gh_repository ) ) {
-			$deployhq_project = create_deployhq_project_for_pressable_site( $site, $this->gh_repository, $this->name );
-			if ( ! \is_null( $deployhq_project ) ) {
-				$deployhq_server = create_deployhq_project_server_for_pressable_site( $site, $deployhq_project, 'Production', 'trunk' );
+			$output->writeln( '<fg=magenta;options=bold>Connecting the repository via the Pressable Git API and triggering an initial deploy...</>' );
 
-				// Trigger initial deployment
-				if ( ! \is_null( $deployhq_server ) ) {
-					$output->writeln( '<fg=magenta;options=bold>Triggering initial deployment...</>' );
-
-					$deployment_success = trigger_deployhq_deployment( $deployhq_project, $this->gh_repository, 'trunk' );
-					if ( $deployment_success ) {
-						$output->writeln( '<fg=green;options=bold>Initial deployment triggered successfully.</>' );
-					} else {
-						$output->writeln( '<error>Failed to trigger initial deployment. You may need to manually deploy from the DeployHQ dashboard.</error>' );
-					}
-				}
+			$git_config = connect_pressable_site_repository_for_site( $site, $this->gh_repository, 'trunk' );
+			if ( ! \is_null( $git_config ) ) {
+				$output->writeln( '<fg=green;options=bold>Repository connected and initial deploy triggered successfully.</>' );
+			} else {
+				$output->writeln( '<error>Failed to connect the repository. You may need to connect it manually via `team51 pressable:connect-site-repository`.</error>' );
 			}
 		}
 

--- a/commands/Pressable_Site_Repository_Connect.php
+++ b/commands/Pressable_Site_Repository_Connect.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace WPCOMSpecialProjects\CLI\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Question\Question;
+use WPCOMSpecialProjects\CLI\Helper\AutocompleteTrait;
+
+/**
+ * Connects a Pressable site to a GitHub repository for deployments via the Pressable Git API.
+ */
+#[AsCommand( name: 'pressable:connect-site-repository' )]
+final class Pressable_Site_Repository_Connect extends Command {
+	use AutocompleteTrait;
+
+	// region FIELDS AND CONSTANTS
+
+	/**
+	 * Pressable site definition to connect the repository to.
+	 *
+	 * @var \stdClass|null
+	 */
+	private ?\stdClass $site = null;
+
+	/**
+	 * The GitHub repository to connect the site to.
+	 *
+	 * @var \stdClass|null
+	 */
+	private ?\stdClass $gh_repository = null;
+
+	/**
+	 * The branch to deploy from.
+	 *
+	 * @var string|null
+	 */
+	private ?string $gh_repo_branch = null;
+
+	/**
+	 * The destination path on the site to deploy to, if any.
+	 *
+	 * @var string|null
+	 */
+	private ?string $destination_path = null;
+
+	/**
+	 * The repository subdirectory to deploy from, if any.
+	 *
+	 * @var string|null
+	 */
+	private ?string $repository_subdirectory = null;
+
+	/**
+	 * If a deployment should be triggered after the connection is complete. The connect call already
+	 * triggers an initial deploy, so this is only useful to queue an additional deploy.
+	 *
+	 * @var bool|null
+	 */
+	private ?bool $deploy = null;
+
+	// endregion
+
+	// region INHERITED METHODS
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function configure(): void {
+		$this->setDescription( 'Connects a Pressable site to a GitHub repository for deployments via the Pressable Git API.' )
+			->setHelp( 'Use this command to connect a Pressable site to a GitHub repository for deployments. OpsOasis stores the GitHub access token on the site and the connection triggers an initial deploy.' );
+
+		$this->addArgument( 'site', InputArgument::REQUIRED, 'Domain or numeric Pressable ID of the site to connect the repository to.' )
+			->addArgument( 'repository', InputArgument::REQUIRED, 'The slug of the GitHub repository to connect.' );
+
+		$this->addOption( 'branch', null, InputOption::VALUE_REQUIRED, 'The branch to deploy from. Defaults to `trunk`.' )
+			->addOption( 'destination-path', null, InputOption::VALUE_REQUIRED, 'The destination path on the site to deploy to. Defaults to `wp-content/`.', 'wp-content/' )
+			->addOption( 'repository-subdirectory', null, InputOption::VALUE_REQUIRED, 'The repository subdirectory to deploy from. Defaults to the repository root.' )
+			->addOption( 'deploy', null, InputOption::VALUE_NONE, 'Queue an additional deploy after the connection is complete (the connection already triggers an initial deploy).' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function initialize( InputInterface $input, OutputInterface $output ): void {
+		$this->site = get_pressable_site_input( $input, fn() => $this->prompt_site_input( $input, $output ) );
+		$input->setArgument( 'site', $this->site );
+
+		$this->gh_repository = get_github_repository_input( $input, fn() => $this->prompt_repository_input( $input, $output ) );
+		$input->setArgument( 'repository', $this->gh_repository );
+
+		$this->gh_repo_branch = get_string_input( $input, 'branch', fn() => $this->prompt_branch_input( $input, $output ) );
+		$input->setOption( 'branch', $this->gh_repo_branch );
+
+		$this->destination_path        = maybe_get_string_input( $input, 'destination-path' );
+		$this->repository_subdirectory = maybe_get_string_input( $input, 'repository-subdirectory' );
+
+		$this->deploy = get_bool_input( $input, 'deploy' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function interact( InputInterface $input, OutputInterface $output ): void {
+		$question = new ConfirmationQuestion( "<question>Are you sure you want to connect the Pressable site {$this->site->displayName} (ID {$this->site->id}, URL {$this->site->url}) to the branch `$this->gh_repo_branch` of the GitHub repository `{$this->gh_repository->full_name}`? [y/N]</question> ", false );
+		if ( true !== $this->getHelper( 'question' )->ask( $input, $output, $question ) ) {
+			$output->writeln( '<comment>Command aborted by user.</comment>' );
+			exit( 2 );
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( InputInterface $input, OutputInterface $output ): int {
+		$output->writeln( "<fg=magenta;options=bold>Connecting the Pressable site {$this->site->displayName} (ID {$this->site->id}, URL {$this->site->url}) to the branch `$this->gh_repo_branch` of the GitHub repository `{$this->gh_repository->full_name}` and triggering an initial deploy.</>" );
+
+		$git_config = connect_pressable_site_repository_for_site( $this->site, $this->gh_repository, $this->gh_repo_branch, $this->destination_path, $this->repository_subdirectory );
+		if ( \is_null( $git_config ) ) {
+			$output->writeln( '<error>Failed to connect the site with the repository.</error>' );
+			return Command::FAILURE;
+		}
+
+		output_table(
+			$output,
+			array(
+				array(
+					(string) $this->site->id,
+					$this->gh_repository->full_name,
+					$git_config->branch ?? $this->gh_repo_branch,
+					! empty( $git_config->connected ) ? 'yes' : 'no',
+					! empty( $git_config->hasToken ) ? 'yes' : 'no', // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				),
+			),
+			array( 'Site ID', 'Repository', 'Branch', 'Connected', 'Has token' ),
+			'Pressable Git configuration'
+		);
+
+		$output->writeln( "<fg=green;options=bold>Site {$this->site->displayName} connected to repository `{$this->gh_repository->full_name}` successfully.</>" );
+
+		if ( $this->deploy ) {
+			$output->writeln( "<fg=magenta;options=bold>Queueing an additional deploy on {$this->site->displayName} (ID {$this->site->id}).</>" );
+
+			$deploy = trigger_pressable_site_git_deployment( $this->site->id );
+			if ( \is_null( $deploy ) ) {
+				$output->writeln( '<error>Failed to queue the deploy.</error>' );
+				return Command::FAILURE;
+			}
+
+			$output->writeln( "<fg=green;options=bold>Deploy queued on {$this->site->displayName} (ID {$this->site->id}).</>" );
+		}
+
+		return Command::SUCCESS;
+	}
+
+	// endregion
+
+	// region HELPERS
+
+	/**
+	 * Prompts the user for a site.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  string|null
+	 */
+	private function prompt_site_input( InputInterface $input, OutputInterface $output ): ?string {
+		$question = new Question( '<question>Enter the domain or Pressable site ID to connect the repository to:</question> ' );
+		if ( ! $input->getOption( 'no-autocomplete' ) ) {
+			$question->setAutocompleterValues( \array_column( get_pressable_sites( include_aliases: true ) ?? array(), 'url' ) );
+		}
+
+		return $this->getHelper( 'question' )->ask( $input, $output, $question );
+	}
+
+	/**
+	 * Prompts the user for a GitHub repository slug.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  string|null
+	 */
+	private function prompt_repository_input( InputInterface $input, OutputInterface $output ): ?string {
+		$question = new Question( '<question>Please enter the slug of the GitHub repository to connect the site to:</question> ' );
+		if ( ! $input->getOption( 'no-autocomplete' ) ) {
+			$question->setAutocompleterValues( \array_column( get_github_repositories() ?? array(), 'name' ) );
+		}
+
+		return $this->getHelper( 'question' )->ask( $input, $output, $question );
+	}
+
+	/**
+	 * Prompts the user for a branch name.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  string|null
+	 */
+	private function prompt_branch_input( InputInterface $input, OutputInterface $output ): ?string {
+		$question = new Question( '<question>Enter the branch to deploy from [trunk]:</question> ', 'trunk' );
+		if ( ! $input->getOption( 'no-autocomplete' ) ) {
+			$question->setAutocompleterValues( \array_column( get_github_repository_branches( $this->gh_repository->name ) ?? array(), 'name' ) );
+		}
+
+		return $this->getHelper( 'question' )->ask( $input, $output, $question );
+	}
+
+	// endregion
+}

--- a/includes/functions-pressable.php
+++ b/includes/functions-pressable.php
@@ -214,6 +214,138 @@ function update_pressable_site_deployhq_server( string $site_id_or_url, string $
 }
 
 /**
+ * Returns the Git deployment configuration for the specified Pressable site.
+ *
+ * @param   string $site_id_or_url The ID or URL of the Pressable site to retrieve the Git configuration for.
+ *
+ * @return  stdClass|null
+ */
+function get_pressable_site_git_config( string $site_id_or_url ): ?stdClass {
+	$site_id_or_url = pressable_maybe_resolve_site_alias( $site_id_or_url );
+	return API_Helper::make_pressable_request( "site-git/$site_id_or_url" );
+}
+
+/**
+ * Connects a GitHub repository to the specified Pressable site and triggers an initial deploy.
+ *
+ * The GitHub access token is stored server-side by OpsOasis, so none is passed from here.
+ *
+ * @param   string      $site_id_or_url          The ID or URL of the Pressable site to connect the repository to.
+ * @param   string      $repository              The HTTPS github.com clone URL (e.g. https://github.com/owner/repo.git).
+ * @param   string      $branch                  The branch to deploy from.
+ * @param   string|null $destination_path        Optional. The destination path on the site to deploy to.
+ * @param   string|null $repository_subdirectory Optional. The repository subdirectory to deploy from.
+ *
+ * @return  stdClass|null
+ */
+function connect_pressable_site_repository( string $site_id_or_url, string $repository, string $branch, ?string $destination_path = null, ?string $repository_subdirectory = null ): ?stdClass {
+	$site_id_or_url = pressable_maybe_resolve_site_alias( $site_id_or_url );
+	return API_Helper::make_pressable_request(
+		"site-git/$site_id_or_url",
+		'POST',
+		array(
+			'repository' => $repository,
+			'branch'     => $branch,
+		) + array_filter(
+			array(
+				'destination_path'        => $destination_path,
+				'repository_subdirectory' => $repository_subdirectory,
+			)
+		)
+	);
+}
+
+/**
+ * Updates the Git deployment configuration for the specified Pressable site.
+ *
+ * @param   string $site_id_or_url The ID or URL of the Pressable site to update the Git configuration for.
+ * @param   array  $params         The configuration properties to update (repository, branch, destination_path, repository_subdirectory).
+ *
+ * @return  stdClass|null
+ */
+function update_pressable_site_git_config( string $site_id_or_url, array $params ): ?stdClass {
+	$site_id_or_url = pressable_maybe_resolve_site_alias( $site_id_or_url );
+	return API_Helper::make_pressable_request( "site-git/$site_id_or_url", 'PUT', $params );
+}
+
+/**
+ * Disconnects the GitHub repository from the specified Pressable site.
+ *
+ * @param   string $site_id_or_url The ID or URL of the Pressable site to disconnect the repository from.
+ *
+ * @return  true|null
+ */
+function disconnect_pressable_site_repository( string $site_id_or_url ): ?true {
+	$site_id_or_url = pressable_maybe_resolve_site_alias( $site_id_or_url );
+	$result         = API_Helper::make_pressable_request( "site-git/$site_id_or_url", 'DELETE' );
+	return is_null( $result ) ? null : true;
+}
+
+/**
+ * Stores the OpsOasis GitHub access token on the specified Pressable site.
+ *
+ * The token itself is injected server-side by OpsOasis, so no token value is sent from here.
+ *
+ * @param   string $site_id_or_url The ID or URL of the Pressable site to store the token on.
+ *
+ * @return  true|null
+ */
+function store_pressable_site_git_token( string $site_id_or_url ): ?true {
+	$site_id_or_url = pressable_maybe_resolve_site_alias( $site_id_or_url );
+	$result         = API_Helper::make_pressable_request( "site-git/$site_id_or_url/token", 'POST' );
+	return is_null( $result ) ? null : true;
+}
+
+/**
+ * Revokes the stored GitHub access token from the specified Pressable site.
+ *
+ * @param   string $site_id_or_url The ID or URL of the Pressable site to revoke the token from.
+ *
+ * @return  true|null
+ */
+function revoke_pressable_site_git_token( string $site_id_or_url ): ?true {
+	$site_id_or_url = pressable_maybe_resolve_site_alias( $site_id_or_url );
+	$result         = API_Helper::make_pressable_request( "site-git/$site_id_or_url/token", 'DELETE' );
+	return is_null( $result ) ? null : true;
+}
+
+/**
+ * Returns the branches available on the repository connected to the specified Pressable site.
+ *
+ * @param   string $site_id_or_url The ID or URL of the Pressable site to retrieve the branches for.
+ *
+ * @return  stdClass[]|null
+ */
+function get_pressable_site_git_branches( string $site_id_or_url ): ?array {
+	$site_id_or_url = pressable_maybe_resolve_site_alias( $site_id_or_url );
+	return API_Helper::make_pressable_request( "site-git/$site_id_or_url/branches" )?->records;
+}
+
+/**
+ * Queues a deploy of the currently configured branch for the specified Pressable site.
+ *
+ * @param   string $site_id_or_url The ID or URL of the Pressable site to deploy.
+ *
+ * @return  stdClass|null
+ */
+function trigger_pressable_site_git_deployment( string $site_id_or_url ): ?stdClass {
+	$site_id_or_url = pressable_maybe_resolve_site_alias( $site_id_or_url );
+	return API_Helper::make_pressable_request( "site-git/$site_id_or_url/deploy", 'POST' );
+}
+
+/**
+ * Returns the deploy history for the specified Pressable site, newest first.
+ *
+ * @param   string $site_id_or_url The ID or URL of the Pressable site to retrieve the deploy history for.
+ *
+ * @return  stdClass[]|null
+ */
+function get_pressable_site_git_history( string $site_id_or_url ): ?array {
+	$site_id_or_url = pressable_maybe_resolve_site_alias( $site_id_or_url );
+	return API_Helper::make_pressable_request( "site-git/$site_id_or_url/history" )?->records;
+}
+
+/**
  * Creates a new collaborator on the specified Pressable site.
  *
  * @param   string $site_id_or_url     The ID or URL of the Pressable site to create the collaborator on.
@@ -707,6 +839,23 @@ function create_deployhq_project_server_for_pressable_site( stdClass $pressable_
 	);
 
 	return $deployhq_project_server;
+}
+
+/**
+ * Connects a GitHub repository to the specified Pressable site via the Pressable Git API and triggers an
+ * initial deploy. OpsOasis stores the GitHub access token server-side as part of the connect request.
+ *
+ * @param   stdClass    $pressable_site          The Pressable site to connect the repository to.
+ * @param   stdClass    $github_repository       The GitHub repository to connect. Must expose a `full_name` property.
+ * @param   string      $branch                  The GitHub branch to deploy from.
+ * @param   string|null $destination_path        Optional. The destination path on the site to deploy to. Defaults to `wp-content/`.
+ * @param   string|null $repository_subdirectory Optional. The repository subdirectory to deploy from. Defaults to the repository root.
+ *
+ * @return  stdClass|null
+ */
+function connect_pressable_site_repository_for_site( stdClass $pressable_site, stdClass $github_repository, string $branch = 'trunk', ?string $destination_path = 'wp-content/', ?string $repository_subdirectory = null ): ?stdClass {
+	$clone_url = "https://github.com/{$github_repository->full_name}.git";
+	return connect_pressable_site_repository( $pressable_site->id, $clone_url, $branch, $destination_path, $repository_subdirectory );
 }
 
 // endregion


### PR DESCRIPTION
Migrate repository deployment flow from DeployHQ to Pressable's native Git API for new/connected sites. Updates:

- README: Document Pressable GitHub deployments and new CLI usage.
- commands/Pressable_Site_Create.php: Use Pressable Git API to connect repos and trigger initial deploys instead of creating DeployHQ projects/servers.
- commands/Pressable_Site_Clone.php: Replace DeployHQ lookups with Pressable Git config handling; connect cloned sites to the repository/branch via the Pressable Git API.
- Added commands/Pressable_Site_Repository_Connect.php: New CLI command (pressable:connect-site-repository) to connect a Pressable site to a GitHub repo and optionally queue an extra deploy.
- includes/functions-pressable.php: Added helpers for site-git endpoints (get/connect/update/disconnect token, branches, deploy, history) and a convenience connector for stdClass site/repo objects.

This removes automatic DeployHQ project/server creation for new/connected Pressable sites and centralizes repo connections via the Pressable Git API; existing DeployHQ-backed sites remain unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to connect Pressable sites to GitHub repositories via the Pressable Git API
  * New command enables connecting existing sites to GitHub repositories with optional automatic deployment

* **Documentation**
  * Updated documentation with guidance on GitHub repository connections and deployment workflows for Pressable sites

<!-- end of auto-generated comment: release notes by coderabbit.ai -->