### PR TITLE
Rename wpcom:list-site-plugins to jetpack:list-site-plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,10 +101,10 @@ The MCP server currently exposes 67 tools across all services. The table below s
 
 | Service | Read Tools | Write Tools |
 |---------|-----------|-------------|
-| **WPCOM** | `wpcom_list_sites`, `wpcom_get_site`, `wpcom_list_site_plugins`, `wpcom_list_site_stickers`, `wpcom_list_sites_with_sticker`, `wpcom_get_site_stats`, `wpcom_list_site_users`, `wpcom_list_deployment_webhooks` | `wpcom_add_sticker`, `wpcom_remove_sticker`, `wpcom_update_site`, `wpcom_rotate_sftp_password`, `wpcom_create_deployment_webhook`, `wpcom_delete_deployment_webhook`, `wpcom_sync_deployment_webhook_secret`, `wpcom_download_site_plugins` |
+| **WPCOM** | `wpcom_list_sites`, `wpcom_get_site`, `wpcom_list_site_stickers`, `wpcom_list_sites_with_sticker`, `wpcom_get_site_stats`, `wpcom_list_site_users`, `wpcom_list_deployment_webhooks` | `wpcom_add_sticker`, `wpcom_remove_sticker`, `wpcom_update_site`, `wpcom_rotate_sftp_password`, `wpcom_create_deployment_webhook`, `wpcom_delete_deployment_webhook`, `wpcom_sync_deployment_webhook_secret`, `wpcom_download_site_plugins` |
 | **Pressable** | `pressable_list_sites`, `pressable_get_site`, `pressable_get_php_errors`, `pressable_list_collaborators`, `pressable_list_sftp_users`, `pressable_list_site_domains` | `pressable_create_site_note`, `pressable_add_collaborator`, `pressable_remove_collaborator`, `pressable_add_domain`, `pressable_rotate_sftp_password`, `pressable_download_site_plugins` |
 | **GitHub** | `github_list_repositories`, `github_get_repository`, `github_list_branches`, `github_list_secrets`, `github_list_workflow_runs` | `github_set_topics`, `github_create_branch`, `github_set_secret`, `github_create_issue` |
-| **Jetpack** | `jetpack_list_modules`, `jetpack_list_site_modules` | `jetpack_update_module_settings` |
+| **Jetpack** | `jetpack_list_modules`, `jetpack_list_site_modules`, `jetpack_list_site_plugins` | `jetpack_update_module_settings` |
 | **DeployHQ** | `deployhq_list_projects`, `deployhq_get_project`, `deployhq_list_project_servers` | `deployhq_rotate_private_key`, `deployhq_connect_repository` |
 
 Write tools are annotated with MCP `ToolAnnotations` (`destructiveHint`, `readOnlyHint`, etc.) so clients prompt for confirmation before executing destructive actions.

--- a/commands/Jetpack_Site_Plugins_List.php
+++ b/commands/Jetpack_Site_Plugins_List.php
@@ -13,8 +13,8 @@ use WPCOMSpecialProjects\CLI\Helper\AutocompleteTrait;
 /**
  * Outputs a list of plugins installed on a given WPCOM or Jetpack-connected site.
  */
-#[AsCommand( name: 'wpcom:list-site-plugins' )]
-final class WPCOM_Site_Plugins_List extends Command {
+#[AsCommand( name: 'jetpack:list-site-plugins' )]
+final class Jetpack_Site_Plugins_List extends Command {
 	use AutocompleteTrait;
 
 	// region FIELDS AND CONSTANTS
@@ -34,8 +34,8 @@ final class WPCOM_Site_Plugins_List extends Command {
 	 * {@inheritDoc}
 	 */
 	protected function configure(): void {
-		$this->setDescription( 'List the plugins installed on a WPCOM site.' )
-			->setHelp( 'Use this command to list the plugins installed on a WPCOM site.' );
+		$this->setDescription( 'List the plugins installed on a WPCOM or Jetpack-connected site.' )
+			->setHelp( 'Use this command to list the plugins installed on a WPCOM or Jetpack-connected site.' );
 
 		$this->addArgument( 'site', InputArgument::REQUIRED, 'Domain or WPCOM ID of the site to list the plugins for.' );
 	}

--- a/mcp/Team51McpTools.php
+++ b/mcp/Team51McpTools.php
@@ -474,8 +474,8 @@ final class Team51McpTools {
 	 *
 	 * @param string $site_id_or_domain The domain name or WPCOM site ID.
 	 */
-	#[McpTool( name: 'wpcom_list_site_plugins' )]
-	public function wpcom_list_site_plugins( string $site_id_or_domain ): array {
+	#[McpTool( name: 'jetpack_list_site_plugins' )]
+	public function jetpack_list_site_plugins( string $site_id_or_domain ): array {
 		$identity_error = self::ensure_identity();
 		if ( $identity_error ) {
 			return $identity_error;


### PR DESCRIPTION
## Summary

- Rename the `wpcom:list-site-plugins` CLI command to `jetpack:list-site-plugins`. The `wpcom` prefix was misleading — the command hits the Jetpack plugins endpoint and works for both WPCOM- and Jetpack-connected sites.
- Rename the command class/file `WPCOM_Site_Plugins_List` → `Jetpack_Site_Plugins_List` and update its description/help text to mention both services.
- Rename the matching MCP tool `wpcom_list_site_plugins` → `jetpack_list_site_plugins` and move it to the **Jetpack** row of the README tools table.
- Refs [T51ENG-1819](https://linear.app/a8c/issue/T51ENG-1819/rename-wpcomlist-site-plugins-command-and-update-docs).

## Notes

- **Breaking change:** no backward-compatible alias was added. Scripts/aliases using `wpcom:list-site-plugins`, and MCP clients referencing `wpcom_list_site_plugins`, must switch to the `jetpack:` / `jetpack_` names.
- The renamed MCP method still physically sits in the `// region WPCOM TOOLS` block (matching existing precedent — `jetpack_export_site_plugins` lives in the legacy region). Left in place to keep the diff minimal; can relocate to the Jetpack region on request.
- The GitHub Wiki command reference still needs its page renamed to match (out of repo scope).

## Test plan

- [ ] `team51 list` shows `jetpack:list-site-plugins` and no longer lists `wpcom:list-site-plugins`.
- [ ] `team51 jetpack:list-site-plugins <site>` prints the plugins table for both a WPCOM- and a Jetpack-connected site.
- [ ] `team51 --mcp` exposes `jetpack_list_site_plugins` and not `wpcom_list_site_plugins`.
- [ ] `composer run lint:php` passes for the changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Site plugin listing tool now available for Jetpack-connected sites in addition to WPCOM sites

* **Documentation**
  * Updated documentation to reflect expanded availability of the site plugins listing tool

<!-- end of auto-generated comment: release notes by coderabbit.ai -->