### PR TITLE
Add jetpack:plugin-update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ claude mcp add team51 -- team51 --mcp
 
 ### Available Tools
 
-The MCP server currently exposes 67 tools across all services. The table below shows a subset of commonly used tools:
+The MCP server currently exposes 68 tools across all services. The table below shows a subset of commonly used tools:
 
 | Service | Read Tools | Write Tools |
 |---------|-----------|-------------|

--- a/commands/Jetpack_Plugin_Update.php
+++ b/commands/Jetpack_Plugin_Update.php
@@ -4,6 +4,7 @@ namespace WPCOMSpecialProjects\CLI\Command;
 
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -25,6 +26,12 @@ final class Jetpack_Plugin_Update extends Command {
 	 * Number of sites per batch when force-installing (each install is a real download + overwrite).
 	 */
 	private const FORCE_BATCH_SIZE = 30;
+
+	/**
+	 * Default seconds to wait after raising a refresh directive for sites to re-check, before updating.
+	 * Comfortably longer than the Atlantis poll interval (~2 minutes) so most sites re-check in time.
+	 */
+	private const DEFAULT_REFRESH_WAIT = 180;
 
 	/**
 	 * The plugin slug to update (matched against folder name, main file name, and textdomain).
@@ -83,6 +90,20 @@ final class Jetpack_Plugin_Update extends Command {
 	private ?string $target_version = null;
 
 	/**
+	 * Whether to raise a fleet-wide update-check refresh before updating (detection path only).
+	 *
+	 * @var bool|null
+	 */
+	private ?bool $refresh = null;
+
+	/**
+	 * Seconds to wait for the refresh to propagate across the fleet before updating.
+	 *
+	 * @var int|null
+	 */
+	private ?int $refresh_wait = null;
+
+	/**
 	 * The list of connected sites.
 	 *
 	 * @var array|null
@@ -106,7 +127,7 @@ final class Jetpack_Plugin_Update extends Command {
 	 */
 	protected function configure(): void {
 		$this->setDescription( 'Force-updates a given plugin on connected sites where it is installed.' )
-			->setHelp( 'Use this command to push a new plugin release to sites that have the plugin installed. Pass --sites to choose the targets: `all` for the whole connected fleet, a comma-separated list of site URLs and/or WPCOM IDs, or the path to a CSV whose first column holds the site URLs. By default each site is updated via the WPCOM plugin update endpoint, which relies on the site having already detected a newer version from the plugin\'s own update source (wp.org, or a custom Update URI such as GitHub) — so a freshly published release may not reach every site immediately. Pass --force with --package <zip-url> to instead overwrite the plugin in place from a specific zip on every targeted site, bypassing update detection entirely (the deterministic way to push a just-published release fleet-wide). Only sites with an active Jetpack connection to WPCOM are processed.' );
+			->setHelp( 'Use this command to push a new plugin release to sites that have the plugin installed. Pass --sites to choose the targets: `all` for the whole connected fleet, a comma-separated list of site URLs and/or WPCOM IDs, or the path to a CSV whose first column holds the site URLs. By default each site is updated via the WPCOM plugin update endpoint, which relies on the site having already detected a newer version from the plugin\'s own update source (wp.org, or a custom Update URI such as GitHub) — so a freshly published release may not reach every site immediately. Pass --force with --package <zip-url> to instead overwrite the plugin in place from a specific zip on every targeted site, bypassing update detection entirely (the deterministic way to push a just-published release fleet-wide). If a release has been published to wp.org but sites have not detected it yet, pass --refresh to make the whole fleet re-check for updates first (via the Atlantis lever), then update — no force-install needed. Only sites with an active Jetpack connection to WPCOM are processed.' );
 
 		$this->addArgument( 'plugin', InputArgument::REQUIRED, 'The plugin to update. The term is matched exactly against the folder name, the main file name, and the textdomain.' );
 
@@ -115,6 +136,8 @@ final class Jetpack_Plugin_Update extends Command {
 			->addOption( 'force', null, InputOption::VALUE_NONE, 'Force-install the plugin from --package, overwriting it in place. Installs only on sites whose version is below the package version; sites already at that version are skipped and sites ahead of it are never touched (no downgrades). Bypasses update detection entirely — use this when a just-published release has not propagated to sites yet.' )
 			->addOption( 'package', null, InputOption::VALUE_REQUIRED, 'The plugin zip URL to install. Required with --force (e.g. a GitHub release asset URL).' )
 			->addOption( 'reinstall', null, InputOption::VALUE_NONE, 'With --force, also overwrite sites already at the package version (a same-version reinstall). Sites ahead of the package version are still never touched.' )
+			->addOption( 'refresh', null, InputOption::VALUE_NONE, 'Before updating, ask every targeted site to re-check for updates (via the Atlantis lever) so a just-published wp.org release is detected even if the site\'s 12h update cache has not refreshed yet. Applies to the default update path; has no effect with --force, which bypasses update detection.' )
+			->addOption( 'refresh-wait', null, InputOption::VALUE_REQUIRED, 'Seconds to wait for the refresh to propagate before updating (default ' . self::DEFAULT_REFRESH_WAIT . '). Pass 0 to raise the refresh and update immediately, then re-run shortly to catch stragglers.' )
 			->addOption( 'dry-run', null, InputOption::VALUE_NONE, 'List the sites that would be updated without updating them.' )
 			->addOption( 'yes', null, InputOption::VALUE_NONE, 'Skip the confirmation prompt before updating.' );
 	}
@@ -137,6 +160,13 @@ final class Jetpack_Plugin_Update extends Command {
 		if ( $this->force && empty( $this->package ) ) {
 			throw new \InvalidArgumentException( 'The --force option requires --package <zip-url> (e.g. a GitHub release asset URL).' );
 		}
+
+		$this->refresh = get_bool_input( $input, 'refresh' );
+		if ( $this->refresh && $this->force ) {
+			throw new \InvalidArgumentException( 'The --refresh option applies to the detection-based update path and has no effect with --force (which bypasses update detection). Use one or the other.' );
+		}
+		$refresh_wait       = maybe_get_string_input( $input, 'refresh-wait' );
+		$this->refresh_wait = null === $refresh_wait ? self::DEFAULT_REFRESH_WAIT : \max( 0, (int) $refresh_wait );
 
 		$sites_spec = get_string_input( $input, 'sites', fn() => $this->prompt_sites_input( $input, $output ) );
 
@@ -240,12 +270,16 @@ final class Jetpack_Plugin_Update extends Command {
 		if ( ! $this->yes ) {
 			$action   = $this->force
 				? 'Force-install `' . $this->plugin . '` from ' . $this->package . ' on '
-				: 'Update `' . $this->plugin . '` on ';
+				: ( $this->refresh ? 'Refresh update-checks, then update `' : 'Update `' ) . $this->plugin . '` on ';
 			$question = new ConfirmationQuestion( '<question>' . $action . \count( $install_ids ) . ' site(s)? [y/N]</question> ', false );
 			if ( true !== $this->getHelper( 'question' )->ask( $input, $output, $question ) ) {
 				$output->writeln( '<comment>Aborted. No sites were changed.</comment>' );
 				return Command::SUCCESS;
 			}
+		}
+
+		if ( $this->refresh ) {
+			$this->run_refresh( $output );
 		}
 
 		if ( $this->force ) {
@@ -347,6 +381,57 @@ final class Jetpack_Plugin_Update extends Command {
 		}
 
 		return array( $results, $errors );
+	}
+
+	/**
+	 * Raises a fleet-wide update-check refresh and waits for it to propagate.
+	 *
+	 * Asks every site (via the Atlantis lever) to clear its plugin-update cache and re-check, so a
+	 * just-published release is detected before we call the version-gated update endpoint. Best-effort:
+	 * if the directive cannot be raised, the update still proceeds for sites that already detected it.
+	 *
+	 * @param   OutputInterface $output The output interface.
+	 *
+	 * @return  void
+	 */
+	private function run_refresh( OutputInterface $output ): void {
+		$output->writeln( '<fg=magenta;options=bold>Requesting a fleet-wide plugin update-check…</>' );
+
+		$directive = refresh_wpcom_site_plugin_updates();
+		if ( ! $directive instanceof \stdClass || ! isset( $directive->epoch ) ) {
+			$output->writeln( '<comment>⚠ Could not raise the refresh directive; proceeding anyway (sites that already detected the release will still update).</comment>' );
+			return;
+		}
+
+		$output->writeln( "<comment>Refresh raised (epoch $directive->epoch). Sites re-check within ~2 minutes.</comment>" );
+
+		if ( 0 >= (int) $this->refresh_wait ) {
+			$output->writeln( '<comment>Skipping the propagation wait (--refresh-wait=0); re-run the command shortly to catch any sites that had not re-checked yet.</comment>' );
+			return;
+		}
+
+		$this->wait_for_propagation( $output, (int) $this->refresh_wait );
+	}
+
+	/**
+	 * Blocks for the given number of seconds with a progress bar, giving sites time to re-check.
+	 *
+	 * @param   OutputInterface $output  The output interface.
+	 * @param   int             $seconds The number of seconds to wait.
+	 *
+	 * @return  void
+	 */
+	private function wait_for_propagation( OutputInterface $output, int $seconds ): void {
+		$output->writeln( "<comment>Waiting {$seconds}s for sites to re-check before updating…</comment>" );
+
+		$progress = new ProgressBar( $output, $seconds );
+		$progress->start();
+		for ( $second = 0; $second < $seconds; $second++ ) {
+			\sleep( 1 );
+			$progress->advance();
+		}
+		$progress->finish();
+		$output->writeln( '' );
 	}
 
 	/**

--- a/commands/Jetpack_Plugin_Update.php
+++ b/commands/Jetpack_Plugin_Update.php
@@ -90,7 +90,7 @@ final class Jetpack_Plugin_Update extends Command {
 	private ?string $target_version = null;
 
 	/**
-	 * Whether to raise a fleet-wide update-check refresh before updating (detection path only).
+	 * Whether to make the targeted sites re-check for updates before updating (detection path only).
 	 *
 	 * @var bool|null
 	 */
@@ -129,7 +129,7 @@ final class Jetpack_Plugin_Update extends Command {
 	 */
 	protected function configure(): void {
 		$this->setDescription( 'Force-updates a given plugin on connected sites where it is installed.' )
-			->setHelp( 'Use this command to push a new plugin release to sites that have the plugin installed. Pass --sites to choose the targets: `all` for the whole connected fleet, a comma-separated list of site URLs and/or WPCOM IDs, or the path to a CSV whose first column holds the site URLs. By default each site is updated via the WPCOM plugin update endpoint, which relies on the site having already detected a newer version from the plugin\'s own update source (wp.org, or a custom Update URI such as GitHub) — so a freshly published release may not reach every site immediately. Pass --force with --package <zip-url> to instead overwrite the plugin in place from a specific zip on every targeted site, bypassing update detection entirely (the deterministic way to push a just-published release fleet-wide). If a release has been published to wp.org but sites have not detected it yet, pass --refresh to make the whole fleet re-check for updates first (via the Atlantis lever), then update — no force-install needed. Only sites with an active Jetpack connection to WPCOM are processed.' );
+			->setHelp( 'Use this command to push a new plugin release to sites that have the plugin installed. Pass --sites to choose the targets: `all` for the whole connected fleet, a comma-separated list of site URLs and/or WPCOM IDs, or the path to a CSV whose first column holds the site URLs. By default each site is updated via the WPCOM plugin update endpoint, which relies on the site having already detected a newer version from the plugin\'s own update source (wp.org, or a custom Update URI such as GitHub) — so a freshly published release may not reach every site immediately. Pass --force with --package <zip-url> to instead overwrite the plugin in place from a specific zip on every targeted site, bypassing update detection entirely (the deterministic way to push a just-published release fleet-wide). If a release has been published to wp.org but sites have not detected it yet, pass --refresh to make the targeted sites (those chosen with --sites) re-check for updates first (via the Atlantis lever), then update — no force-install needed. Only sites with an active Jetpack connection to WPCOM are processed.' );
 
 		$this->addArgument( 'plugin', InputArgument::REQUIRED, 'The plugin to update. The term is matched exactly against the folder name, the main file name, and the textdomain.' );
 
@@ -454,9 +454,10 @@ final class Jetpack_Plugin_Update extends Command {
 		$total    = \count( $chunks );
 		$output->writeln( '<fg=magenta;options=bold>Refreshing the update-check on ' . \count( $site_ids ) . ' site(s)…</>' );
 
-		$results   = array();
-		$errors    = array();
-		$any_batch = false;
+		$results     = array();
+		$errors      = array();
+		$unrefreshed = array();
+		$any_batch   = false;
 		foreach ( $chunks as $index => $chunk ) {
 			if ( $total > 1 ) {
 				$output->writeln( '<comment>Batch ' . ( $index + 1 ) . "/$total: refreshing " . \count( $chunk ) . ' site(s)…</comment>' );
@@ -464,6 +465,8 @@ final class Jetpack_Plugin_Update extends Command {
 			$chunk_results = force_check_wpcom_site_plugins_batch( $chunk, $chunk_errors );
 			if ( \is_null( $chunk_results ) ) {
 				$output->writeln( '<comment>⚠ The refresh request failed for this batch.</comment>' );
+				// Record the whole chunk so its sites are not silently dropped from the coverage summary.
+				$unrefreshed += \array_fill_keys( $chunk, 'The batch refresh request failed (e.g. timeout).' );
 				continue;
 			}
 			$any_batch = true;
@@ -473,11 +476,23 @@ final class Jetpack_Plugin_Update extends Command {
 
 		if ( ! $any_batch ) {
 			$output->writeln( '<comment>⚠ No refresh batch succeeded; proceeding anyway (sites that already detected the release will still update).</comment>' );
-			return;
 		}
 
-		$failed = \count( $errors );
-		$output->writeln( '<comment>Refreshed ' . \count( $results ) . ' site(s)' . ( $failed > 0 ? "; $failed could not be reached (no Atlantis or connection down) and may not detect the release" : '' ) . '.</comment>' );
+		// State coverage explicitly: a failed batch must not read as full coverage and leave its sites
+		// reported "current" at exit 0.
+		$notes = array();
+		if ( \count( $errors ) > 0 ) {
+			$notes[] = \count( $errors ) . ' could not be reached (no Atlantis or connection down)';
+		}
+		if ( \count( $unrefreshed ) > 0 ) {
+			$notes[] = \count( $unrefreshed ) . ' were in a failed batch and not re-checked';
+		}
+		$suffix = empty( $notes ) ? '' : '; ' . \implode( '; ', $notes ) . ' and may not detect the release';
+		$output->writeln( '<comment>Refreshed ' . \count( $results ) . ' of ' . \count( $site_ids ) . ' site(s)' . $suffix . '.</comment>' );
+
+		// Name the sites that were skipped, so they can be re-run or investigated rather than assumed done.
+		maybe_output_wpcom_failed_sites_table( $output, $errors, $this->sites, 'Sites that could NOT be reached to refresh' );
+		maybe_output_wpcom_failed_sites_table( $output, $unrefreshed, $this->sites, 'Sites in a failed refresh batch (not re-checked)' );
 	}
 
 	/**

--- a/commands/Jetpack_Plugin_Update.php
+++ b/commands/Jetpack_Plugin_Update.php
@@ -22,6 +22,11 @@ final class Jetpack_Plugin_Update extends Command {
 	// region FIELDS AND CONSTANTS
 
 	/**
+	 * Number of sites per batch when force-installing (each install is a real download + overwrite).
+	 */
+	private const FORCE_BATCH_SIZE = 30;
+
+	/**
 	 * The plugin slug to update (matched against folder name, main file name, and textdomain).
 	 *
 	 * @var string|null
@@ -50,6 +55,20 @@ final class Jetpack_Plugin_Update extends Command {
 	private ?bool $yes = null;
 
 	/**
+	 * Whether to force-install the package on every targeted site, bypassing update detection.
+	 *
+	 * @var bool|null
+	 */
+	private ?bool $force = null;
+
+	/**
+	 * The plugin zip URL to force-install (required with --force).
+	 *
+	 * @var string|null
+	 */
+	private ?string $package = null;
+
+	/**
 	 * The list of connected sites.
 	 *
 	 * @var array|null
@@ -58,7 +77,7 @@ final class Jetpack_Plugin_Update extends Command {
 
 	/**
 	 * The sites that have the plugin installed and will be updated, keyed by site ID.
-	 * Each entry: array{ name: string, installed: string, siteurl: string }.
+	 * Each entry: array{ name: string, folder: string, installed: string, siteurl: string }.
 	 *
 	 * @var array|null
 	 */
@@ -73,12 +92,14 @@ final class Jetpack_Plugin_Update extends Command {
 	 */
 	protected function configure(): void {
 		$this->setDescription( 'Force-updates a given plugin on connected sites where it is installed.' )
-			->setHelp( 'Use this command to push a new plugin release to sites that have the plugin installed. Pass --sites to choose the targets: `all` for the whole connected fleet, a comma-separated list of site URLs and/or WPCOM IDs, or the path to a CSV whose first column holds the site URLs. Each site is updated via the WPCOM plugin update endpoint, which refreshes its update cache and installs from the plugin\'s own update source (wp.org, or a custom Update URI such as GitHub). Only sites with an active Jetpack connection to WPCOM are processed. The update only fires where a newer version is available, so publish the new release before running this.' );
+			->setHelp( 'Use this command to push a new plugin release to sites that have the plugin installed. Pass --sites to choose the targets: `all` for the whole connected fleet, a comma-separated list of site URLs and/or WPCOM IDs, or the path to a CSV whose first column holds the site URLs. By default each site is updated via the WPCOM plugin update endpoint, which relies on the site having already detected a newer version from the plugin\'s own update source (wp.org, or a custom Update URI such as GitHub) — so a freshly published release may not reach every site immediately. Pass --force with --package <zip-url> to instead overwrite the plugin in place from a specific zip on every targeted site, bypassing update detection entirely (the deterministic way to push a just-published release fleet-wide). Only sites with an active Jetpack connection to WPCOM are processed.' );
 
 		$this->addArgument( 'plugin', InputArgument::REQUIRED, 'The plugin to update. The term is matched exactly against the folder name, the main file name, and the textdomain.' );
 
 		$this->addOption( 'sites', null, InputOption::VALUE_REQUIRED, 'Which sites to update: `all` for the whole connected fleet, a comma-separated list of site URLs and/or numeric WPCOM IDs, or a path to a CSV file whose first column holds the site URLs.' )
 			->addOption( 'release', null, InputOption::VALUE_REQUIRED, 'The plugin version you are publishing. When set, each site is reported as updated / current / ahead / behind relative to it, so sites running a newer (e.g. test) build, or ones the release has not reached, are surfaced.' )
+			->addOption( 'force', null, InputOption::VALUE_NONE, 'Force-install the plugin from --package on every targeted site, overwriting it in place. Bypasses update detection entirely, installing the exact version regardless of what each site currently has or believes is the latest. Use this when a just-published release has not propagated to sites yet.' )
+			->addOption( 'package', null, InputOption::VALUE_REQUIRED, 'The plugin zip URL to install. Required with --force (e.g. a GitHub release asset URL).' )
 			->addOption( 'dry-run', null, InputOption::VALUE_NONE, 'List the sites that would be updated without updating them.' )
 			->addOption( 'yes', null, InputOption::VALUE_NONE, 'Skip the confirmation prompt before updating.' );
 	}
@@ -95,6 +116,11 @@ final class Jetpack_Plugin_Update extends Command {
 		$this->release = maybe_get_string_input( $input, 'release' );
 		$this->dry_run = get_bool_input( $input, 'dry-run' );
 		$this->yes     = get_bool_input( $input, 'yes' );
+		$this->force   = get_bool_input( $input, 'force' );
+		$this->package = maybe_get_string_input( $input, 'package' );
+		if ( $this->force && empty( $this->package ) ) {
+			throw new \InvalidArgumentException( 'The --force option requires --package <zip-url> (e.g. a GitHub release asset URL).' );
+		}
 
 		$sites_spec = get_string_input( $input, 'sites', fn() => $this->prompt_sites_input( $input, $output ) );
 
@@ -133,6 +159,7 @@ final class Jetpack_Plugin_Update extends Command {
 
 				$this->targets[ $site_id ] = array(
 					'name'      => \preg_replace( '/\.php$/', '', $plugin_file ),
+					'folder'    => \dirname( $plugin_file ),
 					// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 					'installed' => (string) $plugin_data->Version,
 					'siteurl'   => (string) ( $this->sites[ $site_id ]->siteurl ?? '' ),
@@ -169,31 +196,22 @@ final class Jetpack_Plugin_Update extends Command {
 		}
 
 		if ( ! $this->yes ) {
-			$question = new ConfirmationQuestion( '<question>Update `' . $this->plugin . '` on ' . \count( $this->targets ) . ' site(s)? [y/N]</question> ', false );
+			$action   = $this->force
+				? 'Force-install `' . $this->plugin . '` from ' . $this->package . ' on '
+				: 'Update `' . $this->plugin . '` on ';
+			$question = new ConfirmationQuestion( '<question>' . $action . \count( $this->targets ) . ' site(s)? [y/N]</question> ', false );
 			if ( true !== $this->getHelper( 'question' )->ask( $input, $output, $question ) ) {
-				$output->writeln( '<comment>Aborted. No sites were updated.</comment>' );
+				$output->writeln( '<comment>Aborted. No sites were changed.</comment>' );
 				return Command::SUCCESS;
 			}
 		}
 
-		$output->writeln( "<fg=magenta;options=bold>Updating `$this->plugin` across " . \count( $this->targets ) . ' site(s).</>' );
-
-		// Group by plugin identifier (near-always a single group) and update each group in one batch call.
-		$groups = array();
-		foreach ( $this->targets as $site_id => $target ) {
-			$groups[ $target['name'] ][] = $site_id;
-		}
-
-		$results = array();
-		$errors  = array();
-		foreach ( $groups as $plugin_name => $site_ids ) {
-			$group_results = update_wpcom_site_plugins_batch( $site_ids, $plugin_name, $group_errors );
-			if ( \is_null( $group_results ) ) {
-				$output->writeln( "<error>The update request failed for plugin `$plugin_name`.</error>" );
-				continue;
-			}
-			$results += $group_results;
-			$errors  += $group_errors ?? array();
+		if ( $this->force ) {
+			$output->writeln( "<fg=magenta;options=bold>Force-installing `$this->plugin` from $this->package across " . \count( $this->targets ) . ' site(s).</>' );
+			[ $results, $errors ] = $this->run_force_install( $output );
+		} else {
+			$output->writeln( "<fg=magenta;options=bold>Updating `$this->plugin` across " . \count( $this->targets ) . ' site(s).</>' );
+			[ $results, $errors ] = $this->run_update( $output );
 		}
 
 		// Build the results table.
@@ -225,7 +243,7 @@ final class Jetpack_Plugin_Update extends Command {
 			$output,
 			$rows,
 			array( 'Site ID', 'Site URL', 'Was', 'Now', 'Result' ),
-			"Update results for `$this->plugin`"
+			( $this->force ? 'Force-install' : 'Update' ) . " results for `$this->plugin`"
 		);
 
 		$summary = "Updated: {$counts['updated']} | Current: {$counts['current']}";
@@ -253,6 +271,69 @@ final class Jetpack_Plugin_Update extends Command {
 	// endregion
 
 	// region HELPERS
+
+	/**
+	 * Updates the plugin on every target site via the WPCOM update endpoint (version-gated).
+	 *
+	 * @param   OutputInterface $output The output interface.
+	 *
+	 * @return  array A two-element list: per-site results and per-site errors, both keyed by site ID.
+	 */
+	private function run_update( OutputInterface $output ): array {
+		// Group by plugin identifier (near-always a single group) and update each group in one batch call.
+		$groups = array();
+		foreach ( $this->targets as $site_id => $target ) {
+			$groups[ $target['name'] ][] = $site_id;
+		}
+
+		$results = array();
+		$errors  = array();
+		foreach ( $groups as $plugin_name => $site_ids ) {
+			$group_results = update_wpcom_site_plugins_batch( $site_ids, $plugin_name, $group_errors );
+			if ( \is_null( $group_results ) ) {
+				$output->writeln( "<error>The update request failed for plugin `$plugin_name`.</error>" );
+				continue;
+			}
+			$results += $group_results;
+			$errors  += $group_errors ?? array();
+		}
+
+		return array( $results, $errors );
+	}
+
+	/**
+	 * Force-installs the package on every target site via the WPCOM replace endpoint, in batches.
+	 *
+	 * @param   OutputInterface $output The output interface.
+	 *
+	 * @return  array A two-element list: per-site results and per-site errors, both keyed by site ID.
+	 */
+	private function run_force_install( OutputInterface $output ): array {
+		// Group by plugin folder (the replace slug); near-always a single group.
+		$groups = array();
+		foreach ( $this->targets as $site_id => $target ) {
+			$groups[ $target['folder'] ][] = $site_id;
+		}
+
+		$results = array();
+		$errors  = array();
+		foreach ( $groups as $slug => $site_ids ) {
+			$chunks = \array_chunk( $site_ids, self::FORCE_BATCH_SIZE );
+			$total  = \count( $chunks );
+			foreach ( $chunks as $index => $chunk ) {
+				$output->writeln( '<comment>Batch ' . ( $index + 1 ) . "/$total: force-installing on " . \count( $chunk ) . ' site(s)…</comment>' );
+				$chunk_results = replace_wpcom_site_plugins_batch( $chunk, $slug, $this->package, $chunk_errors );
+				if ( \is_null( $chunk_results ) ) {
+					$output->writeln( '<error>The force-install request failed for this batch.</error>' );
+					continue;
+				}
+				$results += $chunk_results;
+				$errors  += $chunk_errors ?? array();
+			}
+		}
+
+		return array( $results, $errors );
+	}
 
 	/**
 	 * Prompts the user for the plugin term to update.

--- a/commands/Jetpack_Plugin_Update.php
+++ b/commands/Jetpack_Plugin_Update.php
@@ -69,6 +69,20 @@ final class Jetpack_Plugin_Update extends Command {
 	private ?string $package = null;
 
 	/**
+	 * With --force, whether to also overwrite sites already at the package version (same-version reinstall).
+	 *
+	 * @var bool|null
+	 */
+	private ?bool $reinstall = null;
+
+	/**
+	 * The plugin version contained in the package (read from the zip, or --release as a fallback).
+	 *
+	 * @var string|null
+	 */
+	private ?string $target_version = null;
+
+	/**
 	 * The list of connected sites.
 	 *
 	 * @var array|null
@@ -98,8 +112,9 @@ final class Jetpack_Plugin_Update extends Command {
 
 		$this->addOption( 'sites', null, InputOption::VALUE_REQUIRED, 'Which sites to update: `all` for the whole connected fleet, a comma-separated list of site URLs and/or numeric WPCOM IDs, or a path to a CSV file whose first column holds the site URLs.' )
 			->addOption( 'release', null, InputOption::VALUE_REQUIRED, 'The plugin version you are publishing. When set, each site is reported as updated / current / ahead / behind relative to it, so sites running a newer (e.g. test) build, or ones the release has not reached, are surfaced.' )
-			->addOption( 'force', null, InputOption::VALUE_NONE, 'Force-install the plugin from --package on every targeted site, overwriting it in place. Bypasses update detection entirely, installing the exact version regardless of what each site currently has or believes is the latest. Use this when a just-published release has not propagated to sites yet.' )
+			->addOption( 'force', null, InputOption::VALUE_NONE, 'Force-install the plugin from --package, overwriting it in place. Installs only on sites whose version is below the package version; sites already at that version are skipped and sites ahead of it are never touched (no downgrades). Bypasses update detection entirely — use this when a just-published release has not propagated to sites yet.' )
 			->addOption( 'package', null, InputOption::VALUE_REQUIRED, 'The plugin zip URL to install. Required with --force (e.g. a GitHub release asset URL).' )
+			->addOption( 'reinstall', null, InputOption::VALUE_NONE, 'With --force, also overwrite sites already at the package version (a same-version reinstall). Sites ahead of the package version are still never touched.' )
 			->addOption( 'dry-run', null, InputOption::VALUE_NONE, 'List the sites that would be updated without updating them.' )
 			->addOption( 'yes', null, InputOption::VALUE_NONE, 'Skip the confirmation prompt before updating.' );
 	}
@@ -113,11 +128,12 @@ final class Jetpack_Plugin_Update extends Command {
 		$this->plugin = get_string_input( $input, 'plugin', fn() => $this->prompt_plugin_input( $input, $output ) );
 		$input->setArgument( 'plugin', $this->plugin );
 
-		$this->release = maybe_get_string_input( $input, 'release' );
-		$this->dry_run = get_bool_input( $input, 'dry-run' );
-		$this->yes     = get_bool_input( $input, 'yes' );
-		$this->force   = get_bool_input( $input, 'force' );
-		$this->package = maybe_get_string_input( $input, 'package' );
+		$this->release   = maybe_get_string_input( $input, 'release' );
+		$this->dry_run   = get_bool_input( $input, 'dry-run' );
+		$this->yes       = get_bool_input( $input, 'yes' );
+		$this->force     = get_bool_input( $input, 'force' );
+		$this->reinstall = get_bool_input( $input, 'reinstall' );
+		$this->package   = maybe_get_string_input( $input, 'package' );
 		if ( $this->force && empty( $this->package ) ) {
 			throw new \InvalidArgumentException( 'The --force option requires --package <zip-url> (e.g. a GitHub release asset URL).' );
 		}
@@ -167,6 +183,10 @@ final class Jetpack_Plugin_Update extends Command {
 				break; // One match per site is enough.
 			}
 		}
+
+		if ( $this->force && ! empty( $this->targets ) ) {
+			$this->plan_force_install();
+		}
 	}
 
 	/**
@@ -178,20 +198,42 @@ final class Jetpack_Plugin_Update extends Command {
 			return Command::SUCCESS;
 		}
 
-		// Show what will be updated.
+		// In force mode, targets carry a plan: only `install` sites are written; `current`/`ahead` are skipped.
+		$install_ids = array();
+		foreach ( $this->targets as $site_id => $target ) {
+			if ( 'install' === ( $target['plan'] ?? 'install' ) ) {
+				$install_ids[] = $site_id;
+			}
+		}
+
+		if ( $this->force ) {
+			$skipped_ahead   = \count( \array_filter( $this->targets, static fn( $target ) => 'ahead' === ( $target['plan'] ?? '' ) ) );
+			$skipped_current = \count( \array_filter( $this->targets, static fn( $target ) => 'current' === ( $target['plan'] ?? '' ) ) );
+			if ( $skipped_ahead > 0 ) {
+				$output->writeln( "<comment>Skipping $skipped_ahead site(s) ahead of $this->target_version — never downgraded.</comment>" );
+			}
+			if ( $skipped_current > 0 ) {
+				$output->writeln( "<comment>Skipping $skipped_current site(s) already at $this->target_version — pass --reinstall to overwrite them too.</comment>" );
+			}
+			if ( empty( $install_ids ) ) {
+				$output->writeln( "<info>Nothing to install: every targeted site is already at or ahead of $this->target_version.</info>" );
+				return Command::SUCCESS;
+			}
+		}
+
+		// Show what will be changed.
 		output_table(
 			$output,
 			\array_map(
-				static fn( $site_id, $target ) => array( $site_id, $target['siteurl'], $target['installed'] ),
-				\array_keys( $this->targets ),
-				$this->targets
+				fn( $site_id ) => array( $site_id, $this->targets[ $site_id ]['siteurl'], $this->targets[ $site_id ]['installed'] ),
+				$install_ids
 			),
 			array( 'Site ID', 'Site URL', 'Installed Version' ),
-			"Sites with `$this->plugin` installed"
+			'Sites to ' . ( $this->force ? 'force-install' : 'update' ) . " `$this->plugin`"
 		);
 
 		if ( $this->dry_run ) {
-			$output->writeln( '<comment>Dry run: no sites were updated.</comment>' );
+			$output->writeln( '<comment>Dry run: no sites were changed.</comment>' );
 			return Command::SUCCESS;
 		}
 
@@ -199,7 +241,7 @@ final class Jetpack_Plugin_Update extends Command {
 			$action   = $this->force
 				? 'Force-install `' . $this->plugin . '` from ' . $this->package . ' on '
 				: 'Update `' . $this->plugin . '` on ';
-			$question = new ConfirmationQuestion( '<question>' . $action . \count( $this->targets ) . ' site(s)? [y/N]</question> ', false );
+			$question = new ConfirmationQuestion( '<question>' . $action . \count( $install_ids ) . ' site(s)? [y/N]</question> ', false );
 			if ( true !== $this->getHelper( 'question' )->ask( $input, $output, $question ) ) {
 				$output->writeln( '<comment>Aborted. No sites were changed.</comment>' );
 				return Command::SUCCESS;
@@ -207,10 +249,10 @@ final class Jetpack_Plugin_Update extends Command {
 		}
 
 		if ( $this->force ) {
-			$output->writeln( "<fg=magenta;options=bold>Force-installing `$this->plugin` from $this->package across " . \count( $this->targets ) . ' site(s).</>' );
-			[ $results, $errors ] = $this->run_force_install( $output );
+			$output->writeln( "<fg=magenta;options=bold>Force-installing `$this->plugin` ($this->target_version) across " . \count( $install_ids ) . ' site(s).</>' );
+			[ $results, $errors ] = $this->run_force_install( $output, $install_ids );
 		} else {
-			$output->writeln( "<fg=magenta;options=bold>Updating `$this->plugin` across " . \count( $this->targets ) . ' site(s).</>' );
+			$output->writeln( "<fg=magenta;options=bold>Updating `$this->plugin` across " . \count( $install_ids ) . ' site(s).</>' );
 			[ $results, $errors ] = $this->run_update( $output );
 		}
 
@@ -224,15 +266,20 @@ final class Jetpack_Plugin_Update extends Command {
 			'failed'  => 0,
 		);
 		foreach ( $this->targets as $site_id => $target ) {
-			$was    = $target['installed'];
-			$now    = $was;
-			$result = 'failed';
+			$was  = $target['installed'];
+			$now  = $was;
+			$plan = $target['plan'] ?? 'install';
 
-			if ( isset( $errors[ $site_id ] ) ) {
-				$now = encode_json_content( $errors[ $site_id ]->errors ?? $errors[ $site_id ] );
+			if ( 'install' !== $plan ) {
+				$result = $plan; // Skipped in force mode: `current` or `ahead`, left unchanged.
+			} elseif ( isset( $errors[ $site_id ] ) ) {
+				$now    = encode_json_content( $errors[ $site_id ]->errors ?? $errors[ $site_id ] );
+				$result = 'failed';
 			} elseif ( isset( $results[ $site_id ] ) ) {
 				$now    = (string) ( $results[ $site_id ]->version ?? $was );
 				$result = $this->classify( $was, $now );
+			} else {
+				$result = 'failed';
 			}
 
 			++$counts[ $result ];
@@ -247,19 +294,20 @@ final class Jetpack_Plugin_Update extends Command {
 		);
 
 		$summary = "Updated: {$counts['updated']} | Current: {$counts['current']}";
-		if ( ! empty( $this->release ) ) {
+		if ( $this->force || ! empty( $this->release ) ) {
 			$summary .= " | Ahead: {$counts['ahead']} | Behind: {$counts['behind']}";
 		}
 		$summary .= " | Failed: {$counts['failed']}";
 		$output->writeln( "<info>$summary</info>" );
 
+		$reference = ! empty( $this->target_version ) ? $this->target_version : $this->release;
 		if ( $counts['ahead'] > 0 ) {
-			$output->writeln( "<fg=yellow;options=bold>⚠ {$counts['ahead']} site(s) are AHEAD of `$this->release` (running a newer/test build) and were left unchanged.</>" );
+			$output->writeln( "<fg=yellow;options=bold>⚠ {$counts['ahead']} site(s) are AHEAD of `$reference` (running a newer/test build) and were left unchanged.</>" );
 		}
 		if ( $counts['behind'] > 0 ) {
 			$output->writeln( "<fg=red;options=bold>✗ {$counts['behind']} site(s) are BEHIND `$this->release` — the release did not reach them (its update source may not have it yet).</>" );
 		}
-		if ( empty( $this->release ) && $counts['current'] > 0 ) {
+		if ( ! $this->force && empty( $this->release ) && $counts['current'] > 0 ) {
 			$output->writeln( '<comment>Tip: some sites reported no change — pass --release <version> to distinguish "already current" from "ahead of the release".</comment>' );
 		}
 
@@ -302,17 +350,18 @@ final class Jetpack_Plugin_Update extends Command {
 	}
 
 	/**
-	 * Force-installs the package on every target site via the WPCOM replace endpoint, in batches.
+	 * Force-installs the package on the given sites via the WPCOM replace endpoint, in batches.
 	 *
-	 * @param   OutputInterface $output The output interface.
+	 * @param   OutputInterface $output      The output interface.
+	 * @param   array           $install_ids The site IDs to install on (already filtered by plan).
 	 *
 	 * @return  array A two-element list: per-site results and per-site errors, both keyed by site ID.
 	 */
-	private function run_force_install( OutputInterface $output ): array {
+	private function run_force_install( OutputInterface $output, array $install_ids ): array {
 		// Group by plugin folder (the replace slug); near-always a single group.
 		$groups = array();
-		foreach ( $this->targets as $site_id => $target ) {
-			$groups[ $target['folder'] ][] = $site_id;
+		foreach ( $install_ids as $site_id ) {
+			$groups[ $this->targets[ $site_id ]['folder'] ][] = $site_id;
 		}
 
 		$results = array();
@@ -333,6 +382,85 @@ final class Jetpack_Plugin_Update extends Command {
 		}
 
 		return array( $results, $errors );
+	}
+
+	/**
+	 * Resolves the package version and tags each target with a force-install plan.
+	 *
+	 * The plan enforces the version rules for --force: sites below the package version are installed,
+	 * sites already at it are skipped (unless --reinstall), and sites ahead of it are never touched.
+	 *
+	 * @return  void
+	 *
+	 * @throws  \RuntimeException If the package version cannot be determined (no zip version, no --release).
+	 */
+	private function plan_force_install(): void {
+		$this->target_version = $this->resolve_package_version() ?? $this->release;
+		if ( empty( $this->target_version ) ) {
+			throw new \RuntimeException( 'Could not read the plugin version from the package. Pass --release <version> so already-current and ahead sites can be detected and skipped, or check the --package URL.' );
+		}
+
+		foreach ( $this->targets as $site_id => $target ) {
+			$comparison = \version_compare( $this->normalize_version( $target['installed'] ), $this->normalize_version( $this->target_version ) );
+			if ( $comparison > 0 ) {
+				$this->targets[ $site_id ]['plan'] = 'ahead';   // Never overwrite a newer build.
+			} elseif ( 0 === $comparison && ! $this->reinstall ) {
+				$this->targets[ $site_id ]['plan'] = 'current'; // Already at the target; skip unless --reinstall.
+			} else {
+				$this->targets[ $site_id ]['plan'] = 'install';
+			}
+		}
+	}
+
+	/**
+	 * Reads the plugin version from the package zip's header.
+	 *
+	 * @return  string|null The version, or null if the package could not be downloaded or parsed.
+	 */
+	private function resolve_package_version(): ?string {
+		$tmp = \tempnam( \sys_get_temp_dir(), 't51pkg' );
+		if ( false === $tmp ) {
+			return null;
+		}
+
+		$handle = \fopen( $tmp, 'wb' );
+		$curl   = \curl_init( $this->package );
+		\curl_setopt_array(
+			$curl,
+			array(
+				\CURLOPT_FILE           => $handle,
+				\CURLOPT_FOLLOWLOCATION => true,
+				\CURLOPT_TIMEOUT        => 60,
+			)
+		);
+		$downloaded = \curl_exec( $curl );
+		\curl_close( $curl );
+		\fclose( $handle );
+
+		$version = null;
+		if ( false !== $downloaded && \class_exists( '\ZipArchive' ) ) {
+			$zip = new \ZipArchive();
+			if ( true === $zip->open( $tmp ) ) {
+				for ( $index = 0; $index < $zip->numFiles; $index++ ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+					$name = (string) $zip->getNameIndex( $index );
+					if ( ! \preg_match( '#^[^/]+/[^/]+\.php$#', $name ) ) {
+						continue; // Only top-level PHP files inside the plugin folder.
+					}
+					$contents = $zip->getFromIndex( $index, 8192 );
+					if ( false === $contents || false === \stripos( $contents, 'Plugin Name:' ) ) {
+						continue;
+					}
+					if ( \preg_match( '/^[ \t\/*#@]*Version:\s*(\S+)/mi', $contents, $matches ) ) {
+						$version = \trim( $matches[1] );
+						break;
+					}
+				}
+				$zip->close();
+			}
+		}
+
+		\unlink( $tmp );
+		return $version;
 	}
 
 	/**

--- a/commands/Jetpack_Plugin_Update.php
+++ b/commands/Jetpack_Plugin_Update.php
@@ -35,6 +35,12 @@ final class Jetpack_Plugin_Update extends Command {
 	private const DEFAULT_REFRESH_WAIT = 360;
 
 	/**
+	 * Upper bound for --refresh-wait, in seconds (1 hour). Guards against a typo blocking the CLI
+	 * indefinitely in the second-by-second progress loop.
+	 */
+	private const MAX_REFRESH_WAIT = 3600;
+
+	/**
 	 * The plugin slug to update (matched against folder name, main file name, and textdomain).
 	 *
 	 * @var string|null
@@ -113,7 +119,8 @@ final class Jetpack_Plugin_Update extends Command {
 
 	/**
 	 * The sites that have the plugin installed and will be updated, keyed by site ID.
-	 * Each entry: array{ name: string, folder: string, installed: string, siteurl: string }.
+	 * Each entry: array{ name: string, folder: string, installed: string, siteurl: string, plan?: string }.
+	 * The `plan` key (`install`/`current`/`ahead`) is added by plan_force_install() in --force mode.
 	 *
 	 * @var array|null
 	 */
@@ -195,8 +202,8 @@ final class Jetpack_Plugin_Update extends Command {
 		}
 		if ( null === $refresh_wait ) {
 			$this->refresh_wait = self::DEFAULT_REFRESH_WAIT;
-		} elseif ( ! \is_numeric( $refresh_wait ) || (int) $refresh_wait < 0 ) {
-			throw new \InvalidArgumentException( 'The --refresh-wait option must be a non-negative number of seconds (0 to skip the wait).' );
+		} elseif ( ! \ctype_digit( (string) $refresh_wait ) || (int) $refresh_wait > self::MAX_REFRESH_WAIT ) {
+			throw new \InvalidArgumentException( 'The --refresh-wait option must be a whole number of seconds between 0 and ' . self::MAX_REFRESH_WAIT . ' (0 to skip the wait).' );
 		} else {
 			$this->refresh_wait = (int) $refresh_wait;
 		}
@@ -290,7 +297,11 @@ final class Jetpack_Plugin_Update extends Command {
 				$output->writeln( "<comment>Skipping $skipped_current site(s) already at $this->target_version — pass --reinstall to overwrite them too.</comment>" );
 			}
 			if ( empty( $install_ids ) ) {
-				$output->writeln( "<info>Nothing to install: every targeted site is already at or ahead of $this->target_version.</info>" );
+				if ( ! empty( $this->unqueryable ) ) {
+					$this->warn_unqueryable( $output );
+					return Command::FAILURE;
+				}
+				$output->writeln( "<info>Nothing to install: every assessed site is already at or ahead of $this->target_version.</info>" );
 				return Command::SUCCESS;
 			}
 		}
@@ -308,6 +319,7 @@ final class Jetpack_Plugin_Update extends Command {
 		);
 
 		if ( $this->dry_run ) {
+			$this->warn_unqueryable( $output );
 			$output->writeln( '<comment>Dry run: no sites were changed.</comment>' );
 			return Command::SUCCESS;
 		}
@@ -359,8 +371,11 @@ final class Jetpack_Plugin_Update extends Command {
 				$now    = (string) ( $results[ $site_id ]->version ?? $was );
 				$result = $this->classify( $was, $now );
 				// A forced same-version reinstall succeeded but the version didn't move; report it as
-				// `reinstalled` rather than `current`, which would read as "nothing happened".
-				if ( $this->force && $this->reinstall && 'current' === $result ) {
+				// `reinstalled` rather than `current`, which would read as "nothing happened". Gate on the
+				// installed version actually equalling the target so a below-target site whose response
+				// carried no version is not mislabelled.
+				if ( $this->force && $this->reinstall && 'current' === $result
+					&& 0 === \version_compare( $this->normalize_version( $was ), $this->normalize_version( (string) $this->target_version ) ) ) {
 					$result = 'reinstalled';
 				}
 			} else {
@@ -398,13 +413,24 @@ final class Jetpack_Plugin_Update extends Command {
 		if ( ! $this->force && empty( $this->release ) && $counts['current'] > 0 ) {
 			$output->writeln( '<comment>Tip: some sites reported no change — pass --release <version> to distinguish "already current" from "ahead of the release".</comment>' );
 		}
-		if ( ! empty( $this->unqueryable ) ) {
-			$output->writeln( '<fg=red;options=bold>✗ ' . \count( $this->unqueryable ) . ' site(s) could not be queried for plugins and were not assessed (see the table above).</>' );
-		}
+		$this->warn_unqueryable( $output );
 
 		// Real per-site errors and sites we could not even assess fail the command; `behind` (the release
 		// hasn't propagated to the plugin's own update source yet) and `ahead` are warnings, not failures.
 		return ( 0 === $counts['failed'] && empty( $this->unqueryable ) ) ? Command::SUCCESS : Command::FAILURE;
+	}
+
+	/**
+	 * Warns about sites that could not be queried for their installed plugins, when any.
+	 *
+	 * @param   OutputInterface $output The output interface.
+	 *
+	 * @return  void
+	 */
+	private function warn_unqueryable( OutputInterface $output ): void {
+		if ( ! empty( $this->unqueryable ) ) {
+			$output->writeln( '<fg=red;options=bold>✗ ' . \count( $this->unqueryable ) . ' site(s) could not be queried for plugins and were not assessed (see the table above).</>' );
+		}
 	}
 
 	// endregion
@@ -560,19 +586,20 @@ final class Jetpack_Plugin_Update extends Command {
 	 * @return  string|null The version, or null if the (successfully downloaded) package has no readable
 	 *                      version header.
 	 *
-	 * @throws  \RuntimeException If the package URL cannot be downloaded (curl error or non-2xx response),
-	 *                            since force-installing an unfetchable URL would fail on every site.
+	 * @throws  \RuntimeException If a local temp file cannot be created, or the package URL cannot be
+	 *                            downloaded (curl error or non-2xx response) — force-installing an
+	 *                            unfetchable URL would fail on every site.
 	 */
 	private function resolve_package_version(): ?string {
 		$tmp = \tempnam( \sys_get_temp_dir(), 't51pkg' );
 		if ( false === $tmp ) {
-			return null;
+			throw new \RuntimeException( 'Could not create a local temporary file to download the package into.' );
 		}
 
 		$handle = \fopen( $tmp, 'wb' );
 		if ( false === $handle ) {
 			\unlink( $tmp );
-			return null;
+			throw new \RuntimeException( 'Could not open a local temporary file to download the package into.' );
 		}
 
 		$curl = \curl_init( $this->package );

--- a/commands/Jetpack_Plugin_Update.php
+++ b/commands/Jetpack_Plugin_Update.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Question\Question;
 use WPCOMSpecialProjects\CLI\Helper\AutocompleteTrait;
 
 /**
- * Force-updates a given plugin across all connected Jetpack sites where it is installed.
+ * Updates a given plugin on connected Jetpack sites where it is installed.
  */
 #[AsCommand( name: 'jetpack:plugin-update' )]
 final class Jetpack_Plugin_Update extends Command {
@@ -72,7 +72,7 @@ final class Jetpack_Plugin_Update extends Command {
 
 	/**
 	 * The sites that have the plugin installed and will be updated, keyed by site ID.
-	 * Each entry: array{ name: string, folder: string, installed: string, siteurl: string }.
+	 * Each entry: array{ name: string, installed: string, siteurl: string }.
 	 *
 	 * @var array|null
 	 */
@@ -336,17 +336,7 @@ final class Jetpack_Plugin_Update extends Command {
 	 * @return  string One of `updated`, `current`, `ahead`, `behind`.
 	 */
 	private function classify( string $was, string $now ): string {
-		if ( ! empty( $this->release ) ) {
-			$against_release = \version_compare( normalize_version_string( $now ), normalize_version_string( $this->release ) );
-			if ( $against_release > 0 ) {
-				return 'ahead';
-			}
-			if ( $against_release < 0 ) {
-				return 'behind';
-			}
-		}
-
-		return \version_compare( normalize_version_string( $was ), normalize_version_string( $now ), '<' ) ? 'updated' : 'current';
+		return classify_wpcom_plugin_update_result( $was, $now, $this->release );
 	}
 
 	/**

--- a/commands/Jetpack_Plugin_Update.php
+++ b/commands/Jetpack_Plugin_Update.php
@@ -29,9 +29,10 @@ final class Jetpack_Plugin_Update extends Command {
 
 	/**
 	 * Default seconds to wait after raising a refresh directive for sites to re-check, before updating.
-	 * Comfortably longer than the Atlantis poll interval (~5 minutes) so most sites re-check in time.
+	 * Comfortably longer than the Atlantis poll interval (~5 minutes) so most sites re-check in time;
+	 * pass --refresh-wait to override (0 raises the refresh and updates immediately).
 	 */
-	private const DEFAULT_REFRESH_WAIT = 330;
+	private const DEFAULT_REFRESH_WAIT = 360;
 
 	/**
 	 * The plugin slug to update (matched against folder name, main file name, and textdomain).
@@ -118,6 +119,14 @@ final class Jetpack_Plugin_Update extends Command {
 	 */
 	private ?array $targets = null;
 
+	/**
+	 * Sites that could not be queried for their installed plugins, keyed by WPCOM ID. Surfaced in the
+	 * summary and the exit code so a fleet-wide push cannot silently skip unreachable sites.
+	 *
+	 * @var array
+	 */
+	private array $unqueryable = array();
+
 	// endregion
 
 	// region INHERITED METHODS
@@ -136,7 +145,7 @@ final class Jetpack_Plugin_Update extends Command {
 			->addOption( 'force', null, InputOption::VALUE_NONE, 'Force-install the plugin from --package, overwriting it in place. Installs only on sites whose version is below the package version; sites already at that version are skipped and sites ahead of it are never touched (no downgrades). Bypasses update detection entirely — use this when a just-published release has not propagated to sites yet.' )
 			->addOption( 'package', null, InputOption::VALUE_REQUIRED, 'The plugin zip URL to install. Required with --force (e.g. a GitHub release asset URL).' )
 			->addOption( 'reinstall', null, InputOption::VALUE_NONE, 'With --force, also overwrite sites already at the package version (a same-version reinstall). Sites ahead of the package version are still never touched.' )
-			->addOption( 'refresh', null, InputOption::VALUE_NONE, 'Before updating, ask every targeted site to re-check for updates (via the Atlantis lever) so a just-published wp.org release is detected even if the site\'s 12h update cache has not refreshed yet. Applies to the default update path; has no effect with --force, which bypasses update detection.' )
+			->addOption( 'refresh', null, InputOption::VALUE_NONE, 'Before updating, raise a fleet-wide update-check refresh so sites re-detect a just-published wp.org release even if their 12h update cache has not refreshed yet. The refresh is a global pulse — every site running the Atlantis lever re-checks, regardless of --sites — while the update itself still only touches the --sites you chose. Applies to the default update path; has no effect with --force, which bypasses update detection.' )
 			->addOption( 'refresh-wait', null, InputOption::VALUE_REQUIRED, 'Seconds to wait for the refresh to propagate before updating (default ' . self::DEFAULT_REFRESH_WAIT . '). Pass 0 to raise the refresh and update immediately, then re-run shortly to catch stragglers.' )
 			->addOption( 'dry-run', null, InputOption::VALUE_NONE, 'List the sites that would be updated without updating them.' )
 			->addOption( 'yes', null, InputOption::VALUE_NONE, 'Skip the confirmation prompt before updating.' );
@@ -145,7 +154,12 @@ final class Jetpack_Plugin_Update extends Command {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @throws \InvalidArgumentException If `--sites` is missing or matches no connected Jetpack site.
+	 * @throws \InvalidArgumentException If `--sites` is missing/unmatched, or an option is misused
+	 *                                   (`--force` without `--package`; `--package`/`--reinstall` without
+	 *                                   `--force`; `--refresh` with `--force`; `--refresh-wait` without
+	 *                                   `--refresh` or with a negative/non-numeric value).
+	 * @throws \RuntimeException         If the connected fleet, the sites' installed plugins, or the
+	 *                                   `--package` zip cannot be fetched.
 	 */
 	protected function initialize( InputInterface $input, OutputInterface $output ): void {
 		$this->plugin = get_string_input( $input, 'plugin', fn() => $this->prompt_plugin_input( $input, $output ) );
@@ -157,20 +171,42 @@ final class Jetpack_Plugin_Update extends Command {
 		$this->force     = get_bool_input( $input, 'force' );
 		$this->reinstall = get_bool_input( $input, 'reinstall' );
 		$this->package   = maybe_get_string_input( $input, 'package' );
+		$this->refresh   = get_bool_input( $input, 'refresh' );
+
+		// Reject misused option combinations instead of silently ignoring them.
 		if ( $this->force && empty( $this->package ) ) {
 			throw new \InvalidArgumentException( 'The --force option requires --package <zip-url> (e.g. a GitHub release asset URL).' );
 		}
-
-		$this->refresh = get_bool_input( $input, 'refresh' );
+		if ( ! $this->force && ! empty( $this->package ) ) {
+			throw new \InvalidArgumentException( 'The --package option only applies to --force.' );
+		}
+		if ( ! $this->force && $this->reinstall ) {
+			throw new \InvalidArgumentException( 'The --reinstall option only applies to --force.' );
+		}
 		if ( $this->refresh && $this->force ) {
 			throw new \InvalidArgumentException( 'The --refresh option applies to the detection-based update path and has no effect with --force (which bypasses update detection). Use one or the other.' );
 		}
-		$refresh_wait       = maybe_get_string_input( $input, 'refresh-wait' );
-		$this->refresh_wait = null === $refresh_wait ? self::DEFAULT_REFRESH_WAIT : \max( 0, (int) $refresh_wait );
+
+		// Read --refresh-wait directly: maybe_get_string_input() treats "0" as absent, which would make
+		// the documented `--refresh-wait 0` ("update immediately") silently fall back to the default.
+		$refresh_wait = $input->getOption( 'refresh-wait' );
+		if ( null !== $refresh_wait && ! $this->refresh ) {
+			throw new \InvalidArgumentException( 'The --refresh-wait option only applies to --refresh.' );
+		}
+		if ( null === $refresh_wait ) {
+			$this->refresh_wait = self::DEFAULT_REFRESH_WAIT;
+		} elseif ( ! \is_numeric( $refresh_wait ) || (int) $refresh_wait < 0 ) {
+			throw new \InvalidArgumentException( 'The --refresh-wait option must be a non-negative number of seconds (0 to skip the wait).' );
+		} else {
+			$this->refresh_wait = (int) $refresh_wait;
+		}
 
 		$sites_spec = get_string_input( $input, 'sites', fn() => $this->prompt_sites_input( $input, $output ) );
 
 		$all_sites = get_wpcom_jetpack_sites();
+		if ( \is_null( $all_sites ) ) {
+			throw new \RuntimeException( 'Could not fetch the connected Jetpack sites from WPCOM.' );
+		}
 		$output->writeln( '<comment>Successfully fetched ' . \count( $all_sites ) . ' connected Jetpack site(s).</comment>' );
 
 		if ( 'all' === \strtolower( \trim( $sites_spec ) ) ) {
@@ -194,7 +230,11 @@ final class Jetpack_Plugin_Update extends Command {
 
 		// Fetch the plugins installed on the target sites and compile the list of sites to update.
 		$plugins = get_wpcom_site_plugins_batch( \array_column( $this->sites, 'userblog_id' ), $errors );
-		maybe_output_wpcom_failed_sites_table( $output, $errors ?? array(), $this->sites, 'Sites that could NOT be queried for plugins' );
+		if ( \is_null( $plugins ) ) {
+			throw new \RuntimeException( 'Could not fetch the installed plugins for the requested sites from WPCOM.' );
+		}
+		$this->unqueryable = \is_array( $errors ) ? $errors : array();
+		maybe_output_wpcom_failed_sites_table( $output, $this->unqueryable, $this->sites, 'Sites that could NOT be queried for plugins' );
 
 		$this->targets = array();
 		foreach ( $plugins as $site_id => $site_plugins ) {
@@ -224,6 +264,10 @@ final class Jetpack_Plugin_Update extends Command {
 	 */
 	protected function execute( InputInterface $input, OutputInterface $output ): int {
 		if ( empty( $this->targets ) ) {
+			if ( ! empty( $this->unqueryable ) ) {
+				$output->writeln( '<error>' . \count( $this->unqueryable ) . ' site(s) could not be queried for plugins (see the table above), so no sites could be assessed.</error>' );
+				return Command::FAILURE;
+			}
 			$output->writeln( "<comment>No connected sites have the plugin `$this->plugin` installed.</comment>" );
 			return Command::SUCCESS;
 		}
@@ -251,14 +295,15 @@ final class Jetpack_Plugin_Update extends Command {
 			}
 		}
 
-		// Show what will be changed.
+		// Show what will be changed. The matched plugin identifier is shown so a heterogeneous match
+		// (different folders/textdomains across sites) is visible before a fleet-wide overwrite.
 		output_table(
 			$output,
 			\array_map(
-				fn( $site_id ) => array( $site_id, $this->targets[ $site_id ]['siteurl'], $this->targets[ $site_id ]['installed'] ),
+				fn( $site_id ) => array( $site_id, $this->targets[ $site_id ]['siteurl'], $this->targets[ $site_id ]['name'], $this->targets[ $site_id ]['installed'] ),
 				$install_ids
 			),
-			array( 'Site ID', 'Site URL', 'Installed Version' ),
+			array( 'Site ID', 'Site URL', 'Plugin', 'Installed Version' ),
 			'Sites to ' . ( $this->force ? 'force-install' : 'update' ) . " `$this->plugin`"
 		);
 
@@ -293,11 +338,12 @@ final class Jetpack_Plugin_Update extends Command {
 		// Build the results table.
 		$rows   = array();
 		$counts = array(
-			'updated' => 0,
-			'current' => 0,
-			'ahead'   => 0,
-			'behind'  => 0,
-			'failed'  => 0,
+			'updated'     => 0,
+			'reinstalled' => 0,
+			'current'     => 0,
+			'ahead'       => 0,
+			'behind'      => 0,
+			'failed'      => 0,
 		);
 		foreach ( $this->targets as $site_id => $target ) {
 			$was  = $target['installed'];
@@ -312,6 +358,11 @@ final class Jetpack_Plugin_Update extends Command {
 			} elseif ( isset( $results[ $site_id ] ) ) {
 				$now    = (string) ( $results[ $site_id ]->version ?? $was );
 				$result = $this->classify( $was, $now );
+				// A forced same-version reinstall succeeded but the version didn't move; report it as
+				// `reinstalled` rather than `current`, which would read as "nothing happened".
+				if ( $this->force && $this->reinstall && 'current' === $result ) {
+					$result = 'reinstalled';
+				}
 			} else {
 				$result = 'failed';
 			}
@@ -328,6 +379,9 @@ final class Jetpack_Plugin_Update extends Command {
 		);
 
 		$summary = "Updated: {$counts['updated']} | Current: {$counts['current']}";
+		if ( $this->force ) {
+			$summary .= " | Reinstalled: {$counts['reinstalled']}";
+		}
 		if ( $this->force || ! empty( $this->release ) ) {
 			$summary .= " | Ahead: {$counts['ahead']} | Behind: {$counts['behind']}";
 		}
@@ -344,10 +398,13 @@ final class Jetpack_Plugin_Update extends Command {
 		if ( ! $this->force && empty( $this->release ) && $counts['current'] > 0 ) {
 			$output->writeln( '<comment>Tip: some sites reported no change — pass --release <version> to distinguish "already current" from "ahead of the release".</comment>' );
 		}
+		if ( ! empty( $this->unqueryable ) ) {
+			$output->writeln( '<fg=red;options=bold>✗ ' . \count( $this->unqueryable ) . ' site(s) could not be queried for plugins and were not assessed (see the table above).</>' );
+		}
 
-		// Only real per-site errors fail the command; `behind` (the release hasn't propagated to the
-		// plugin's own update source yet) and `ahead` are surfaced as warnings but are not failures.
-		return 0 === $counts['failed'] ? Command::SUCCESS : Command::FAILURE;
+		// Real per-site errors and sites we could not even assess fail the command; `behind` (the release
+		// hasn't propagated to the plugin's own update source yet) and `ahead` are warnings, not failures.
+		return ( 0 === $counts['failed'] && empty( $this->unqueryable ) ) ? Command::SUCCESS : Command::FAILURE;
 	}
 
 	// endregion
@@ -403,7 +460,7 @@ final class Jetpack_Plugin_Update extends Command {
 			return;
 		}
 
-		$output->writeln( "<comment>Refresh raised (epoch $directive->epoch). Sites re-check within ~5 minutes.</comment>" );
+		$output->writeln( "<comment>Refresh raised (epoch $directive->epoch). Every Atlantis-running site re-checks within ~5 minutes — fleet-wide, regardless of --sites.</comment>" );
 
 		if ( 0 >= (int) $this->refresh_wait ) {
 			$output->writeln( '<comment>Skipping the propagation wait (--refresh-wait=0); re-run the command shortly to catch any sites that had not re-checked yet.</comment>' );
@@ -500,7 +557,11 @@ final class Jetpack_Plugin_Update extends Command {
 	/**
 	 * Reads the plugin version from the package zip's header.
 	 *
-	 * @return  string|null The version, or null if the package could not be downloaded or parsed.
+	 * @return  string|null The version, or null if the (successfully downloaded) package has no readable
+	 *                      version header.
+	 *
+	 * @throws  \RuntimeException If the package URL cannot be downloaded (curl error or non-2xx response),
+	 *                            since force-installing an unfetchable URL would fail on every site.
 	 */
 	private function resolve_package_version(): ?string {
 		$tmp = \tempnam( \sys_get_temp_dir(), 't51pkg' );
@@ -509,7 +570,12 @@ final class Jetpack_Plugin_Update extends Command {
 		}
 
 		$handle = \fopen( $tmp, 'wb' );
-		$curl   = \curl_init( $this->package );
+		if ( false === $handle ) {
+			\unlink( $tmp );
+			return null;
+		}
+
+		$curl = \curl_init( $this->package );
 		\curl_setopt_array(
 			$curl,
 			array(
@@ -519,11 +585,21 @@ final class Jetpack_Plugin_Update extends Command {
 			)
 		);
 		$downloaded = \curl_exec( $curl );
+		$http_code  = (int) \curl_getinfo( $curl, \CURLINFO_RESPONSE_CODE );
+		$curl_error = \curl_error( $curl );
 		\curl_close( $curl );
 		\fclose( $handle );
 
+		// A bad --package URL is a hard error: don't silently fall back to --release and push a URL that
+		// already failed to fetch locally out to the whole fleet.
+		if ( false === $downloaded || $http_code < 200 || $http_code >= 300 ) {
+			\unlink( $tmp );
+			$detail = '' !== $curl_error ? $curl_error : "HTTP $http_code";
+			throw new \RuntimeException( "Could not download the package from `$this->package` ($detail)." );
+		}
+
 		$version = null;
-		if ( false !== $downloaded && \class_exists( '\ZipArchive' ) ) {
+		if ( \class_exists( '\ZipArchive' ) ) {
 			$zip = new \ZipArchive();
 			if ( true === $zip->open( $tmp ) ) {
 				for ( $index = 0; $index < $zip->numFiles; $index++ ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
@@ -746,11 +822,12 @@ final class Jetpack_Plugin_Update extends Command {
 	 */
 	private function format_result( string $result ): string {
 		return match ( $result ) {
-			'updated' => '<fg=green>updated</>',
-			'ahead'   => '<fg=yellow;options=bold>⚠ ahead</>',
-			'behind'  => '<fg=red;options=bold>✗ behind</>',
-			'failed'  => '<fg=red>failed</>',
-			default   => $result,
+			'updated'     => '<fg=green>updated</>',
+			'reinstalled' => '<fg=green>reinstalled</>',
+			'ahead'       => '<fg=yellow;options=bold>⚠ ahead</>',
+			'behind'      => '<fg=red;options=bold>✗ behind</>',
+			'failed'      => '<fg=red>failed</>',
+			default       => $result,
 		};
 	}
 

--- a/commands/Jetpack_Plugin_Update.php
+++ b/commands/Jetpack_Plugin_Update.php
@@ -29,9 +29,9 @@ final class Jetpack_Plugin_Update extends Command {
 
 	/**
 	 * Default seconds to wait after raising a refresh directive for sites to re-check, before updating.
-	 * Comfortably longer than the Atlantis poll interval (~2 minutes) so most sites re-check in time.
+	 * Comfortably longer than the Atlantis poll interval (~5 minutes) so most sites re-check in time.
 	 */
-	private const DEFAULT_REFRESH_WAIT = 180;
+	private const DEFAULT_REFRESH_WAIT = 330;
 
 	/**
 	 * The plugin slug to update (matched against folder name, main file name, and textdomain).
@@ -403,7 +403,7 @@ final class Jetpack_Plugin_Update extends Command {
 			return;
 		}
 
-		$output->writeln( "<comment>Refresh raised (epoch $directive->epoch). Sites re-check within ~2 minutes.</comment>" );
+		$output->writeln( "<comment>Refresh raised (epoch $directive->epoch). Sites re-check within ~5 minutes.</comment>" );
 
 		if ( 0 >= (int) $this->refresh_wait ) {
 			$output->writeln( '<comment>Skipping the propagation wait (--refresh-wait=0); re-run the command shortly to catch any sites that had not re-checked yet.</comment>' );

--- a/commands/Jetpack_Plugin_Update.php
+++ b/commands/Jetpack_Plugin_Update.php
@@ -4,7 +4,6 @@ namespace WPCOMSpecialProjects\CLI\Command;
 
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -26,19 +25,6 @@ final class Jetpack_Plugin_Update extends Command {
 	 * Number of sites per batch when force-installing (each install is a real download + overwrite).
 	 */
 	private const FORCE_BATCH_SIZE = 30;
-
-	/**
-	 * Default seconds to wait after raising a refresh directive for sites to re-check, before updating.
-	 * Comfortably longer than the Atlantis poll interval (~5 minutes) so most sites re-check in time;
-	 * pass --refresh-wait to override (0 raises the refresh and updates immediately).
-	 */
-	private const DEFAULT_REFRESH_WAIT = 360;
-
-	/**
-	 * Upper bound for --refresh-wait, in seconds (1 hour). Guards against a typo blocking the CLI
-	 * indefinitely in the second-by-second progress loop.
-	 */
-	private const MAX_REFRESH_WAIT = 3600;
 
 	/**
 	 * The plugin slug to update (matched against folder name, main file name, and textdomain).
@@ -104,13 +90,6 @@ final class Jetpack_Plugin_Update extends Command {
 	private ?bool $refresh = null;
 
 	/**
-	 * Seconds to wait for the refresh to propagate across the fleet before updating.
-	 *
-	 * @var int|null
-	 */
-	private ?int $refresh_wait = null;
-
-	/**
 	 * The list of connected sites.
 	 *
 	 * @var array|null
@@ -152,8 +131,7 @@ final class Jetpack_Plugin_Update extends Command {
 			->addOption( 'force', null, InputOption::VALUE_NONE, 'Force-install the plugin from --package, overwriting it in place. Installs only on sites whose version is below the package version; sites already at that version are skipped and sites ahead of it are never touched (no downgrades). Bypasses update detection entirely — use this when a just-published release has not propagated to sites yet.' )
 			->addOption( 'package', null, InputOption::VALUE_REQUIRED, 'The plugin zip URL to install. Required with --force (e.g. a GitHub release asset URL).' )
 			->addOption( 'reinstall', null, InputOption::VALUE_NONE, 'With --force, also overwrite sites already at the package version (a same-version reinstall). Sites ahead of the package version are still never touched.' )
-			->addOption( 'refresh', null, InputOption::VALUE_NONE, 'Before updating, raise a fleet-wide update-check refresh so sites re-detect a just-published wp.org release even if their 12h update cache has not refreshed yet. The refresh is a global pulse — every site running the Atlantis lever re-checks, regardless of --sites — while the update itself still only touches the --sites you chose. Applies to the default update path; has no effect with --force, which bypasses update detection.' )
-			->addOption( 'refresh-wait', null, InputOption::VALUE_REQUIRED, 'Seconds to wait for the refresh to propagate before updating (default ' . self::DEFAULT_REFRESH_WAIT . '). Pass 0 to raise the refresh and update immediately, then re-run shortly to catch stragglers.' )
+			->addOption( 'refresh', null, InputOption::VALUE_NONE, 'Before updating, force the targeted sites to re-check for updates (via the Atlantis lever) so a just-published wp.org or WooCommerce.com release is detected even if their update cache has not refreshed yet. Runs synchronously against the sites you chose with --sites. Applies to the default update path; has no effect with --force, which bypasses update detection.' )
 			->addOption( 'dry-run', null, InputOption::VALUE_NONE, 'List the sites that would be updated without updating them.' )
 			->addOption( 'yes', null, InputOption::VALUE_NONE, 'Skip the confirmation prompt before updating.' );
 	}
@@ -163,8 +141,7 @@ final class Jetpack_Plugin_Update extends Command {
 	 *
 	 * @throws \InvalidArgumentException If `--sites` is missing/unmatched, or an option is misused
 	 *                                   (`--force` without `--package`; `--package`/`--reinstall` without
-	 *                                   `--force`; `--refresh` with `--force`; `--refresh-wait` without
-	 *                                   `--refresh` or with a negative/non-numeric value).
+	 *                                   `--force`; `--refresh` with `--force`).
 	 * @throws \RuntimeException         If the connected fleet, the sites' installed plugins, or the
 	 *                                   `--package` zip cannot be fetched.
 	 */
@@ -192,20 +169,6 @@ final class Jetpack_Plugin_Update extends Command {
 		}
 		if ( $this->refresh && $this->force ) {
 			throw new \InvalidArgumentException( 'The --refresh option applies to the detection-based update path and has no effect with --force (which bypasses update detection). Use one or the other.' );
-		}
-
-		// Read --refresh-wait directly: maybe_get_string_input() treats "0" as absent, which would make
-		// the documented `--refresh-wait 0` ("update immediately") silently fall back to the default.
-		$refresh_wait = $input->getOption( 'refresh-wait' );
-		if ( null !== $refresh_wait && ! $this->refresh ) {
-			throw new \InvalidArgumentException( 'The --refresh-wait option only applies to --refresh.' );
-		}
-		if ( null === $refresh_wait ) {
-			$this->refresh_wait = self::DEFAULT_REFRESH_WAIT;
-		} elseif ( ! \ctype_digit( (string) $refresh_wait ) || (int) $refresh_wait > self::MAX_REFRESH_WAIT ) {
-			throw new \InvalidArgumentException( 'The --refresh-wait option must be a whole number of seconds between 0 and ' . self::MAX_REFRESH_WAIT . ' (0 to skip the wait).' );
-		} else {
-			$this->refresh_wait = (int) $refresh_wait;
 		}
 
 		$sites_spec = get_string_input( $input, 'sites', fn() => $this->prompt_sites_input( $input, $output ) );
@@ -467,54 +430,29 @@ final class Jetpack_Plugin_Update extends Command {
 	}
 
 	/**
-	 * Raises a fleet-wide update-check refresh and waits for it to propagate.
+	 * Forces a fresh update-check on the targeted sites before updating.
 	 *
-	 * Asks every site (via the Atlantis lever) to clear its plugin-update cache and re-check, so a
-	 * just-published release is detected before we call the version-gated update endpoint. Best-effort:
-	 * if the directive cannot be raised, the update still proceeds for sites that already detected it.
+	 * Calls the Atlantis lever (via OpsOasis, over the authenticated Jetpack REST tunnel) on the sites
+	 * that have the plugin, so each clears its update cache and re-detects a just-published release
+	 * synchronously — before we call the version-gated update endpoint. Best-effort: sites that can't be
+	 * reached (no Atlantis, or connection down) are reported, and the update still proceeds.
 	 *
 	 * @param   OutputInterface $output The output interface.
 	 *
 	 * @return  void
 	 */
 	private function run_refresh( OutputInterface $output ): void {
-		$output->writeln( '<fg=magenta;options=bold>Requesting a fleet-wide plugin update-check…</>' );
+		$site_ids = \array_keys( $this->targets );
+		$output->writeln( '<fg=magenta;options=bold>Refreshing the update-check on ' . \count( $site_ids ) . ' site(s)…</>' );
 
-		$directive = refresh_wpcom_site_plugin_updates();
-		if ( ! $directive instanceof \stdClass || ! isset( $directive->epoch ) ) {
-			$output->writeln( '<comment>⚠ Could not raise the refresh directive; proceeding anyway (sites that already detected the release will still update).</comment>' );
+		$results = force_check_wpcom_site_plugins_batch( $site_ids, $errors );
+		if ( \is_null( $results ) ) {
+			$output->writeln( '<comment>⚠ The refresh request failed; proceeding anyway (sites that already detected the release will still update).</comment>' );
 			return;
 		}
 
-		$output->writeln( "<comment>Refresh raised (epoch $directive->epoch). Every Atlantis-running site re-checks within ~5 minutes — fleet-wide, regardless of --sites.</comment>" );
-
-		if ( 0 >= (int) $this->refresh_wait ) {
-			$output->writeln( '<comment>Skipping the propagation wait (--refresh-wait=0); re-run the command shortly to catch any sites that had not re-checked yet.</comment>' );
-			return;
-		}
-
-		$this->wait_for_propagation( $output, (int) $this->refresh_wait );
-	}
-
-	/**
-	 * Blocks for the given number of seconds with a progress bar, giving sites time to re-check.
-	 *
-	 * @param   OutputInterface $output  The output interface.
-	 * @param   int             $seconds The number of seconds to wait.
-	 *
-	 * @return  void
-	 */
-	private function wait_for_propagation( OutputInterface $output, int $seconds ): void {
-		$output->writeln( "<comment>Waiting {$seconds}s for sites to re-check before updating…</comment>" );
-
-		$progress = new ProgressBar( $output, $seconds );
-		$progress->start();
-		for ( $second = 0; $second < $seconds; $second++ ) {
-			\sleep( 1 );
-			$progress->advance();
-		}
-		$progress->finish();
-		$output->writeln( '' );
+		$failed = \count( $errors ?? array() );
+		$output->writeln( '<comment>Refreshed ' . \count( $results ) . ' site(s)' . ( $failed > 0 ? "; $failed could not be reached (no Atlantis or connection down) and may not detect the release" : '' ) . '.</comment>' );
 	}
 
 	/**

--- a/commands/Jetpack_Plugin_Update.php
+++ b/commands/Jetpack_Plugin_Update.php
@@ -333,10 +333,13 @@ final class Jetpack_Plugin_Update extends Command {
 					&& 0 === \version_compare( normalize_version_string( $was ), normalize_version_string( (string) $this->target_version ) ) ) {
 					$result = 'reinstalled';
 				}
-				// A forced --downgrade succeeded: the site was ahead of the package and was rolled back.
-				// classify() reads the backwards version move as `current`, so label it `downgraded` instead.
+				// A forced --downgrade succeeded: the site was ahead of the package AND the version actually
+				// moved back. classify() reads the backwards move as `current`, so relabel it `downgraded`.
+				// Require the version to have decreased so a version-less replace response (now == was) is
+				// not mislabelled as a rollback that never landed.
 				if ( $this->force && $this->downgrade
-					&& \version_compare( normalize_version_string( $was ), normalize_version_string( (string) $this->target_version ), '>' ) ) {
+					&& \version_compare( normalize_version_string( $was ), normalize_version_string( (string) $this->target_version ), '>' )
+					&& \version_compare( normalize_version_string( $now ), normalize_version_string( $was ), '<' ) ) {
 					$result = 'downgraded';
 				}
 			} else {

--- a/commands/Jetpack_Plugin_Update.php
+++ b/commands/Jetpack_Plugin_Update.php
@@ -29,11 +29,11 @@ final class Jetpack_Plugin_Update extends Command {
 	private ?string $plugin = null;
 
 	/**
-	 * Optional guard: only update sites whose installed version is below this value.
+	 * Optional release version being published; sites are classified against it (updated/current/ahead/behind).
 	 *
 	 * @var string|null
 	 */
-	private ?string $min_version = null;
+	private ?string $release = null;
 
 	/**
 	 * Whether to only list the sites that would be updated, without updating them.
@@ -72,13 +72,13 @@ final class Jetpack_Plugin_Update extends Command {
 	 * {@inheritDoc}
 	 */
 	protected function configure(): void {
-		$this->setDescription( 'Force-updates a given plugin on all connected sites where it is installed.' )
-			->setHelp( 'Use this command to push a new plugin release to every site that has the plugin installed. Each site is updated via the WPCOM plugin update endpoint, which refreshes its update cache and installs from the plugin\'s own update source (wp.org, or a custom Update URI such as GitHub). Only sites with an active Jetpack connection to WPCOM are processed. The update only fires where a newer version is available, so publish the new release before running this.' );
+		$this->setDescription( 'Force-updates a given plugin on connected sites where it is installed.' )
+			->setHelp( 'Use this command to push a new plugin release to sites that have the plugin installed. Pass --sites to choose the targets: `all` for the whole connected fleet, a comma-separated list of site URLs and/or WPCOM IDs, or the path to a CSV whose first column holds the site URLs. Each site is updated via the WPCOM plugin update endpoint, which refreshes its update cache and installs from the plugin\'s own update source (wp.org, or a custom Update URI such as GitHub). Only sites with an active Jetpack connection to WPCOM are processed. The update only fires where a newer version is available, so publish the new release before running this.' );
 
 		$this->addArgument( 'plugin', InputArgument::REQUIRED, 'The plugin to update. The term is matched exactly against the folder name, the main file name, and the textdomain.' );
 
-		$this->addOption( 'site', null, InputOption::VALUE_REQUIRED, 'Limit the update to a single site (numeric WPCOM ID or a domain). Useful to canary before running against the fleet.' )
-			->addOption( 'min-version', null, InputOption::VALUE_REQUIRED, 'Only update sites whose installed version is below this value.' )
+		$this->addOption( 'sites', null, InputOption::VALUE_REQUIRED, 'Which sites to update: `all` for the whole connected fleet, a comma-separated list of site URLs and/or numeric WPCOM IDs, or a path to a CSV file whose first column holds the site URLs.' )
+			->addOption( 'release', null, InputOption::VALUE_REQUIRED, 'The plugin version you are publishing. When set, each site is reported as updated / current / ahead / behind relative to it, so sites running a newer (e.g. test) build, or ones the release has not reached, are surfaced.' )
 			->addOption( 'dry-run', null, InputOption::VALUE_NONE, 'List the sites that would be updated without updating them.' )
 			->addOption( 'yes', null, InputOption::VALUE_NONE, 'Skip the confirmation prompt before updating.' );
 	}
@@ -86,29 +86,38 @@ final class Jetpack_Plugin_Update extends Command {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @throws \InvalidArgumentException If the `--site` value matches no connected Jetpack site.
+	 * @throws \InvalidArgumentException If `--sites` is missing or matches no connected Jetpack site.
 	 */
 	protected function initialize( InputInterface $input, OutputInterface $output ): void {
 		$this->plugin = get_string_input( $input, 'plugin', fn() => $this->prompt_plugin_input( $input, $output ) );
 		$input->setArgument( 'plugin', $this->plugin );
 
-		$this->min_version = maybe_get_string_input( $input, 'min-version' );
-		$this->dry_run     = get_bool_input( $input, 'dry-run' );
-		$this->yes         = get_bool_input( $input, 'yes' );
+		$this->release = maybe_get_string_input( $input, 'release' );
+		$this->dry_run = get_bool_input( $input, 'dry-run' );
+		$this->yes     = get_bool_input( $input, 'yes' );
 
-		$this->sites = get_wpcom_jetpack_sites();
-		$output->writeln( '<comment>Successfully fetched ' . \count( $this->sites ) . ' Jetpack site(s).</comment>' );
+		$sites_spec = get_string_input( $input, 'sites', fn() => $this->prompt_sites_input( $input, $output ) );
 
-		$site_option = $input->getOption( 'site' );
-		if ( ! empty( $site_option ) ) {
-			$this->sites = \array_filter(
-				$this->sites,
-				static fn( $site ) => (string) $site->userblog_id === (string) $site_option
-					|| false !== \stripos( (string) ( $site->siteurl ?? '' ), (string) $site_option )
-			);
-			if ( empty( $this->sites ) ) {
-				throw new \InvalidArgumentException( "No connected Jetpack site matched `$site_option`." );
+		$all_sites = get_wpcom_jetpack_sites();
+		$output->writeln( '<comment>Successfully fetched ' . \count( $all_sites ) . ' connected Jetpack site(s).</comment>' );
+
+		if ( 'all' === \strtolower( \trim( $sites_spec ) ) ) {
+			$this->sites = $all_sites;
+		} else {
+			[ $matched, $unmatched ] = $this->resolve_sites( $this->parse_requested_identifiers( $sites_spec ), $all_sites );
+
+			if ( ! empty( $unmatched ) ) {
+				$output->writeln( '<comment>⚠ Not found in the connected fleet, skipped:</comment>' );
+				foreach ( $unmatched as $identifier ) {
+					$output->writeln( "  - $identifier" );
+				}
 			}
+			if ( empty( $matched ) ) {
+				throw new \InvalidArgumentException( 'None of the requested sites were found in the connected Jetpack fleet.' );
+			}
+
+			$this->sites = $matched;
+			$output->writeln( '<comment>Matched ' . \count( $matched ) . ' of the requested site(s).</comment>' );
 		}
 
 		// Fetch the plugins installed on the target sites and compile the list of sites to update.
@@ -122,15 +131,10 @@ final class Jetpack_Plugin_Update extends Command {
 					continue;
 				}
 
-				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-				$installed = (string) $plugin_data->Version;
-				if ( ! empty( $this->min_version ) && ! \version_compare( $installed, $this->min_version, '<' ) ) {
-					break; // Already at or above the guard version; skip this site.
-				}
-
 				$this->targets[ $site_id ] = array(
 					'name'      => \preg_replace( '/\.php$/', '', $plugin_file ),
-					'installed' => $installed,
+					// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+					'installed' => (string) $plugin_data->Version,
 					'siteurl'   => (string) ( $this->sites[ $site_id ]->siteurl ?? '' ),
 				);
 				break; // One match per site is enough.
@@ -143,7 +147,7 @@ final class Jetpack_Plugin_Update extends Command {
 	 */
 	protected function execute( InputInterface $input, OutputInterface $output ): int {
 		if ( empty( $this->targets ) ) {
-			$output->writeln( "<comment>No connected sites have the plugin `$this->plugin` installed" . ( empty( $this->min_version ) ? '' : " below version $this->min_version" ) . '.</comment>' );
+			$output->writeln( "<comment>No connected sites have the plugin `$this->plugin` installed.</comment>" );
 			return Command::SUCCESS;
 		}
 
@@ -197,6 +201,8 @@ final class Jetpack_Plugin_Update extends Command {
 		$counts = array(
 			'updated' => 0,
 			'current' => 0,
+			'ahead'   => 0,
+			'behind'  => 0,
 			'failed'  => 0,
 		);
 		foreach ( $this->targets as $site_id => $target ) {
@@ -207,15 +213,12 @@ final class Jetpack_Plugin_Update extends Command {
 			if ( isset( $errors[ $site_id ] ) ) {
 				$now = encode_json_content( $errors[ $site_id ]->errors ?? $errors[ $site_id ] );
 			} elseif ( isset( $results[ $site_id ] ) ) {
-				$response = $results[ $site_id ];
-				$now      = (string) ( $response->version ?? $was );
-				$log      = \implode( ' ', (array) ( $response->log ?? array() ) );
-				// The update endpoint always logs either "No update needed" or the upgrade steps.
-				$result = false !== \stripos( $log, 'no update needed' ) ? 'current' : 'updated';
+				$now    = (string) ( $results[ $site_id ]->version ?? $was );
+				$result = $this->classify( $was, $now );
 			}
 
 			++$counts[ $result ];
-			$rows[] = array( $site_id, $target['siteurl'], $was, $now, $result );
+			$rows[] = array( $site_id, $target['siteurl'], $was, $now, $this->format_result( $result ) );
 		}
 
 		output_table(
@@ -225,9 +228,24 @@ final class Jetpack_Plugin_Update extends Command {
 			"Update results for `$this->plugin`"
 		);
 
-		$output->writeln( "<info>Updated: {$counts['updated']} | Already current: {$counts['current']} | Failed: {$counts['failed']}</info>" );
+		$summary = "Updated: {$counts['updated']} | Current: {$counts['current']}";
+		if ( ! empty( $this->release ) ) {
+			$summary .= " | Ahead: {$counts['ahead']} | Behind: {$counts['behind']}";
+		}
+		$summary .= " | Failed: {$counts['failed']}";
+		$output->writeln( "<info>$summary</info>" );
 
-		return 0 === $counts['failed'] ? Command::SUCCESS : Command::FAILURE;
+		if ( $counts['ahead'] > 0 ) {
+			$output->writeln( "<fg=yellow;options=bold>⚠ {$counts['ahead']} site(s) are AHEAD of `$this->release` (running a newer/test build) and were left unchanged.</>" );
+		}
+		if ( $counts['behind'] > 0 ) {
+			$output->writeln( "<fg=red;options=bold>✗ {$counts['behind']} site(s) are BEHIND `$this->release` — the release did not reach them (its update source may not have it yet).</>" );
+		}
+		if ( empty( $this->release ) && $counts['current'] > 0 ) {
+			$output->writeln( '<comment>Tip: some sites reported no change — pass --release <version> to distinguish "already current" from "ahead of the release".</comment>' );
+		}
+
+		return ( 0 === $counts['failed'] && 0 === $counts['behind'] ) ? Command::SUCCESS : Command::FAILURE;
 	}
 
 	// endregion
@@ -260,6 +278,195 @@ final class Jetpack_Plugin_Update extends Command {
 		return $this->plugin === $plugin_data->TextDomain // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 			|| $this->plugin === $plugin_folder
 			|| $this->plugin === $plugin_file;
+	}
+
+	/**
+	 * Prompts the user for the sites to update.
+	 *
+	 * @param   InputInterface  $input  The input interface.
+	 * @param   OutputInterface $output The output interface.
+	 *
+	 * @return  string
+	 */
+	private function prompt_sites_input( InputInterface $input, OutputInterface $output ): string {
+		$question = new Question( '<question>Which sites? Enter `all`, a comma-separated list of site URLs/IDs, or a path to a CSV:</question> ' );
+		return (string) $this->getHelper( 'question' )->ask( $input, $output, $question );
+	}
+
+	/**
+	 * Parses the `--sites` value into a list of requested site identifiers.
+	 *
+	 * The value is either a path to a CSV file (first column holds the site URLs) or a
+	 * comma-separated list of URLs and/or numeric WPCOM IDs. Blank and implausible entries
+	 * (such as a CSV header row) are dropped.
+	 *
+	 * @param   string $spec The raw `--sites` value.
+	 *
+	 * @return  string[]
+	 */
+	private function parse_requested_identifiers( string $spec ): array {
+		$raw = \is_file( $spec ) ? $this->read_csv_first_column( $spec ) : \explode( ',', $spec );
+
+		$identifiers = array();
+		foreach ( $raw as $value ) {
+			$value = \trim( (string) $value );
+			// Keep only plausible identifiers: numeric WPCOM IDs, or values that look like a domain.
+			// This also discards a CSV header cell such as "URL" without surfacing it as unmatched.
+			if ( '' === $value || ( ! \is_numeric( $value ) && ! \str_contains( $value, '.' ) ) ) {
+				continue;
+			}
+			$identifiers[ $value ] = $value;
+		}
+
+		return \array_values( $identifiers );
+	}
+
+	/**
+	 * Reads the first column of a CSV file.
+	 *
+	 * @param   string $path The path to the CSV file.
+	 *
+	 * @return  string[]
+	 *
+	 * @throws  \RuntimeException If the file cannot be opened.
+	 */
+	private function read_csv_first_column( string $path ): array {
+		$handle = \fopen( $path, 'r' );
+		if ( false === $handle ) {
+			throw new \RuntimeException( "Could not open the sites file `$path`." );
+		}
+
+		$values = array();
+		while ( false !== ( $row = \fgetcsv( $handle, 0, ',', '"', '' ) ) ) {
+			if ( isset( $row[0] ) ) {
+				$values[] = $row[0];
+			}
+		}
+		\fclose( $handle );
+
+		return $values;
+	}
+
+	/**
+	 * Matches the requested identifiers against the connected fleet.
+	 *
+	 * @param   string[] $identifiers The requested site URLs and/or numeric WPCOM IDs.
+	 * @param   array    $all_sites   The connected Jetpack sites, keyed by WPCOM ID.
+	 *
+	 * @return  array A two-element list: the matched sites keyed by WPCOM ID, and the unmatched identifiers.
+	 */
+	private function resolve_sites( array $identifiers, array $all_sites ): array {
+		$matched   = array();
+		$unmatched = array();
+
+		foreach ( $identifiers as $identifier ) {
+			$key = $this->match_site( $identifier, $all_sites );
+			if ( \is_null( $key ) ) {
+				$unmatched[] = $identifier;
+				continue;
+			}
+			$matched[ $key ] = $all_sites[ $key ];
+		}
+
+		return array( $matched, $unmatched );
+	}
+
+	/**
+	 * Finds the fleet key for a single requested identifier, by numeric WPCOM ID or by host.
+	 *
+	 * @param   string $identifier The requested site URL or numeric WPCOM ID.
+	 * @param   array  $all_sites  The connected Jetpack sites, keyed by WPCOM ID.
+	 *
+	 * @return  int|string|null The matching fleet key, or null when no site matches.
+	 */
+	private function match_site( string $identifier, array $all_sites ): int|string|null {
+		if ( \is_numeric( $identifier ) ) {
+			foreach ( $all_sites as $key => $site ) {
+				if ( (string) $site->userblog_id === $identifier ) {
+					return $key;
+				}
+			}
+		}
+
+		$needle = $this->normalize_host( $identifier );
+		if ( '' !== $needle ) {
+			foreach ( $all_sites as $key => $site ) {
+				if ( $this->normalize_host( (string) ( $site->siteurl ?? '' ) ) === $needle ) {
+					return $key;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Normalizes a URL or host to a bare lowercase host for comparison.
+	 *
+	 * @param   string $value The URL or host to normalize.
+	 *
+	 * @return  string
+	 */
+	private function normalize_host( string $value ): string {
+		$value = \strtolower( \trim( $value ) );
+		$value = \preg_replace( '#^https?://#', '', $value );
+		$value = \preg_replace( '#/.*$#', '', $value );
+
+		return $value;
+	}
+
+	/**
+	 * Classifies a site's outcome from its installed and resulting versions.
+	 *
+	 * With `--release` set, the site is compared to the release being published, so a newer
+	 * (e.g. test) build surfaces as `ahead` and one the release has not reached as `behind`.
+	 * Without it, the result is simply whether the version moved forward.
+	 *
+	 * @param   string $was The version installed before the update.
+	 * @param   string $now The version reported after the update.
+	 *
+	 * @return  string One of `updated`, `current`, `ahead`, `behind`.
+	 */
+	private function classify( string $was, string $now ): string {
+		if ( ! empty( $this->release ) ) {
+			$against_release = \version_compare( $this->normalize_version( $now ), $this->normalize_version( $this->release ) );
+			if ( $against_release > 0 ) {
+				return 'ahead';
+			}
+			if ( $against_release < 0 ) {
+				return 'behind';
+			}
+		}
+
+		return \version_compare( $this->normalize_version( $was ), $this->normalize_version( $now ), '<' ) ? 'updated' : 'current';
+	}
+
+	/**
+	 * Formats a result label with colour/emphasis so anomalies stand out in the table.
+	 *
+	 * @param   string $result The result label.
+	 *
+	 * @return  string
+	 */
+	private function format_result( string $result ): string {
+		return match ( $result ) {
+			'updated' => '<fg=green>updated</>',
+			'ahead'   => '<fg=yellow;options=bold>⚠ ahead</>',
+			'behind'  => '<fg=red;options=bold>✗ behind</>',
+			'failed'  => '<fg=red>failed</>',
+			default   => $result,
+		};
+	}
+
+	/**
+	 * Normalizes a version string for comparison (drops a leading `v`).
+	 *
+	 * @param   string $version The version string.
+	 *
+	 * @return  string
+	 */
+	private function normalize_version( string $version ): string {
+		return \ltrim( \trim( $version ), 'vV' );
 	}
 
 	// endregion

--- a/commands/Jetpack_Plugin_Update.php
+++ b/commands/Jetpack_Plugin_Update.php
@@ -22,18 +22,6 @@ final class Jetpack_Plugin_Update extends Command {
 	// region FIELDS AND CONSTANTS
 
 	/**
-	 * Number of sites per batch when force-installing (each install is a real download + overwrite).
-	 */
-	private const FORCE_BATCH_SIZE = 30;
-
-	/**
-	 * Number of sites per batch when refreshing the update-check. Matches the server-side `maxItems`
-	 * on `sites/batch/atlantis-force-check`: that route fans out one concurrent tunnelled POST per
-	 * site with no chunking, so the client keeps each request self-limiting.
-	 */
-	private const REFRESH_BATCH_SIZE = 30;
-
-	/**
 	 * The plugin slug to update (matched against folder name, main file name, and textdomain).
 	 *
 	 * @var string|null
@@ -81,6 +69,20 @@ final class Jetpack_Plugin_Update extends Command {
 	 * @var bool|null
 	 */
 	private ?bool $reinstall = null;
+
+	/**
+	 * With --force, whether to also overwrite sites ahead of the package version (deliberate downgrade).
+	 *
+	 * @var bool|null
+	 */
+	private ?bool $downgrade = null;
+
+	/**
+	 * Optional environment filter applied to the chosen sites: `staging` or `production` (by URL substring).
+	 *
+	 * @var string|null
+	 */
+	private ?string $environment = null;
 
 	/**
 	 * The plugin version contained in the package (read from the zip, or --release as a fallback).
@@ -134,10 +136,12 @@ final class Jetpack_Plugin_Update extends Command {
 		$this->addArgument( 'plugin', InputArgument::REQUIRED, 'The plugin to update. The term is matched exactly against the folder name, the main file name, and the textdomain.' );
 
 		$this->addOption( 'sites', null, InputOption::VALUE_REQUIRED, 'Which sites to update: `all` for the whole connected fleet, a comma-separated list of site URLs and/or numeric WPCOM IDs, or a path to a CSV file whose first column holds the site URLs.' )
+			->addOption( 'environment', null, InputOption::VALUE_REQUIRED, 'Restrict the chosen sites by environment: `staging` acts only on sites whose URL contains "staging"; `production` skips every site whose URL contains "staging". Applied after --sites.' )
 			->addOption( 'release', null, InputOption::VALUE_REQUIRED, 'The plugin version you are publishing. When set, each site is reported as updated / current / ahead / behind relative to it, so sites running a newer (e.g. test) build, or ones the release has not reached, are surfaced.' )
-			->addOption( 'force', null, InputOption::VALUE_NONE, 'Force-install the plugin from --package, overwriting it in place. Installs only on sites whose version is below the package version; sites already at that version are skipped and sites ahead of it are never touched (no downgrades). Bypasses update detection entirely — use this when a just-published release has not propagated to sites yet.' )
+			->addOption( 'force', null, InputOption::VALUE_NONE, 'Force-install the plugin from --package, overwriting it in place. Installs only on sites whose version is below the package version; sites already at that version are skipped (see --reinstall) and sites ahead of it are never touched (see --downgrade). Bypasses update detection entirely — use this when a just-published release has not propagated to sites yet.' )
 			->addOption( 'package', null, InputOption::VALUE_REQUIRED, 'The plugin zip URL to install. Required with --force (e.g. a GitHub release asset URL).' )
 			->addOption( 'reinstall', null, InputOption::VALUE_NONE, 'With --force, also overwrite sites already at the package version (a same-version reinstall). Sites ahead of the package version are still never touched.' )
+			->addOption( 'downgrade', null, InputOption::VALUE_NONE, 'With --force, ALSO overwrite sites running a version NEWER than the package — i.e. roll them back to the package version. This deliberately bypasses the no-downgrade guard; use it to recover sites stuck on a broken newer build. Destructive: newer builds are replaced with the (older) package.' )
 			->addOption( 'refresh', null, InputOption::VALUE_NONE, 'Before updating, force the targeted sites to re-check for updates (via the Atlantis lever) so a just-published wp.org or WooCommerce.com release is detected even if their update cache has not refreshed yet. Runs synchronously against the sites you chose with --sites. Applies to the default update path; has no effect with --force, which bypasses update detection.' )
 			->addOption( 'dry-run', null, InputOption::VALUE_NONE, 'List the sites that would be updated without updating them.' )
 			->addOption( 'yes', null, InputOption::VALUE_NONE, 'Skip the confirmation prompt before updating.' );
@@ -146,9 +150,11 @@ final class Jetpack_Plugin_Update extends Command {
 	/**
 	 * {@inheritDoc}
 	 *
-	 * @throws \InvalidArgumentException If `--sites` is missing/unmatched, or an option is misused
-	 *                                   (`--force` without `--package`; `--package`/`--reinstall` without
-	 *                                   `--force`; `--refresh` with `--force`).
+	 * @throws \InvalidArgumentException If `--sites` is missing/unmatched, no sites survive the
+	 *                                   `--environment` filter, an unknown `--environment` value is given, or
+	 *                                   an option is misused (`--force` without `--package`;
+	 *                                   `--package`/`--reinstall`/`--downgrade` without `--force`; `--refresh`
+	 *                                   with `--force`).
 	 * @throws \RuntimeException         If the connected fleet, the sites' installed plugins, or the
 	 *                                   `--package` zip cannot be fetched.
 	 */
@@ -156,84 +162,44 @@ final class Jetpack_Plugin_Update extends Command {
 		$this->plugin = get_string_input( $input, 'plugin', fn() => $this->prompt_plugin_input( $input, $output ) );
 		$input->setArgument( 'plugin', $this->plugin );
 
-		$this->release   = maybe_get_string_input( $input, 'release' );
-		$this->dry_run   = get_bool_input( $input, 'dry-run' );
-		$this->yes       = get_bool_input( $input, 'yes' );
-		$this->force     = get_bool_input( $input, 'force' );
-		$this->reinstall = get_bool_input( $input, 'reinstall' );
-		$this->package   = maybe_get_string_input( $input, 'package' );
-		$this->refresh   = get_bool_input( $input, 'refresh' );
+		$this->release     = maybe_get_string_input( $input, 'release' );
+		$this->dry_run     = get_bool_input( $input, 'dry-run' );
+		$this->yes         = get_bool_input( $input, 'yes' );
+		$this->force       = get_bool_input( $input, 'force' );
+		$this->reinstall   = get_bool_input( $input, 'reinstall' );
+		$this->downgrade   = get_bool_input( $input, 'downgrade' );
+		$this->package     = maybe_get_string_input( $input, 'package' );
+		$this->refresh     = get_bool_input( $input, 'refresh' );
+		$this->environment = maybe_get_string_input( $input, 'environment' );
 
 		// Reject misused option combinations instead of silently ignoring them.
-		if ( $this->force && empty( $this->package ) ) {
-			throw new \InvalidArgumentException( 'The --force option requires --package <zip-url> (e.g. a GitHub release asset URL).' );
-		}
-		if ( ! $this->force && ! empty( $this->package ) ) {
-			throw new \InvalidArgumentException( 'The --package option only applies to --force.' );
-		}
-		if ( ! $this->force && $this->reinstall ) {
-			throw new \InvalidArgumentException( 'The --reinstall option only applies to --force.' );
-		}
-		if ( $this->refresh && $this->force ) {
-			throw new \InvalidArgumentException( 'The --refresh option applies to the detection-based update path and has no effect with --force (which bypasses update detection). Use one or the other.' );
-		}
+		validate_wpcom_plugin_update_options( (bool) $this->force, $this->package, (bool) $this->reinstall, (bool) $this->downgrade, (bool) $this->refresh, $this->environment );
 
 		$sites_spec = get_string_input( $input, 'sites', fn() => $this->prompt_sites_input( $input, $output ) );
 
-		$all_sites = get_wpcom_jetpack_sites();
-		if ( \is_null( $all_sites ) ) {
-			throw new \RuntimeException( 'Could not fetch the connected Jetpack sites from WPCOM.' );
-		}
-		$output->writeln( '<comment>Successfully fetched ' . \count( $all_sites ) . ' connected Jetpack site(s).</comment>' );
+		// Resolve, filter, inventory, and plan via the shared planner (single source of the no-downgrade guard).
+		$plan = build_wpcom_plugin_update_plan( $this->plugin, $sites_spec, $this->environment, (bool) $this->force, $this->package, $this->release, (bool) $this->reinstall, (bool) $this->downgrade );
 
-		if ( 'all' === \strtolower( \trim( $sites_spec ) ) ) {
-			$this->sites = $all_sites;
-		} else {
-			[ $matched, $unmatched ] = $this->resolve_sites( $this->parse_requested_identifiers( $sites_spec ), $all_sites );
+		$this->sites          = $plan['sites'];
+		$this->targets        = $plan['targets'];
+		$this->target_version = $plan['target_version'];
+		$this->unqueryable    = $plan['unqueryable'];
 
-			if ( ! empty( $unmatched ) ) {
+		// Surface how the fleet was narrowed, mirroring what the planner did.
+		$output->writeln( '<comment>Successfully fetched ' . $plan['fetched_count'] . ' connected Jetpack site(s).</comment>' );
+		if ( 'all' !== \strtolower( \trim( $sites_spec ) ) ) {
+			if ( ! empty( $plan['unmatched'] ) ) {
 				$output->writeln( '<comment>⚠ Not found in the connected fleet, skipped:</comment>' );
-				foreach ( $unmatched as $identifier ) {
+				foreach ( $plan['unmatched'] as $identifier ) {
 					$output->writeln( "  - $identifier" );
 				}
 			}
-			if ( empty( $matched ) ) {
-				throw new \InvalidArgumentException( 'None of the requested sites were found in the connected Jetpack fleet.' );
-			}
-
-			$this->sites = $matched;
-			$output->writeln( '<comment>Matched ' . \count( $matched ) . ' of the requested site(s).</comment>' );
+			$output->writeln( '<comment>Matched ' . $plan['matched_count'] . ' of the requested site(s).</comment>' );
 		}
-
-		// Fetch the plugins installed on the target sites and compile the list of sites to update.
-		$plugins = get_wpcom_site_plugins_batch( \array_column( $this->sites, 'userblog_id' ), $errors );
-		if ( \is_null( $plugins ) ) {
-			throw new \RuntimeException( 'Could not fetch the installed plugins for the requested sites from WPCOM.' );
+		if ( ! \is_null( $this->environment ) ) {
+			$output->writeln( '<comment>Environment filter `' . $this->environment . '`: kept ' . $plan['env_after'] . ' of ' . $plan['env_before'] . ' site(s).</comment>' );
 		}
-		$this->unqueryable = \is_array( $errors ) ? $errors : array();
 		maybe_output_wpcom_failed_sites_table( $output, $this->unqueryable, $this->sites, 'Sites that could NOT be queried for plugins' );
-
-		$this->targets = array();
-		foreach ( $plugins as $site_id => $site_plugins ) {
-			foreach ( $site_plugins as $plugin_file => $plugin_data ) {
-				if ( ! $this->is_exact_match( $plugin_data, \dirname( $plugin_file ), \basename( $plugin_file, '.php' ) ) ) {
-					continue;
-				}
-
-				$this->targets[ $site_id ] = array(
-					'name'      => \preg_replace( '/\.php$/', '', $plugin_file ),
-					'folder'    => \dirname( $plugin_file ),
-					// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-					'installed' => (string) $plugin_data->Version,
-					'siteurl'   => (string) ( $this->sites[ $site_id ]->siteurl ?? '' ),
-				);
-				break; // One match per site is enough.
-			}
-		}
-
-		if ( $this->force && ! empty( $this->targets ) ) {
-			$this->plan_force_install();
-		}
 	}
 
 	/**
@@ -265,6 +231,16 @@ final class Jetpack_Plugin_Update extends Command {
 			}
 			if ( $skipped_current > 0 ) {
 				$output->writeln( "<comment>Skipping $skipped_current site(s) already at $this->target_version — pass --reinstall to overwrite them too.</comment>" );
+			}
+			$to_downgrade = \count(
+				\array_filter(
+					$this->targets,
+					fn( $target ) => 'install' === ( $target['plan'] ?? 'install' )
+						&& \version_compare( normalize_version_string( $target['installed'] ), normalize_version_string( (string) $this->target_version ), '>' )
+				)
+			);
+			if ( $to_downgrade > 0 ) {
+				$output->writeln( "<fg=red;options=bold>⚠ DOWNGRADE: $to_downgrade site(s) are NEWER than $this->target_version and will be ROLLED BACK to it — newer builds get overwritten with the older package.</>" );
 			}
 			if ( empty( $install_ids ) ) {
 				if ( ! empty( $this->unqueryable ) ) {
@@ -305,23 +281,32 @@ final class Jetpack_Plugin_Update extends Command {
 			}
 		}
 
+		$progress = fn( string $message ) => $output->writeln( $message );
+
+		// Refresh the update-check first (detection path only) so a just-published release is detected,
+		// naming any sites the refresh could not reach or re-check so they are not assumed done.
 		if ( $this->refresh ) {
-			$this->run_refresh( $output );
+			$refresh = run_wpcom_plugin_update_refresh( \array_keys( $this->targets ), $progress );
+			maybe_output_wpcom_failed_sites_table( $output, $refresh['unreachable'], $this->sites, 'Sites that could NOT be reached to refresh' );
+			maybe_output_wpcom_failed_sites_table( $output, $refresh['unrefreshed'], $this->sites, 'Sites in a failed refresh batch (not re-checked)' );
 		}
 
-		if ( $this->force ) {
-			$output->writeln( "<fg=magenta;options=bold>Force-installing `$this->plugin` ($this->target_version) across " . \count( $install_ids ) . ' site(s).</>' );
-			[ $results, $errors ] = $this->run_force_install( $output, $install_ids );
-		} else {
-			$output->writeln( "<fg=magenta;options=bold>Updating `$this->plugin` across " . \count( $install_ids ) . ' site(s).</>' );
-			[ $results, $errors ] = $this->run_update( $output );
-		}
+		$output->writeln(
+			$this->force
+				? "<fg=magenta;options=bold>Force-installing `$this->plugin` ($this->target_version) across " . \count( $install_ids ) . ' site(s).</>'
+				: "<fg=magenta;options=bold>Updating `$this->plugin` across " . \count( $install_ids ) . ' site(s).</>'
+		);
+
+		$execution = execute_wpcom_plugin_update_plan( array( 'targets' => $this->targets ), (bool) $this->force, $this->package, $progress );
+		$results   = $execution['results'];
+		$errors    = $execution['errors'];
 
 		// Build the results table.
 		$rows   = array();
 		$counts = array(
 			'updated'     => 0,
 			'reinstalled' => 0,
+			'downgraded'  => 0,
 			'current'     => 0,
 			'ahead'       => 0,
 			'behind'      => 0,
@@ -345,8 +330,14 @@ final class Jetpack_Plugin_Update extends Command {
 				// installed version actually equalling the target so a below-target site whose response
 				// carried no version is not mislabelled.
 				if ( $this->force && $this->reinstall && 'current' === $result
-					&& 0 === \version_compare( $this->normalize_version( $was ), $this->normalize_version( (string) $this->target_version ) ) ) {
+					&& 0 === \version_compare( normalize_version_string( $was ), normalize_version_string( (string) $this->target_version ) ) ) {
 					$result = 'reinstalled';
+				}
+				// A forced --downgrade succeeded: the site was ahead of the package and was rolled back.
+				// classify() reads the backwards version move as `current`, so label it `downgraded` instead.
+				if ( $this->force && $this->downgrade
+					&& \version_compare( normalize_version_string( $was ), normalize_version_string( (string) $this->target_version ), '>' ) ) {
+					$result = 'downgraded';
 				}
 			} else {
 				$result = 'failed';
@@ -366,6 +357,9 @@ final class Jetpack_Plugin_Update extends Command {
 		$summary = "Updated: {$counts['updated']} | Current: {$counts['current']}";
 		if ( $this->force ) {
 			$summary .= " | Reinstalled: {$counts['reinstalled']}";
+			if ( $counts['downgraded'] > 0 ) {
+				$summary .= " | Downgraded: {$counts['downgraded']}";
+			}
 		}
 		if ( $this->force || ! empty( $this->release ) ) {
 			$summary .= " | Ahead: {$counts['ahead']} | Behind: {$counts['behind']}";
@@ -407,227 +401,10 @@ final class Jetpack_Plugin_Update extends Command {
 
 	// region HELPERS
 
-	/**
-	 * Updates the plugin on every target site via the WPCOM update endpoint (version-gated).
-	 *
-	 * @param   OutputInterface $output The output interface.
-	 *
-	 * @return  array A two-element list: per-site results and per-site errors, both keyed by site ID.
-	 */
-	private function run_update( OutputInterface $output ): array {
-		// Group by plugin identifier (near-always a single group) and update each group in one batch call.
-		$groups = array();
-		foreach ( $this->targets as $site_id => $target ) {
-			$groups[ $target['name'] ][] = $site_id;
-		}
 
-		$results = array();
-		$errors  = array();
-		foreach ( $groups as $plugin_name => $site_ids ) {
-			$group_results = update_wpcom_site_plugins_batch( $site_ids, $plugin_name, $group_errors );
-			if ( \is_null( $group_results ) ) {
-				$output->writeln( "<error>The update request failed for plugin `$plugin_name`.</error>" );
-				continue;
-			}
-			$results += $group_results;
-			$errors  += $group_errors ?? array();
-		}
 
-		return array( $results, $errors );
-	}
 
-	/**
-	 * Forces a fresh update-check on the targeted sites before updating.
-	 *
-	 * Calls the Atlantis lever (via OpsOasis, over the authenticated Jetpack REST tunnel) on the sites
-	 * that have the plugin, so each clears its update cache and re-detects a just-published release
-	 * synchronously — before we call the version-gated update endpoint. Best-effort: sites that can't be
-	 * reached (no Atlantis, or connection down) are reported, and the update still proceeds.
-	 *
-	 * @param   OutputInterface $output The output interface.
-	 *
-	 * @return  void
-	 */
-	private function run_refresh( OutputInterface $output ): void {
-		$site_ids = \array_keys( $this->targets );
-		$chunks   = \array_chunk( $site_ids, self::REFRESH_BATCH_SIZE );
-		$total    = \count( $chunks );
-		$output->writeln( '<fg=magenta;options=bold>Refreshing the update-check on ' . \count( $site_ids ) . ' site(s)…</>' );
 
-		$results     = array();
-		$errors      = array();
-		$unrefreshed = array();
-		$any_batch   = false;
-		foreach ( $chunks as $index => $chunk ) {
-			if ( $total > 1 ) {
-				$output->writeln( '<comment>Batch ' . ( $index + 1 ) . "/$total: refreshing " . \count( $chunk ) . ' site(s)…</comment>' );
-			}
-			$chunk_results = force_check_wpcom_site_plugins_batch( $chunk, $chunk_errors );
-			if ( \is_null( $chunk_results ) ) {
-				$output->writeln( '<comment>⚠ The refresh request failed for this batch.</comment>' );
-				// Record the whole chunk so its sites are not silently dropped from the coverage summary.
-				$unrefreshed += \array_fill_keys( $chunk, 'The batch refresh request failed (e.g. timeout).' );
-				continue;
-			}
-			$any_batch = true;
-			$results  += $chunk_results;
-			$errors   += $chunk_errors ?? array();
-		}
-
-		if ( ! $any_batch ) {
-			$output->writeln( '<comment>⚠ No refresh batch succeeded; proceeding anyway (sites that already detected the release will still update).</comment>' );
-		}
-
-		// State coverage explicitly: a failed batch must not read as full coverage and leave its sites
-		// reported "current" at exit 0.
-		$notes = array();
-		if ( \count( $errors ) > 0 ) {
-			$notes[] = \count( $errors ) . ' could not be reached (no Atlantis or connection down)';
-		}
-		if ( \count( $unrefreshed ) > 0 ) {
-			$notes[] = \count( $unrefreshed ) . ' were in a failed batch and not re-checked';
-		}
-		$suffix = empty( $notes ) ? '' : '; ' . \implode( '; ', $notes ) . ' and may not detect the release';
-		$output->writeln( '<comment>Refreshed ' . \count( $results ) . ' of ' . \count( $site_ids ) . ' site(s)' . $suffix . '.</comment>' );
-
-		// Name the sites that were skipped, so they can be re-run or investigated rather than assumed done.
-		maybe_output_wpcom_failed_sites_table( $output, $errors, $this->sites, 'Sites that could NOT be reached to refresh' );
-		maybe_output_wpcom_failed_sites_table( $output, $unrefreshed, $this->sites, 'Sites in a failed refresh batch (not re-checked)' );
-	}
-
-	/**
-	 * Force-installs the package on the given sites via the WPCOM replace endpoint, in batches.
-	 *
-	 * @param   OutputInterface $output      The output interface.
-	 * @param   array           $install_ids The site IDs to install on (already filtered by plan).
-	 *
-	 * @return  array A two-element list: per-site results and per-site errors, both keyed by site ID.
-	 */
-	private function run_force_install( OutputInterface $output, array $install_ids ): array {
-		// Group by plugin folder (the replace slug); near-always a single group.
-		$groups = array();
-		foreach ( $install_ids as $site_id ) {
-			$groups[ $this->targets[ $site_id ]['folder'] ][] = $site_id;
-		}
-
-		$results = array();
-		$errors  = array();
-		foreach ( $groups as $slug => $site_ids ) {
-			$chunks = \array_chunk( $site_ids, self::FORCE_BATCH_SIZE );
-			$total  = \count( $chunks );
-			foreach ( $chunks as $index => $chunk ) {
-				$output->writeln( '<comment>Batch ' . ( $index + 1 ) . "/$total: force-installing on " . \count( $chunk ) . ' site(s)…</comment>' );
-				$chunk_results = replace_wpcom_site_plugins_batch( $chunk, $slug, $this->package, $chunk_errors );
-				if ( \is_null( $chunk_results ) ) {
-					$output->writeln( '<error>The force-install request failed for this batch.</error>' );
-					continue;
-				}
-				$results += $chunk_results;
-				$errors  += $chunk_errors ?? array();
-			}
-		}
-
-		return array( $results, $errors );
-	}
-
-	/**
-	 * Resolves the package version and tags each target with a force-install plan.
-	 *
-	 * The plan enforces the version rules for --force: sites below the package version are installed,
-	 * sites already at it are skipped (unless --reinstall), and sites ahead of it are never touched.
-	 *
-	 * @return  void
-	 *
-	 * @throws  \RuntimeException If the package version cannot be determined (no zip version, no --release).
-	 */
-	private function plan_force_install(): void {
-		$this->target_version = $this->resolve_package_version() ?? $this->release;
-		if ( empty( $this->target_version ) ) {
-			throw new \RuntimeException( 'Could not read the plugin version from the package. Pass --release <version> so already-current and ahead sites can be detected and skipped, or check the --package URL.' );
-		}
-
-		foreach ( $this->targets as $site_id => $target ) {
-			$comparison = \version_compare( $this->normalize_version( $target['installed'] ), $this->normalize_version( $this->target_version ) );
-			if ( $comparison > 0 ) {
-				$this->targets[ $site_id ]['plan'] = 'ahead';   // Never overwrite a newer build.
-			} elseif ( 0 === $comparison && ! $this->reinstall ) {
-				$this->targets[ $site_id ]['plan'] = 'current'; // Already at the target; skip unless --reinstall.
-			} else {
-				$this->targets[ $site_id ]['plan'] = 'install';
-			}
-		}
-	}
-
-	/**
-	 * Reads the plugin version from the package zip's header.
-	 *
-	 * @return  string|null The version, or null if the (successfully downloaded) package has no readable
-	 *                      version header.
-	 *
-	 * @throws  \RuntimeException If a local temp file cannot be created, or the package URL cannot be
-	 *                            downloaded (curl error or non-2xx response) — force-installing an
-	 *                            unfetchable URL would fail on every site.
-	 */
-	private function resolve_package_version(): ?string {
-		$tmp = \tempnam( \sys_get_temp_dir(), 't51pkg' );
-		if ( false === $tmp ) {
-			throw new \RuntimeException( 'Could not create a local temporary file to download the package into.' );
-		}
-
-		$handle = \fopen( $tmp, 'wb' );
-		if ( false === $handle ) {
-			\unlink( $tmp );
-			throw new \RuntimeException( 'Could not open a local temporary file to download the package into.' );
-		}
-
-		$curl = \curl_init( $this->package );
-		\curl_setopt_array(
-			$curl,
-			array(
-				\CURLOPT_FILE           => $handle,
-				\CURLOPT_FOLLOWLOCATION => true,
-				\CURLOPT_TIMEOUT        => 60,
-			)
-		);
-		$downloaded = \curl_exec( $curl );
-		$http_code  = (int) \curl_getinfo( $curl, \CURLINFO_RESPONSE_CODE );
-		$curl_error = \curl_error( $curl );
-		\curl_close( $curl );
-		\fclose( $handle );
-
-		// A bad --package URL is a hard error: don't silently fall back to --release and push a URL that
-		// already failed to fetch locally out to the whole fleet.
-		if ( false === $downloaded || $http_code < 200 || $http_code >= 300 ) {
-			\unlink( $tmp );
-			$detail = '' !== $curl_error ? $curl_error : "HTTP $http_code";
-			throw new \RuntimeException( "Could not download the package from `$this->package` ($detail)." );
-		}
-
-		$version = null;
-		if ( \class_exists( '\ZipArchive' ) ) {
-			$zip = new \ZipArchive();
-			if ( true === $zip->open( $tmp ) ) {
-				for ( $index = 0; $index < $zip->numFiles; $index++ ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-					$name = (string) $zip->getNameIndex( $index );
-					if ( ! \preg_match( '#^[^/]+/[^/]+\.php$#', $name ) ) {
-						continue; // Only top-level PHP files inside the plugin folder.
-					}
-					$contents = $zip->getFromIndex( $index, 8192 );
-					if ( false === $contents || false === \stripos( $contents, 'Plugin Name:' ) ) {
-						continue;
-					}
-					if ( \preg_match( '/^[ \t\/*#@]*Version:\s*(\S+)/mi', $contents, $matches ) ) {
-						$version = \trim( $matches[1] );
-						break;
-					}
-				}
-				$zip->close();
-			}
-		}
-
-		\unlink( $tmp );
-		return $version;
-	}
 
 	/**
 	 * Prompts the user for the plugin term to update.
@@ -642,20 +419,6 @@ final class Jetpack_Plugin_Update extends Command {
 		return $this->getHelper( 'question' )->ask( $input, $output, $question );
 	}
 
-	/**
-	 * Checks if the plugin data matches the search term exactly.
-	 *
-	 * @param   \stdClass $plugin_data   The plugin data.
-	 * @param   string    $plugin_folder The plugin folder.
-	 * @param   string    $plugin_file   The plugin file.
-	 *
-	 * @return  boolean
-	 */
-	private function is_exact_match( \stdClass $plugin_data, string $plugin_folder, string $plugin_file ): bool {
-		return $this->plugin === $plugin_data->TextDomain // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-			|| $this->plugin === $plugin_folder
-			|| $this->plugin === $plugin_file;
-	}
 
 	/**
 	 * Prompts the user for the sites to update.
@@ -670,127 +433,10 @@ final class Jetpack_Plugin_Update extends Command {
 		return (string) $this->getHelper( 'question' )->ask( $input, $output, $question );
 	}
 
-	/**
-	 * Parses the `--sites` value into a list of requested site identifiers.
-	 *
-	 * The value is either a path to a CSV file (first column holds the site URLs) or a
-	 * comma-separated list of URLs and/or numeric WPCOM IDs. Blank and implausible entries
-	 * (such as a CSV header row) are dropped.
-	 *
-	 * @param   string $spec The raw `--sites` value.
-	 *
-	 * @return  string[]
-	 */
-	private function parse_requested_identifiers( string $spec ): array {
-		$raw = \is_file( $spec ) ? $this->read_csv_first_column( $spec ) : \explode( ',', $spec );
 
-		$identifiers = array();
-		foreach ( $raw as $value ) {
-			$value = \trim( (string) $value );
-			// Keep only plausible identifiers: numeric WPCOM IDs, or values that look like a domain.
-			// This also discards a CSV header cell such as "URL" without surfacing it as unmatched.
-			if ( '' === $value || ( ! \is_numeric( $value ) && ! \str_contains( $value, '.' ) ) ) {
-				continue;
-			}
-			$identifiers[ $value ] = $value;
-		}
 
-		return \array_values( $identifiers );
-	}
 
-	/**
-	 * Reads the first column of a CSV file.
-	 *
-	 * @param   string $path The path to the CSV file.
-	 *
-	 * @return  string[]
-	 *
-	 * @throws  \RuntimeException If the file cannot be opened.
-	 */
-	private function read_csv_first_column( string $path ): array {
-		$handle = \fopen( $path, 'r' );
-		if ( false === $handle ) {
-			throw new \RuntimeException( "Could not open the sites file `$path`." );
-		}
 
-		$values = array();
-		while ( false !== ( $row = \fgetcsv( $handle, 0, ',', '"', '' ) ) ) {
-			if ( isset( $row[0] ) ) {
-				$values[] = $row[0];
-			}
-		}
-		\fclose( $handle );
-
-		return $values;
-	}
-
-	/**
-	 * Matches the requested identifiers against the connected fleet.
-	 *
-	 * @param   string[] $identifiers The requested site URLs and/or numeric WPCOM IDs.
-	 * @param   array    $all_sites   The connected Jetpack sites, keyed by WPCOM ID.
-	 *
-	 * @return  array A two-element list: the matched sites keyed by WPCOM ID, and the unmatched identifiers.
-	 */
-	private function resolve_sites( array $identifiers, array $all_sites ): array {
-		$matched   = array();
-		$unmatched = array();
-
-		foreach ( $identifiers as $identifier ) {
-			$key = $this->match_site( $identifier, $all_sites );
-			if ( \is_null( $key ) ) {
-				$unmatched[] = $identifier;
-				continue;
-			}
-			$matched[ $key ] = $all_sites[ $key ];
-		}
-
-		return array( $matched, $unmatched );
-	}
-
-	/**
-	 * Finds the fleet key for a single requested identifier, by numeric WPCOM ID or by host.
-	 *
-	 * @param   string $identifier The requested site URL or numeric WPCOM ID.
-	 * @param   array  $all_sites  The connected Jetpack sites, keyed by WPCOM ID.
-	 *
-	 * @return  int|string|null The matching fleet key, or null when no site matches.
-	 */
-	private function match_site( string $identifier, array $all_sites ): int|string|null {
-		if ( \is_numeric( $identifier ) ) {
-			foreach ( $all_sites as $key => $site ) {
-				if ( (string) $site->userblog_id === $identifier ) {
-					return $key;
-				}
-			}
-		}
-
-		$needle = $this->normalize_host( $identifier );
-		if ( '' !== $needle ) {
-			foreach ( $all_sites as $key => $site ) {
-				if ( $this->normalize_host( (string) ( $site->siteurl ?? '' ) ) === $needle ) {
-					return $key;
-				}
-			}
-		}
-
-		return null;
-	}
-
-	/**
-	 * Normalizes a URL or host to a bare lowercase host for comparison.
-	 *
-	 * @param   string $value The URL or host to normalize.
-	 *
-	 * @return  string
-	 */
-	private function normalize_host( string $value ): string {
-		$value = \strtolower( \trim( $value ) );
-		$value = \preg_replace( '#^https?://#', '', $value );
-		$value = \preg_replace( '#/.*$#', '', $value );
-
-		return $value;
-	}
 
 	/**
 	 * Classifies a site's outcome from its installed and resulting versions.
@@ -806,7 +452,7 @@ final class Jetpack_Plugin_Update extends Command {
 	 */
 	private function classify( string $was, string $now ): string {
 		if ( ! empty( $this->release ) ) {
-			$against_release = \version_compare( $this->normalize_version( $now ), $this->normalize_version( $this->release ) );
+			$against_release = \version_compare( normalize_version_string( $now ), normalize_version_string( $this->release ) );
 			if ( $against_release > 0 ) {
 				return 'ahead';
 			}
@@ -815,7 +461,7 @@ final class Jetpack_Plugin_Update extends Command {
 			}
 		}
 
-		return \version_compare( $this->normalize_version( $was ), $this->normalize_version( $now ), '<' ) ? 'updated' : 'current';
+		return \version_compare( normalize_version_string( $was ), normalize_version_string( $now ), '<' ) ? 'updated' : 'current';
 	}
 
 	/**
@@ -829,6 +475,7 @@ final class Jetpack_Plugin_Update extends Command {
 		return match ( $result ) {
 			'updated'     => '<fg=green>updated</>',
 			'reinstalled' => '<fg=green>reinstalled</>',
+			'downgraded'  => '<fg=yellow;options=bold>↓ downgraded</>',
 			'ahead'       => '<fg=yellow;options=bold>⚠ ahead</>',
 			'behind'      => '<fg=red;options=bold>✗ behind</>',
 			'failed'      => '<fg=red>failed</>',
@@ -836,16 +483,6 @@ final class Jetpack_Plugin_Update extends Command {
 		};
 	}
 
-	/**
-	 * Normalizes a version string for comparison (drops a leading `v`).
-	 *
-	 * @param   string $version The version string.
-	 *
-	 * @return  string
-	 */
-	private function normalize_version( string $version ): string {
-		return \ltrim( \trim( $version ), 'vV' );
-	}
 
 	// endregion
 }

--- a/commands/Jetpack_Plugin_Update.php
+++ b/commands/Jetpack_Plugin_Update.php
@@ -27,6 +27,13 @@ final class Jetpack_Plugin_Update extends Command {
 	private const FORCE_BATCH_SIZE = 30;
 
 	/**
+	 * Number of sites per batch when refreshing the update-check. Matches the server-side `maxItems`
+	 * on `sites/batch/atlantis-force-check`: that route fans out one concurrent tunnelled POST per
+	 * site with no chunking, so the client keeps each request self-limiting.
+	 */
+	private const REFRESH_BATCH_SIZE = 30;
+
+	/**
 	 * The plugin slug to update (matched against folder name, main file name, and textdomain).
 	 *
 	 * @var string|null
@@ -443,15 +450,33 @@ final class Jetpack_Plugin_Update extends Command {
 	 */
 	private function run_refresh( OutputInterface $output ): void {
 		$site_ids = \array_keys( $this->targets );
+		$chunks   = \array_chunk( $site_ids, self::REFRESH_BATCH_SIZE );
+		$total    = \count( $chunks );
 		$output->writeln( '<fg=magenta;options=bold>Refreshing the update-check on ' . \count( $site_ids ) . ' site(s)…</>' );
 
-		$results = force_check_wpcom_site_plugins_batch( $site_ids, $errors );
-		if ( \is_null( $results ) ) {
-			$output->writeln( '<comment>⚠ The refresh request failed; proceeding anyway (sites that already detected the release will still update).</comment>' );
+		$results   = array();
+		$errors    = array();
+		$any_batch = false;
+		foreach ( $chunks as $index => $chunk ) {
+			if ( $total > 1 ) {
+				$output->writeln( '<comment>Batch ' . ( $index + 1 ) . "/$total: refreshing " . \count( $chunk ) . ' site(s)…</comment>' );
+			}
+			$chunk_results = force_check_wpcom_site_plugins_batch( $chunk, $chunk_errors );
+			if ( \is_null( $chunk_results ) ) {
+				$output->writeln( '<comment>⚠ The refresh request failed for this batch.</comment>' );
+				continue;
+			}
+			$any_batch = true;
+			$results  += $chunk_results;
+			$errors   += $chunk_errors ?? array();
+		}
+
+		if ( ! $any_batch ) {
+			$output->writeln( '<comment>⚠ No refresh batch succeeded; proceeding anyway (sites that already detected the release will still update).</comment>' );
 			return;
 		}
 
-		$failed = \count( $errors ?? array() );
+		$failed = \count( $errors );
 		$output->writeln( '<comment>Refreshed ' . \count( $results ) . ' site(s)' . ( $failed > 0 ? "; $failed could not be reached (no Atlantis or connection down) and may not detect the release" : '' ) . '.</comment>' );
 	}
 

--- a/commands/Jetpack_Plugin_Update.php
+++ b/commands/Jetpack_Plugin_Update.php
@@ -245,7 +245,9 @@ final class Jetpack_Plugin_Update extends Command {
 			$output->writeln( '<comment>Tip: some sites reported no change — pass --release <version> to distinguish "already current" from "ahead of the release".</comment>' );
 		}
 
-		return ( 0 === $counts['failed'] && 0 === $counts['behind'] ) ? Command::SUCCESS : Command::FAILURE;
+		// Only real per-site errors fail the command; `behind` (the release hasn't propagated to the
+		// plugin's own update source yet) and `ahead` are surfaced as warnings but are not failures.
+		return 0 === $counts['failed'] ? Command::SUCCESS : Command::FAILURE;
 	}
 
 	// endregion

--- a/commands/Jetpack_Plugin_Update.php
+++ b/commands/Jetpack_Plugin_Update.php
@@ -50,46 +50,11 @@ final class Jetpack_Plugin_Update extends Command {
 	private ?bool $yes = null;
 
 	/**
-	 * Whether to force-install the package on every targeted site, bypassing update detection.
-	 *
-	 * @var bool|null
-	 */
-	private ?bool $force = null;
-
-	/**
-	 * The plugin zip URL to force-install (required with --force).
-	 *
-	 * @var string|null
-	 */
-	private ?string $package = null;
-
-	/**
-	 * With --force, whether to also overwrite sites already at the package version (same-version reinstall).
-	 *
-	 * @var bool|null
-	 */
-	private ?bool $reinstall = null;
-
-	/**
-	 * With --force, whether to also overwrite sites ahead of the package version (deliberate downgrade).
-	 *
-	 * @var bool|null
-	 */
-	private ?bool $downgrade = null;
-
-	/**
 	 * Optional environment filter applied to the chosen sites: `staging` or `production` (by URL substring).
 	 *
 	 * @var string|null
 	 */
 	private ?string $environment = null;
-
-	/**
-	 * The plugin version contained in the package (read from the zip, or --release as a fallback).
-	 *
-	 * @var string|null
-	 */
-	private ?string $target_version = null;
 
 	/**
 	 * Whether to make the targeted sites re-check for updates before updating (detection path only).
@@ -107,8 +72,7 @@ final class Jetpack_Plugin_Update extends Command {
 
 	/**
 	 * The sites that have the plugin installed and will be updated, keyed by site ID.
-	 * Each entry: array{ name: string, folder: string, installed: string, siteurl: string, plan?: string }.
-	 * The `plan` key (`install`/`current`/`ahead`) is added by plan_force_install() in --force mode.
+	 * Each entry: array{ name: string, folder: string, installed: string, siteurl: string }.
 	 *
 	 * @var array|null
 	 */
@@ -130,19 +94,15 @@ final class Jetpack_Plugin_Update extends Command {
 	 * {@inheritDoc}
 	 */
 	protected function configure(): void {
-		$this->setDescription( 'Force-updates a given plugin on connected sites where it is installed.' )
-			->setHelp( 'Use this command to push a new plugin release to sites that have the plugin installed. Pass --sites to choose the targets: `all` for the whole connected fleet, a comma-separated list of site URLs and/or WPCOM IDs, or the path to a CSV whose first column holds the site URLs. By default each site is updated via the WPCOM plugin update endpoint, which relies on the site having already detected a newer version from the plugin\'s own update source (wp.org, or a custom Update URI such as GitHub) — so a freshly published release may not reach every site immediately. Pass --force with --package <zip-url> to instead overwrite the plugin in place from a specific zip on every targeted site, bypassing update detection entirely (the deterministic way to push a just-published release fleet-wide). If a release has been published to wp.org but sites have not detected it yet, pass --refresh to make the targeted sites (those chosen with --sites) re-check for updates first (via the Atlantis lever), then update — no force-install needed. Only sites with an active Jetpack connection to WPCOM are processed.' );
+		$this->setDescription( 'Updates a given plugin on connected sites where it is installed.' )
+			->setHelp( 'Use this command to push a new plugin release to sites that have the plugin installed. Pass --sites to choose the targets: `all` for the whole connected fleet, a comma-separated list of site URLs and/or WPCOM IDs, or the path to a CSV whose first column holds the site URLs. Each site is updated via the WPCOM plugin update endpoint, which relies on the site having already detected a newer version from the plugin\'s own update source (wp.org, or a custom Update URI such as GitHub) — so a freshly published release may not reach every site immediately. If a release has been published but sites have not detected it yet, pass --refresh to make the targeted sites (those chosen with --sites) re-check for updates first (via the Atlantis lever), then update. Only sites with an active Jetpack connection to WPCOM are processed.' );
 
 		$this->addArgument( 'plugin', InputArgument::REQUIRED, 'The plugin to update. The term is matched exactly against the folder name, the main file name, and the textdomain.' );
 
 		$this->addOption( 'sites', null, InputOption::VALUE_REQUIRED, 'Which sites to update: `all` for the whole connected fleet, a comma-separated list of site URLs and/or numeric WPCOM IDs, or a path to a CSV file whose first column holds the site URLs.' )
 			->addOption( 'environment', null, InputOption::VALUE_REQUIRED, 'Restrict the chosen sites by environment: `staging` acts only on sites whose URL contains "staging"; `production` skips every site whose URL contains "staging". Applied after --sites.' )
 			->addOption( 'release', null, InputOption::VALUE_REQUIRED, 'The plugin version you are publishing. When set, each site is reported as updated / current / ahead / behind relative to it, so sites running a newer (e.g. test) build, or ones the release has not reached, are surfaced.' )
-			->addOption( 'force', null, InputOption::VALUE_NONE, 'Force-install the plugin from --package, overwriting it in place. Installs only on sites whose version is below the package version; sites already at that version are skipped (see --reinstall) and sites ahead of it are never touched (see --downgrade). Bypasses update detection entirely — use this when a just-published release has not propagated to sites yet.' )
-			->addOption( 'package', null, InputOption::VALUE_REQUIRED, 'The plugin zip URL to install. Required with --force (e.g. a GitHub release asset URL).' )
-			->addOption( 'reinstall', null, InputOption::VALUE_NONE, 'With --force, also overwrite sites already at the package version (a same-version reinstall). Sites ahead of the package version are still never touched.' )
-			->addOption( 'downgrade', null, InputOption::VALUE_NONE, 'With --force, ALSO overwrite sites running a version NEWER than the package — i.e. roll them back to the package version. This deliberately bypasses the no-downgrade guard; use it to recover sites stuck on a broken newer build. Destructive: newer builds are replaced with the (older) package.' )
-			->addOption( 'refresh', null, InputOption::VALUE_NONE, 'Before updating, force the targeted sites to re-check for updates (via the Atlantis lever) so a just-published wp.org or WooCommerce.com release is detected even if their update cache has not refreshed yet. Runs synchronously against the sites you chose with --sites. Applies to the default update path; has no effect with --force, which bypasses update detection.' )
+			->addOption( 'refresh', null, InputOption::VALUE_NONE, 'Before updating, force the targeted sites to re-check for updates (via the Atlantis lever) so a just-published wp.org or WooCommerce.com release is detected even if their update cache has not refreshed yet. Runs synchronously against the sites you chose with --sites.' )
 			->addOption( 'dry-run', null, InputOption::VALUE_NONE, 'List the sites that would be updated without updating them.' )
 			->addOption( 'yes', null, InputOption::VALUE_NONE, 'Skip the confirmation prompt before updating.' );
 	}
@@ -151,12 +111,8 @@ final class Jetpack_Plugin_Update extends Command {
 	 * {@inheritDoc}
 	 *
 	 * @throws \InvalidArgumentException If `--sites` is missing/unmatched, no sites survive the
-	 *                                   `--environment` filter, an unknown `--environment` value is given, or
-	 *                                   an option is misused (`--force` without `--package`;
-	 *                                   `--package`/`--reinstall`/`--downgrade` without `--force`; `--refresh`
-	 *                                   with `--force`).
-	 * @throws \RuntimeException         If the connected fleet, the sites' installed plugins, or the
-	 *                                   `--package` zip cannot be fetched.
+	 *                                   `--environment` filter, or an unknown `--environment` value is given.
+	 * @throws \RuntimeException         If the connected fleet or the sites' installed plugins cannot be fetched.
 	 */
 	protected function initialize( InputInterface $input, OutputInterface $output ): void {
 		$this->plugin = get_string_input( $input, 'plugin', fn() => $this->prompt_plugin_input( $input, $output ) );
@@ -165,25 +121,20 @@ final class Jetpack_Plugin_Update extends Command {
 		$this->release     = maybe_get_string_input( $input, 'release' );
 		$this->dry_run     = get_bool_input( $input, 'dry-run' );
 		$this->yes         = get_bool_input( $input, 'yes' );
-		$this->force       = get_bool_input( $input, 'force' );
-		$this->reinstall   = get_bool_input( $input, 'reinstall' );
-		$this->downgrade   = get_bool_input( $input, 'downgrade' );
-		$this->package     = maybe_get_string_input( $input, 'package' );
 		$this->refresh     = get_bool_input( $input, 'refresh' );
 		$this->environment = maybe_get_string_input( $input, 'environment' );
 
 		// Reject misused option combinations instead of silently ignoring them.
-		validate_wpcom_plugin_update_options( (bool) $this->force, $this->package, (bool) $this->reinstall, (bool) $this->downgrade, (bool) $this->refresh, $this->environment );
+		validate_wpcom_plugin_update_options( $this->environment );
 
 		$sites_spec = get_string_input( $input, 'sites', fn() => $this->prompt_sites_input( $input, $output ) );
 
-		// Resolve, filter, inventory, and plan via the shared planner (single source of the no-downgrade guard).
-		$plan = build_wpcom_plugin_update_plan( $this->plugin, $sites_spec, $this->environment, (bool) $this->force, $this->package, $this->release, (bool) $this->reinstall, (bool) $this->downgrade );
+		// Resolve, filter, and inventory via the shared planner.
+		$plan = build_wpcom_plugin_update_plan( $this->plugin, $sites_spec, $this->environment );
 
-		$this->sites          = $plan['sites'];
-		$this->targets        = $plan['targets'];
-		$this->target_version = $plan['target_version'];
-		$this->unqueryable    = $plan['unqueryable'];
+		$this->sites       = $plan['sites'];
+		$this->targets     = $plan['targets'];
+		$this->unqueryable = $plan['unqueryable'];
 
 		// Surface how the fleet was narrowed, mirroring what the planner did.
 		$output->writeln( '<comment>Successfully fetched ' . $plan['fetched_count'] . ' connected Jetpack site(s).</comment>' );
@@ -215,42 +166,8 @@ final class Jetpack_Plugin_Update extends Command {
 			return Command::SUCCESS;
 		}
 
-		// In force mode, targets carry a plan: only `install` sites are written; `current`/`ahead` are skipped.
-		$install_ids = array();
-		foreach ( $this->targets as $site_id => $target ) {
-			if ( 'install' === ( $target['plan'] ?? 'install' ) ) {
-				$install_ids[] = $site_id;
-			}
-		}
-
-		if ( $this->force ) {
-			$skipped_ahead   = \count( \array_filter( $this->targets, static fn( $target ) => 'ahead' === ( $target['plan'] ?? '' ) ) );
-			$skipped_current = \count( \array_filter( $this->targets, static fn( $target ) => 'current' === ( $target['plan'] ?? '' ) ) );
-			if ( $skipped_ahead > 0 ) {
-				$output->writeln( "<comment>Skipping $skipped_ahead site(s) ahead of $this->target_version — never downgraded.</comment>" );
-			}
-			if ( $skipped_current > 0 ) {
-				$output->writeln( "<comment>Skipping $skipped_current site(s) already at $this->target_version — pass --reinstall to overwrite them too.</comment>" );
-			}
-			$to_downgrade = \count(
-				\array_filter(
-					$this->targets,
-					fn( $target ) => 'install' === ( $target['plan'] ?? 'install' )
-						&& \version_compare( normalize_version_string( $target['installed'] ), normalize_version_string( (string) $this->target_version ), '>' )
-				)
-			);
-			if ( $to_downgrade > 0 ) {
-				$output->writeln( "<fg=red;options=bold>⚠ DOWNGRADE: $to_downgrade site(s) are NEWER than $this->target_version and will be ROLLED BACK to it — newer builds get overwritten with the older package.</>" );
-			}
-			if ( empty( $install_ids ) ) {
-				if ( ! empty( $this->unqueryable ) ) {
-					$this->warn_unqueryable( $output );
-					return Command::FAILURE;
-				}
-				$output->writeln( "<info>Nothing to install: every assessed site is already at or ahead of $this->target_version.</info>" );
-				return Command::SUCCESS;
-			}
-		}
+		// Every matched site is updated via the detection-based update endpoint.
+		$install_ids = \array_keys( $this->targets );
 
 		// Show what will be changed. The matched plugin identifier is shown so a heterogeneous match
 		// (different folders/textdomains across sites) is visible before a fleet-wide overwrite.
@@ -261,7 +178,7 @@ final class Jetpack_Plugin_Update extends Command {
 				$install_ids
 			),
 			array( 'Site ID', 'Site URL', 'Plugin', 'Installed Version' ),
-			'Sites to ' . ( $this->force ? 'force-install' : 'update' ) . " `$this->plugin`"
+			"Sites to update `$this->plugin`"
 		);
 
 		if ( $this->dry_run ) {
@@ -271,9 +188,7 @@ final class Jetpack_Plugin_Update extends Command {
 		}
 
 		if ( ! $this->yes ) {
-			$action   = $this->force
-				? 'Force-install `' . $this->plugin . '` from ' . $this->package . ' on '
-				: ( $this->refresh ? 'Refresh update-checks, then update `' : 'Update `' ) . $this->plugin . '` on ';
+			$action   = ( $this->refresh ? 'Refresh update-checks, then update `' : 'Update `' ) . $this->plugin . '` on ';
 			$question = new ConfirmationQuestion( '<question>' . $action . \count( $install_ids ) . ' site(s)? [y/N]</question> ', false );
 			if ( true !== $this->getHelper( 'question' )->ask( $input, $output, $question ) ) {
 				$output->writeln( '<comment>Aborted. No sites were changed.</comment>' );
@@ -291,57 +206,31 @@ final class Jetpack_Plugin_Update extends Command {
 			maybe_output_wpcom_failed_sites_table( $output, $refresh['unrefreshed'], $this->sites, 'Sites in a failed refresh batch (not re-checked)' );
 		}
 
-		$output->writeln(
-			$this->force
-				? "<fg=magenta;options=bold>Force-installing `$this->plugin` ($this->target_version) across " . \count( $install_ids ) . ' site(s).</>'
-				: "<fg=magenta;options=bold>Updating `$this->plugin` across " . \count( $install_ids ) . ' site(s).</>'
-		);
+		$output->writeln( "<fg=magenta;options=bold>Updating `$this->plugin` across " . \count( $install_ids ) . ' site(s).</>' );
 
-		$execution = execute_wpcom_plugin_update_plan( array( 'targets' => $this->targets ), (bool) $this->force, $this->package, $progress );
+		$execution = execute_wpcom_plugin_update_plan( array( 'targets' => $this->targets ), $progress );
 		$results   = $execution['results'];
 		$errors    = $execution['errors'];
 
 		// Build the results table.
 		$rows   = array();
 		$counts = array(
-			'updated'     => 0,
-			'reinstalled' => 0,
-			'downgraded'  => 0,
-			'current'     => 0,
-			'ahead'       => 0,
-			'behind'      => 0,
-			'failed'      => 0,
+			'updated' => 0,
+			'current' => 0,
+			'ahead'   => 0,
+			'behind'  => 0,
+			'failed'  => 0,
 		);
 		foreach ( $this->targets as $site_id => $target ) {
-			$was  = $target['installed'];
-			$now  = $was;
-			$plan = $target['plan'] ?? 'install';
+			$was = $target['installed'];
+			$now = $was;
 
-			if ( 'install' !== $plan ) {
-				$result = $plan; // Skipped in force mode: `current` or `ahead`, left unchanged.
-			} elseif ( isset( $errors[ $site_id ] ) ) {
+			if ( isset( $errors[ $site_id ] ) ) {
 				$now    = encode_json_content( $errors[ $site_id ]->errors ?? $errors[ $site_id ] );
 				$result = 'failed';
 			} elseif ( isset( $results[ $site_id ] ) ) {
 				$now    = (string) ( $results[ $site_id ]->version ?? $was );
 				$result = $this->classify( $was, $now );
-				// A forced same-version reinstall succeeded but the version didn't move; report it as
-				// `reinstalled` rather than `current`, which would read as "nothing happened". Gate on the
-				// installed version actually equalling the target so a below-target site whose response
-				// carried no version is not mislabelled.
-				if ( $this->force && $this->reinstall && 'current' === $result
-					&& 0 === \version_compare( normalize_version_string( $was ), normalize_version_string( (string) $this->target_version ) ) ) {
-					$result = 'reinstalled';
-				}
-				// A forced --downgrade succeeded: the site was ahead of the package AND the version actually
-				// moved back. classify() reads the backwards move as `current`, so relabel it `downgraded`.
-				// Require the version to have decreased so a version-less replace response (now == was) is
-				// not mislabelled as a rollback that never landed.
-				if ( $this->force && $this->downgrade
-					&& \version_compare( normalize_version_string( $was ), normalize_version_string( (string) $this->target_version ), '>' )
-					&& \version_compare( normalize_version_string( $now ), normalize_version_string( $was ), '<' ) ) {
-					$result = 'downgraded';
-				}
 			} else {
 				$result = 'failed';
 			}
@@ -354,30 +243,23 @@ final class Jetpack_Plugin_Update extends Command {
 			$output,
 			$rows,
 			array( 'Site ID', 'Site URL', 'Was', 'Now', 'Result' ),
-			( $this->force ? 'Force-install' : 'Update' ) . " results for `$this->plugin`"
+			"Update results for `$this->plugin`"
 		);
 
 		$summary = "Updated: {$counts['updated']} | Current: {$counts['current']}";
-		if ( $this->force ) {
-			$summary .= " | Reinstalled: {$counts['reinstalled']}";
-			if ( $counts['downgraded'] > 0 ) {
-				$summary .= " | Downgraded: {$counts['downgraded']}";
-			}
-		}
-		if ( $this->force || ! empty( $this->release ) ) {
+		if ( ! empty( $this->release ) ) {
 			$summary .= " | Ahead: {$counts['ahead']} | Behind: {$counts['behind']}";
 		}
 		$summary .= " | Failed: {$counts['failed']}";
 		$output->writeln( "<info>$summary</info>" );
 
-		$reference = ! empty( $this->target_version ) ? $this->target_version : $this->release;
 		if ( $counts['ahead'] > 0 ) {
-			$output->writeln( "<fg=yellow;options=bold>⚠ {$counts['ahead']} site(s) are AHEAD of `$reference` (running a newer/test build) and were left unchanged.</>" );
+			$output->writeln( "<fg=yellow;options=bold>⚠ {$counts['ahead']} site(s) are AHEAD of `$this->release` (running a newer/test build) and were left unchanged.</>" );
 		}
 		if ( $counts['behind'] > 0 ) {
 			$output->writeln( "<fg=red;options=bold>✗ {$counts['behind']} site(s) are BEHIND `$this->release` — the release did not reach them (its update source may not have it yet).</>" );
 		}
-		if ( ! $this->force && empty( $this->release ) && $counts['current'] > 0 ) {
+		if ( empty( $this->release ) && $counts['current'] > 0 ) {
 			$output->writeln( '<comment>Tip: some sites reported no change — pass --release <version> to distinguish "already current" from "ahead of the release".</comment>' );
 		}
 		$this->warn_unqueryable( $output );
@@ -476,13 +358,11 @@ final class Jetpack_Plugin_Update extends Command {
 	 */
 	private function format_result( string $result ): string {
 		return match ( $result ) {
-			'updated'     => '<fg=green>updated</>',
-			'reinstalled' => '<fg=green>reinstalled</>',
-			'downgraded'  => '<fg=yellow;options=bold>↓ downgraded</>',
-			'ahead'       => '<fg=yellow;options=bold>⚠ ahead</>',
-			'behind'      => '<fg=red;options=bold>✗ behind</>',
-			'failed'      => '<fg=red>failed</>',
-			default       => $result,
+			'updated' => '<fg=green>updated</>',
+			'ahead'   => '<fg=yellow;options=bold>⚠ ahead</>',
+			'behind'  => '<fg=red;options=bold>✗ behind</>',
+			'failed'  => '<fg=red>failed</>',
+			default   => $result,
 		};
 	}
 

--- a/commands/Jetpack_Plugin_Update.php
+++ b/commands/Jetpack_Plugin_Update.php
@@ -1,0 +1,266 @@
+<?php
+
+namespace WPCOMSpecialProjects\CLI\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Question\Question;
+use WPCOMSpecialProjects\CLI\Helper\AutocompleteTrait;
+
+/**
+ * Force-updates a given plugin across all connected Jetpack sites where it is installed.
+ */
+#[AsCommand( name: 'jetpack:plugin-update' )]
+final class Jetpack_Plugin_Update extends Command {
+	use AutocompleteTrait;
+
+	// region FIELDS AND CONSTANTS
+
+	/**
+	 * The plugin slug to update (matched against folder name, main file name, and textdomain).
+	 *
+	 * @var string|null
+	 */
+	private ?string $plugin = null;
+
+	/**
+	 * Optional guard: only update sites whose installed version is below this value.
+	 *
+	 * @var string|null
+	 */
+	private ?string $min_version = null;
+
+	/**
+	 * Whether to only list the sites that would be updated, without updating them.
+	 *
+	 * @var bool|null
+	 */
+	private ?bool $dry_run = null;
+
+	/**
+	 * Whether to skip the confirmation prompt before updating.
+	 *
+	 * @var bool|null
+	 */
+	private ?bool $yes = null;
+
+	/**
+	 * The list of connected sites.
+	 *
+	 * @var array|null
+	 */
+	private ?array $sites = null;
+
+	/**
+	 * The sites that have the plugin installed and will be updated, keyed by site ID.
+	 * Each entry: array{ name: string, installed: string, siteurl: string }.
+	 *
+	 * @var array|null
+	 */
+	private ?array $targets = null;
+
+	// endregion
+
+	// region INHERITED METHODS
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function configure(): void {
+		$this->setDescription( 'Force-updates a given plugin on all connected sites where it is installed.' )
+			->setHelp( 'Use this command to push a new plugin release to every site that has the plugin installed. Each site is updated via the WPCOM plugin update endpoint, which refreshes its update cache and installs from the plugin\'s own update source (wp.org, or a custom Update URI such as GitHub). Only sites with an active Jetpack connection to WPCOM are processed. The update only fires where a newer version is available, so publish the new release before running this.' );
+
+		$this->addArgument( 'plugin', InputArgument::REQUIRED, 'The plugin to update. The term is matched exactly against the folder name, the main file name, and the textdomain.' );
+
+		$this->addOption( 'site', null, InputOption::VALUE_REQUIRED, 'Limit the update to a single site (numeric WPCOM ID or a domain). Useful to canary before running against the fleet.' )
+			->addOption( 'min-version', null, InputOption::VALUE_REQUIRED, 'Only update sites whose installed version is below this value.' )
+			->addOption( 'dry-run', null, InputOption::VALUE_NONE, 'List the sites that would be updated without updating them.' )
+			->addOption( 'yes', null, InputOption::VALUE_NONE, 'Skip the confirmation prompt before updating.' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @throws \InvalidArgumentException If the `--site` value matches no connected Jetpack site.
+	 */
+	protected function initialize( InputInterface $input, OutputInterface $output ): void {
+		$this->plugin = get_string_input( $input, 'plugin', fn() => $this->prompt_plugin_input( $input, $output ) );
+		$input->setArgument( 'plugin', $this->plugin );
+
+		$this->min_version = maybe_get_string_input( $input, 'min-version' );
+		$this->dry_run     = get_bool_input( $input, 'dry-run' );
+		$this->yes         = get_bool_input( $input, 'yes' );
+
+		$this->sites = get_wpcom_jetpack_sites();
+		$output->writeln( '<comment>Successfully fetched ' . \count( $this->sites ) . ' Jetpack site(s).</comment>' );
+
+		$site_option = $input->getOption( 'site' );
+		if ( ! empty( $site_option ) ) {
+			$this->sites = \array_filter(
+				$this->sites,
+				static fn( $site ) => (string) $site->userblog_id === (string) $site_option
+					|| false !== \stripos( (string) ( $site->siteurl ?? '' ), (string) $site_option )
+			);
+			if ( empty( $this->sites ) ) {
+				throw new \InvalidArgumentException( "No connected Jetpack site matched `$site_option`." );
+			}
+		}
+
+		// Fetch the plugins installed on the target sites and compile the list of sites to update.
+		$plugins = get_wpcom_site_plugins_batch( \array_column( $this->sites, 'userblog_id' ), $errors );
+		maybe_output_wpcom_failed_sites_table( $output, $errors ?? array(), $this->sites, 'Sites that could NOT be queried for plugins' );
+
+		$this->targets = array();
+		foreach ( $plugins as $site_id => $site_plugins ) {
+			foreach ( $site_plugins as $plugin_file => $plugin_data ) {
+				if ( ! $this->is_exact_match( $plugin_data, \dirname( $plugin_file ), \basename( $plugin_file, '.php' ) ) ) {
+					continue;
+				}
+
+				// phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				$installed = (string) $plugin_data->Version;
+				if ( ! empty( $this->min_version ) && ! \version_compare( $installed, $this->min_version, '<' ) ) {
+					break; // Already at or above the guard version; skip this site.
+				}
+
+				$this->targets[ $site_id ] = array(
+					'name'      => \preg_replace( '/\.php$/', '', $plugin_file ),
+					'installed' => $installed,
+					'siteurl'   => (string) ( $this->sites[ $site_id ]->siteurl ?? '' ),
+				);
+				break; // One match per site is enough.
+			}
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( InputInterface $input, OutputInterface $output ): int {
+		if ( empty( $this->targets ) ) {
+			$output->writeln( "<comment>No connected sites have the plugin `$this->plugin` installed" . ( empty( $this->min_version ) ? '' : " below version $this->min_version" ) . '.</comment>' );
+			return Command::SUCCESS;
+		}
+
+		// Show what will be updated.
+		output_table(
+			$output,
+			\array_map(
+				static fn( $site_id, $target ) => array( $site_id, $target['siteurl'], $target['installed'] ),
+				\array_keys( $this->targets ),
+				$this->targets
+			),
+			array( 'Site ID', 'Site URL', 'Installed Version' ),
+			"Sites with `$this->plugin` installed"
+		);
+
+		if ( $this->dry_run ) {
+			$output->writeln( '<comment>Dry run: no sites were updated.</comment>' );
+			return Command::SUCCESS;
+		}
+
+		if ( ! $this->yes ) {
+			$question = new ConfirmationQuestion( '<question>Update `' . $this->plugin . '` on ' . \count( $this->targets ) . ' site(s)? [y/N]</question> ', false );
+			if ( true !== $this->getHelper( 'question' )->ask( $input, $output, $question ) ) {
+				$output->writeln( '<comment>Aborted. No sites were updated.</comment>' );
+				return Command::SUCCESS;
+			}
+		}
+
+		$output->writeln( "<fg=magenta;options=bold>Updating `$this->plugin` across " . \count( $this->targets ) . ' site(s).</>' );
+
+		// Group by plugin identifier (near-always a single group) and update each group in one batch call.
+		$groups = array();
+		foreach ( $this->targets as $site_id => $target ) {
+			$groups[ $target['name'] ][] = $site_id;
+		}
+
+		$results = array();
+		$errors  = array();
+		foreach ( $groups as $plugin_name => $site_ids ) {
+			$group_results = update_wpcom_site_plugins_batch( $site_ids, $plugin_name, $group_errors );
+			if ( \is_null( $group_results ) ) {
+				$output->writeln( "<error>The update request failed for plugin `$plugin_name`.</error>" );
+				continue;
+			}
+			$results += $group_results;
+			$errors  += $group_errors ?? array();
+		}
+
+		// Build the results table.
+		$rows   = array();
+		$counts = array(
+			'updated' => 0,
+			'current' => 0,
+			'failed'  => 0,
+		);
+		foreach ( $this->targets as $site_id => $target ) {
+			$was    = $target['installed'];
+			$now    = $was;
+			$result = 'failed';
+
+			if ( isset( $errors[ $site_id ] ) ) {
+				$now = encode_json_content( $errors[ $site_id ]->errors ?? $errors[ $site_id ] );
+			} elseif ( isset( $results[ $site_id ] ) ) {
+				$response = $results[ $site_id ];
+				$now      = (string) ( $response->version ?? $was );
+				$log      = \implode( ' ', (array) ( $response->log ?? array() ) );
+				// The update endpoint always logs either "No update needed" or the upgrade steps.
+				$result = false !== \stripos( $log, 'no update needed' ) ? 'current' : 'updated';
+			}
+
+			++$counts[ $result ];
+			$rows[] = array( $site_id, $target['siteurl'], $was, $now, $result );
+		}
+
+		output_table(
+			$output,
+			$rows,
+			array( 'Site ID', 'Site URL', 'Was', 'Now', 'Result' ),
+			"Update results for `$this->plugin`"
+		);
+
+		$output->writeln( "<info>Updated: {$counts['updated']} | Already current: {$counts['current']} | Failed: {$counts['failed']}</info>" );
+
+		return 0 === $counts['failed'] ? Command::SUCCESS : Command::FAILURE;
+	}
+
+	// endregion
+
+	// region HELPERS
+
+	/**
+	 * Prompts the user for the plugin term to update.
+	 *
+	 * @param   InputInterface  $input  The input interface.
+	 * @param   OutputInterface $output The output interface.
+	 *
+	 * @return  string
+	 */
+	private function prompt_plugin_input( InputInterface $input, OutputInterface $output ): string {
+		$question = new Question( '<question>Enter the slug of the plugin to update:</question> ' );
+		return $this->getHelper( 'question' )->ask( $input, $output, $question );
+	}
+
+	/**
+	 * Checks if the plugin data matches the search term exactly.
+	 *
+	 * @param   \stdClass $plugin_data   The plugin data.
+	 * @param   string    $plugin_folder The plugin folder.
+	 * @param   string    $plugin_file   The plugin file.
+	 *
+	 * @return  boolean
+	 */
+	private function is_exact_match( \stdClass $plugin_data, string $plugin_folder, string $plugin_file ): bool {
+		return $this->plugin === $plugin_data->TextDomain // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+			|| $this->plugin === $plugin_folder
+			|| $this->plugin === $plugin_file;
+	}
+
+	// endregion
+}

--- a/includes/functions-wpcom.php
+++ b/includes/functions-wpcom.php
@@ -231,6 +231,23 @@ function replace_wpcom_site_plugins_batch( array $site_ids_or_urls, string $slug
 }
 
 /**
+ * Raises the fleet-wide plugin update-check directive.
+ *
+ * Proxies the OpsOasis directive endpoint, which bumps a monotonic epoch that every site running the
+ * Atlantis plugin polls. On seeing a newer epoch, each site clears its `update_plugins` transient and
+ * re-runs its update check, so a freshly published wp.org release becomes visible to the normal update
+ * path without waiting out WordPress core's ~12h check throttle. The directive is a global pulse: it
+ * names no specific site or plugin (per-site scoping stays in the update batch) and expires after a
+ * few hours.
+ *
+ * @return  stdClass|null  The raised directive (with `epoch` and `expires_at`), or null on failure.
+ */
+function refresh_wpcom_site_plugin_updates(): ?stdClass {
+	$directive = API_Helper::make_wpcom_request( 'sites/batch/plugin-refresh', 'POST', array() );
+	return $directive instanceof stdClass ? $directive : null;
+}
+
+/**
  * Returns the stats for a WPCOM or Jetpack Connected site.
  *
  * @param   string      $site_id_or_url The site URL or WordPress.com site ID.

--- a/includes/functions-wpcom.php
+++ b/includes/functions-wpcom.php
@@ -199,38 +199,6 @@ function update_wpcom_site_plugins_batch( array $site_ids_or_urls, string $plugi
 }
 
 /**
- * Force-installs a plugin from a zip package across a batch of WPCOM/Jetpack sites.
- *
- * Proxies the OpsOasis batch endpoint, which downloads the package once and overwrites the plugin in
- * place on each site via the WPCOM `plugins/replace` endpoint. Unlike an update, this ignores the site's
- * update cache, the check throttle, and the plugin's own update source, so it installs the given version
- * on every site regardless of what is currently installed or what the site believes is the latest.
- *
- * @param   array      $site_ids_or_urls The list of site domains or numeric WPCOM IDs.
- * @param   string     $slug             The plugin slug (must match the zip's top-level folder).
- * @param   string     $package_url      The URL of the plugin zip to install.
- * @param   array|null $errors           The list of errors that occurred during the request.
- *
- * @return  stdClass[]|null  Per-site result keyed by site ID (with `version` and `log`).
- */
-function replace_wpcom_site_plugins_batch( array $site_ids_or_urls, string $slug, string $package_url, ?array &$errors = null ): ?array {
-	$results = API_Helper::make_wpcom_request(
-		'sites/batch/plugin-replace',
-		'POST',
-		array(
-			'sites'   => $site_ids_or_urls,
-			'slug'    => $slug,
-			'package' => $package_url,
-		)
-	);
-	if ( is_null( $results ) ) {
-		return null;
-	}
-
-	return parse_batch_response( $results, $errors );
-}
-
-/**
  * Forces a fresh plugin update-check on a batch of WPCOM/Jetpack sites.
  *
  * Proxies the OpsOasis batch endpoint, which calls the Atlantis `force-update-check` route on each site
@@ -411,135 +379,35 @@ function is_exact_wpcom_plugin_match( \stdClass $plugin_data, string $term, stri
 }
 
 /**
- * Reads the plugin version from a package zip's header, downloading it locally first.
+ * Validates the cross-option rules for a plugin update request.
  *
- * @param   string $package_url The URL of the plugin zip to read.
- *
- * @return  string|null The version, or null if the (successfully downloaded) package has no readable version.
- *
- * @throws  \RuntimeException If a local temp file cannot be created, or the package URL cannot be downloaded
- *                           (curl error or non-2xx response) — force-installing an unfetchable URL would
- *                           fail on every site.
- */
-function read_wpcom_plugin_package_version( string $package_url ): ?string {
-	$tmp = \tempnam( \sys_get_temp_dir(), 't51pkg' );
-	if ( false === $tmp ) {
-		throw new \RuntimeException( 'Could not create a local temporary file to download the package into.' );
-	}
-
-	$handle = \fopen( $tmp, 'wb' );
-	if ( false === $handle ) {
-		\unlink( $tmp );
-		throw new \RuntimeException( 'Could not open a local temporary file to download the package into.' );
-	}
-
-	$curl = \curl_init( $package_url );
-	\curl_setopt_array(
-		$curl,
-		array(
-			\CURLOPT_FILE           => $handle,
-			\CURLOPT_FOLLOWLOCATION => true,
-			\CURLOPT_TIMEOUT        => 60,
-		)
-	);
-	$downloaded = \curl_exec( $curl );
-	$http_code  = (int) \curl_getinfo( $curl, \CURLINFO_RESPONSE_CODE );
-	$curl_error = \curl_error( $curl );
-	\curl_close( $curl );
-	\fclose( $handle );
-
-	// A bad package URL is a hard error: don't silently fall back to a claimed version and push a URL that
-	// already failed to fetch locally out to the whole fleet.
-	if ( false === $downloaded || $http_code < 200 || $http_code >= 300 ) {
-		\unlink( $tmp );
-		$detail = '' !== $curl_error ? $curl_error : "HTTP $http_code";
-		throw new \RuntimeException( "Could not download the package from `$package_url` ($detail)." );
-	}
-
-	$version = null;
-	if ( \class_exists( '\ZipArchive' ) ) {
-		$zip = new \ZipArchive();
-		if ( true === $zip->open( $tmp ) ) {
-			for ( $index = 0; $index < $zip->numFiles; $index++ ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
-				$name = (string) $zip->getNameIndex( $index );
-				if ( ! \preg_match( '#^[^/]+/[^/]+\.php$#', $name ) ) {
-					continue; // Only top-level PHP files inside the plugin folder.
-				}
-				$contents = $zip->getFromIndex( $index, 8192 );
-				if ( false === $contents || false === \stripos( $contents, 'Plugin Name:' ) ) {
-					continue;
-				}
-				if ( \preg_match( '/^[ \t\/*#@]*Version:\s*(\S+)/mi', $contents, $matches ) ) {
-					$version = \trim( $matches[1] );
-					break;
-				}
-			}
-			$zip->close();
-		}
-	}
-
-	\unlink( $tmp );
-
-	return $version;
-}
-
-/**
- * Validates the cross-option rules for a plugin update / force-install request.
- *
- * @param   boolean     $force       Whether force-install is requested.
- * @param   string|null $package     The package zip URL, if any.
- * @param   boolean     $reinstall   Whether same-version reinstall is requested.
- * @param   boolean     $downgrade   Whether downgrade is requested.
- * @param   boolean     $refresh     Whether a pre-update refresh is requested.
  * @param   string|null $environment The environment filter, if any.
  *
  * @return  void
  *
- * @throws  \InvalidArgumentException If any option combination is invalid.
+ * @throws  \InvalidArgumentException If any option is invalid.
  */
-function validate_wpcom_plugin_update_options( bool $force, ?string $package, bool $reinstall, bool $downgrade, bool $refresh, ?string $environment ): void {
-	if ( $force && empty( $package ) ) {
-		throw new \InvalidArgumentException( 'The --force option requires --package <zip-url> (e.g. a GitHub release asset URL).' );
-	}
-	if ( ! $force && ! empty( $package ) ) {
-		throw new \InvalidArgumentException( 'The --package option only applies to --force.' );
-	}
-	if ( ! $force && $reinstall ) {
-		throw new \InvalidArgumentException( 'The --reinstall option only applies to --force.' );
-	}
-	if ( ! $force && $downgrade ) {
-		throw new \InvalidArgumentException( 'The --downgrade option only applies to --force.' );
-	}
-	if ( $refresh && $force ) {
-		throw new \InvalidArgumentException( 'The --refresh option applies to the detection-based update path and has no effect with --force (which bypasses update detection). Use one or the other.' );
-	}
+function validate_wpcom_plugin_update_options( ?string $environment ): void {
 	if ( ! \is_null( $environment ) && ! \in_array( $environment, array( 'staging', 'production' ), true ) ) {
 		throw new \InvalidArgumentException( 'The --environment option must be either `staging` or `production`.' );
 	}
 }
 
 /**
- * Resolves sites + plugin into a target/plan structure for a plugin update or force-install.
+ * Resolves sites + plugin into a target structure for a plugin update.
  *
- * Pure of console output. Reproduces the resolve -> environment filter -> inventory -> match -> plan flow.
- * In force mode it tags each target with a `plan` of `install`/`current`/`ahead` per the version rules
- * (below target installs; equal skips unless `$reinstall`; ahead skips unless `$downgrade`).
+ * Pure of console output. Reproduces the resolve -> environment filter -> inventory -> match flow.
  *
  * @param   string      $plugin      The plugin term (matched against folder / main file / textdomain).
  * @param   string      $sites_spec  `all`, a comma-separated list of URLs/IDs, or a CSV path.
  * @param   string|null $environment Optional `staging`/`production` URL filter.
- * @param   boolean     $force       Whether force-install is requested (enables the version plan).
- * @param   string|null $package     The package zip URL (required in force mode).
- * @param   string|null $release     Fallback target version when the package has no readable header.
- * @param   boolean     $reinstall   Whether to also install equal-version sites.
- * @param   boolean     $downgrade   Whether to also install ahead-version sites (roll back).
  *
- * @return  array{targets: array, target_version: ?string, unqueryable: array, unmatched: array, sites: array, fetched_count: int, matched_count: int, env_before: int, env_after: int}
+ * @return  array{targets: array, unqueryable: array, unmatched: array, sites: array, fetched_count: int, matched_count: int, env_before: int, env_after: int}
  *
  * @throws  \InvalidArgumentException If no sites match or none survive the environment filter.
- * @throws  \RuntimeException         If the fleet, the inventory, or the package version cannot be resolved.
+ * @throws  \RuntimeException         If the fleet or the inventory cannot be resolved.
  */
-function build_wpcom_plugin_update_plan( string $plugin, string $sites_spec, ?string $environment, bool $force, ?string $package, ?string $release, bool $reinstall, bool $downgrade ): array {
+function build_wpcom_plugin_update_plan( string $plugin, string $sites_spec, ?string $environment ): array {
 	$all_sites = get_wpcom_jetpack_sites();
 	if ( \is_null( $all_sites ) ) {
 		throw new \RuntimeException( 'Could not fetch the connected Jetpack sites from WPCOM.' );
@@ -596,35 +464,15 @@ function build_wpcom_plugin_update_plan( string $plugin, string $sites_spec, ?st
 		}
 	}
 
-	$target_version = null;
-	if ( $force && ! empty( $targets ) ) {
-		$target_version = read_wpcom_plugin_package_version( (string) $package ) ?? $release;
-		if ( empty( $target_version ) ) {
-			throw new \RuntimeException( 'Could not read the plugin version from the package. Pass --release <version> so already-current and ahead sites can be detected and skipped, or check the --package URL.' );
-		}
-
-		foreach ( $targets as $site_id => $target ) {
-			$comparison = \version_compare( normalize_version_string( $target['installed'] ), normalize_version_string( $target_version ) );
-			if ( $comparison > 0 && ! $downgrade ) {
-				$targets[ $site_id ]['plan'] = 'ahead';   // Newer build; never overwritten unless downgrade.
-			} elseif ( 0 === $comparison && ! $reinstall ) {
-				$targets[ $site_id ]['plan'] = 'current'; // Already at the target; skip unless reinstall.
-			} else {
-				$targets[ $site_id ]['plan'] = 'install'; // Below target, or ahead+downgrade, or equal+reinstall.
-			}
-		}
-	}
-
 	return array(
-		'targets'        => $targets,
-		'target_version' => $target_version,
-		'unqueryable'    => $unqueryable,
-		'unmatched'      => $unmatched,
-		'sites'          => $sites,
-		'fetched_count'  => $fetched_count,
-		'matched_count'  => $matched_count,
-		'env_before'     => $env_before,
-		'env_after'      => $env_after,
+		'targets'       => $targets,
+		'unqueryable'   => $unqueryable,
+		'unmatched'     => $unmatched,
+		'sites'         => $sites,
+		'fetched_count' => $fetched_count,
+		'matched_count' => $matched_count,
+		'env_before'    => $env_before,
+		'env_after'     => $env_after,
 	);
 }
 
@@ -687,61 +535,36 @@ function run_wpcom_plugin_update_refresh( array $site_ids, ?callable $progress =
 }
 
 /**
- * Executes a built plan: update or force-install on the planned sites. (Refresh, when requested, is a
- * separate step the caller runs first via run_wpcom_plugin_update_refresh().)
+ * Executes a built plan: updates the planned sites via the detection-based update endpoint. (Refresh,
+ * when requested, is a separate step the caller runs first via run_wpcom_plugin_update_refresh().)
  *
  * Pure of direct console writes — progress is emitted only via the optional callback.
  *
  * @param   array         $plan     A plan from build_wpcom_plugin_update_plan().
- * @param   boolean       $force    Whether to force-install from $package (vs the detection update).
- * @param   string|null   $package  The package zip URL (force mode).
  * @param   callable|null $progress Optional progress emitter: `fn( string $message ): void`.
  *
  * @return  array{results: array, errors: array}
  */
-function execute_wpcom_plugin_update_plan( array $plan, bool $force, ?string $package, ?callable $progress = null ): array {
+function execute_wpcom_plugin_update_plan( array $plan, ?callable $progress = null ): array {
 	$emit    = static fn( string $message ) => \is_callable( $progress ) ? $progress( $message ) : null;
 	$targets = $plan['targets'];
 
 	$results = array();
 	$errors  = array();
-	if ( $force ) {
-		// Group by plugin folder (the replace slug); near-always a single group. Only `install` sites.
-		$groups = array();
-		foreach ( $targets as $site_id => $target ) {
-			if ( 'install' === ( $target['plan'] ?? 'install' ) ) {
-				$groups[ $target['folder'] ][] = $site_id;
-			}
+
+	// Group by plugin identifier (near-always a single group) and update each group in one batch call.
+	$groups = array();
+	foreach ( $targets as $site_id => $target ) {
+		$groups[ $target['name'] ][] = $site_id;
+	}
+	foreach ( $groups as $plugin_name => $site_ids ) {
+		$group_results = update_wpcom_site_plugins_batch( $site_ids, $plugin_name, $group_errors );
+		if ( \is_null( $group_results ) ) {
+			$emit( "<error>The update request failed for plugin `$plugin_name`.</error>" );
+			continue;
 		}
-		foreach ( $groups as $slug => $site_ids ) {
-			$chunks = \array_chunk( $site_ids, WPCOM_PLUGIN_UPDATE_BATCH_SIZE );
-			$total  = \count( $chunks );
-			foreach ( $chunks as $index => $chunk ) {
-				$emit( '<comment>Batch ' . ( $index + 1 ) . "/$total: force-installing on " . \count( $chunk ) . ' site(s)…</comment>' );
-				$chunk_results = replace_wpcom_site_plugins_batch( $chunk, $slug, (string) $package, $chunk_errors );
-				if ( \is_null( $chunk_results ) ) {
-					$emit( '<error>The force-install request failed for this batch.</error>' );
-					continue;
-				}
-				$results += $chunk_results;
-				$errors  += $chunk_errors ?? array();
-			}
-		}
-	} else {
-		// Group by plugin identifier (near-always a single group) and update each group in one batch call.
-		$groups = array();
-		foreach ( $targets as $site_id => $target ) {
-			$groups[ $target['name'] ][] = $site_id;
-		}
-		foreach ( $groups as $plugin_name => $site_ids ) {
-			$group_results = update_wpcom_site_plugins_batch( $site_ids, $plugin_name, $group_errors );
-			if ( \is_null( $group_results ) ) {
-				$emit( "<error>The update request failed for plugin `$plugin_name`.</error>" );
-				continue;
-			}
-			$results += $group_results;
-			$errors  += $group_errors ?? array();
-		}
+		$results += $group_results;
+		$errors  += $group_errors ?? array();
 	}
 
 	return array(

--- a/includes/functions-wpcom.php
+++ b/includes/functions-wpcom.php
@@ -199,6 +199,38 @@ function update_wpcom_site_plugins_batch( array $site_ids_or_urls, string $plugi
 }
 
 /**
+ * Force-installs a plugin from a zip package across a batch of WPCOM/Jetpack sites.
+ *
+ * Proxies the OpsOasis batch endpoint, which downloads the package once and overwrites the plugin in
+ * place on each site via the WPCOM `plugins/replace` endpoint. Unlike an update, this ignores the site's
+ * update cache, the check throttle, and the plugin's own update source, so it installs the given version
+ * on every site regardless of what is currently installed or what the site believes is the latest.
+ *
+ * @param   array      $site_ids_or_urls The list of site domains or numeric WPCOM IDs.
+ * @param   string     $slug             The plugin slug (must match the zip's top-level folder).
+ * @param   string     $package_url      The URL of the plugin zip to install.
+ * @param   array|null $errors           The list of errors that occurred during the request.
+ *
+ * @return  stdClass[]|null  Per-site result keyed by site ID (with `version` and `log`).
+ */
+function replace_wpcom_site_plugins_batch( array $site_ids_or_urls, string $slug, string $package_url, ?array &$errors = null ): ?array {
+	$results = API_Helper::make_wpcom_request(
+		'sites/batch/plugin-replace',
+		'POST',
+		array(
+			'sites'   => $site_ids_or_urls,
+			'slug'    => $slug,
+			'package' => $package_url,
+		)
+	);
+	if ( is_null( $results ) ) {
+		return null;
+	}
+
+	return parse_batch_response( $results, $errors );
+}
+
+/**
  * Returns the stats for a WPCOM or Jetpack Connected site.
  *
  * @param   string      $site_id_or_url The site URL or WordPress.com site ID.

--- a/includes/functions-wpcom.php
+++ b/includes/functions-wpcom.php
@@ -227,8 +227,8 @@ function force_check_wpcom_site_plugins_batch( array $site_ids_or_urls, ?array &
 }
 
 /**
- * Number of sites per batch when force-installing or refreshing (each is a real per-site tunnelled call).
- * Matches the server-side `maxItems` on the OpsOasis batch routes.
+ * Number of sites per batch when refreshing update-checks (each is a real per-site tunnelled call).
+ * Matches the server-side `maxItems` on the OpsOasis batch route.
  */
 const WPCOM_PLUGIN_UPDATE_BATCH_SIZE = 30;
 
@@ -241,6 +241,33 @@ const WPCOM_PLUGIN_UPDATE_BATCH_SIZE = 30;
  */
 function normalize_version_string( string $version ): string {
 	return \ltrim( \trim( $version ), 'vV' );
+}
+
+/**
+ * Classifies a site's update outcome from its before/after versions, optionally against a release.
+ *
+ * With $release set, a resulting version newer than it is `ahead` and older is `behind` (so a site the
+ * release has not reached, or one running a newer test build, is surfaced); otherwise the result is
+ * simply whether the version moved forward (`updated`) or not (`current`).
+ *
+ * @param   string      $was     The version installed before the update.
+ * @param   string      $now     The version reported after the update.
+ * @param   string|null $release Optional release version to compare the result against.
+ *
+ * @return  string One of `updated`, `current`, `ahead`, `behind`.
+ */
+function classify_wpcom_plugin_update_result( string $was, string $now, ?string $release = null ): string {
+	if ( ! empty( $release ) ) {
+		$against_release = \version_compare( normalize_version_string( $now ), normalize_version_string( $release ) );
+		if ( $against_release > 0 ) {
+			return 'ahead';
+		}
+		if ( $against_release < 0 ) {
+			return 'behind';
+		}
+	}
+
+	return \version_compare( normalize_version_string( $was ), normalize_version_string( $now ), '<' ) ? 'updated' : 'current';
 }
 
 /**
@@ -456,7 +483,6 @@ function build_wpcom_plugin_update_plan( string $plugin, string $sites_spec, ?st
 			}
 			$targets[ $site_id ] = array(
 				'name'      => \preg_replace( '/\.php$/', '', $plugin_file ),
-				'folder'    => \dirname( $plugin_file ),
 				'installed' => (string) $plugin_data->Version, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 				'siteurl'   => (string) ( $sites[ $site_id ]->siteurl ?? '' ),
 			);

--- a/includes/functions-wpcom.php
+++ b/includes/functions-wpcom.php
@@ -315,19 +315,31 @@ function read_wpcom_sites_csv_first_column( string $path ): array {
  * Parses a `--sites` value into a list of requested site identifiers.
  *
  * The value is either a path to a CSV file (first column holds the site URLs) or a comma-separated list
- * of URLs and/or numeric WPCOM IDs. Blank and implausible entries (such as a CSV header row) are dropped.
+ * of URLs and/or numeric WPCOM IDs. Blank entries are always dropped.
+ *
+ * The two sources differ in how implausible tokens are treated. In a CSV, a first-column value that is
+ * neither a numeric ID nor a hostname is almost always a header row and is dropped silently. In a typed
+ * comma-separated list, every non-blank token was entered deliberately, so none is dropped here — a token
+ * that does not resolve (e.g. a bare slug) flows through to the caller's `unmatched` list rather than
+ * vanishing, so a mixed list cannot silently cover fewer sites than requested and still report success.
  *
  * @param   string $spec The raw sites value.
  *
  * @return  string[]
  */
 function parse_wpcom_site_identifiers( string $spec ): array {
-	$raw = \is_file( $spec ) ? read_wpcom_sites_csv_first_column( $spec ) : \explode( ',', $spec );
+	$is_csv = \is_file( $spec );
+	$raw    = $is_csv ? read_wpcom_sites_csv_first_column( $spec ) : \explode( ',', $spec );
 
 	$identifiers = array();
 	foreach ( $raw as $value ) {
 		$value = \trim( (string) $value );
-		if ( '' === $value || ( ! \is_numeric( $value ) && ! \str_contains( $value, '.' ) ) ) {
+		if ( '' === $value ) {
+			continue;
+		}
+		// CSV only: skip header-like rows that are neither a numeric ID nor a hostname. Typed tokens are
+		// always kept so an unresolvable one is surfaced by the caller instead of being swallowed here.
+		if ( $is_csv && ! \is_numeric( $value ) && ! \str_contains( $value, '.' ) ) {
 			continue;
 		}
 		$identifiers[ $value ] = $value;

--- a/includes/functions-wpcom.php
+++ b/includes/functions-wpcom.php
@@ -231,20 +231,31 @@ function replace_wpcom_site_plugins_batch( array $site_ids_or_urls, string $slug
 }
 
 /**
- * Raises the fleet-wide plugin update-check directive.
+ * Forces a fresh plugin update-check on a batch of WPCOM/Jetpack sites.
  *
- * Proxies the OpsOasis directive endpoint, which bumps a monotonic epoch that every site running the
- * Atlantis plugin polls. On seeing a newer epoch, each site clears its `update_plugins` transient and
- * re-runs its update check, so a freshly published wp.org release becomes visible to the normal update
- * path without waiting out WordPress core's ~12h check throttle. The directive is a global pulse: it
- * names no specific site or plugin (per-site scoping stays in the update batch) and expires after a
- * few hours.
+ * Proxies the OpsOasis batch endpoint, which calls the Atlantis `force-update-check` route on each site
+ * over the authenticated Jetpack REST tunnel. Each site clears its `update_plugins` transient (and
+ * WooCommerce.com's helper cache) and re-runs its update check, so a just-published wp.org /
+ * WooCommerce.com release becomes visible to the version-checked update path without waiting out
+ * WordPress core's ~12h throttle. Sites without Atlantis (or without a live connection) are returned
+ * via $errors.
  *
- * @return  stdClass|null  The raised directive (with `epoch` and `expires_at`), or null on failure.
+ * @param   array      $site_ids_or_urls The list of site domains or numeric WPCOM IDs.
+ * @param   array|null $errors           The list of errors that occurred during the request.
+ *
+ * @return  stdClass[]|null  Per-site result keyed by site ID, or null if the request failed entirely.
  */
-function refresh_wpcom_site_plugin_updates(): ?stdClass {
-	$directive = API_Helper::make_wpcom_request( 'sites/batch/plugin-refresh', 'POST', array() );
-	return $directive instanceof stdClass ? $directive : null;
+function force_check_wpcom_site_plugins_batch( array $site_ids_or_urls, ?array &$errors = null ): ?array {
+	$results = API_Helper::make_wpcom_request(
+		'sites/batch/atlantis-force-check',
+		'POST',
+		array( 'sites' => $site_ids_or_urls )
+	);
+	if ( is_null( $results ) ) {
+		return null;
+	}
+
+	return parse_batch_response( $results, $errors );
 }
 
 /**

--- a/includes/functions-wpcom.php
+++ b/includes/functions-wpcom.php
@@ -653,7 +653,10 @@ function run_wpcom_plugin_update_refresh( array $site_ids, ?callable $progress =
 		$chunk_results = force_check_wpcom_site_plugins_batch( $chunk, $chunk_errors );
 		if ( \is_null( $chunk_results ) ) {
 			$emit( '<comment>⚠ The refresh request failed for this batch.</comment>' );
-			$unrefreshed += \array_fill_keys( $chunk, 'The batch refresh request failed (e.g. timeout).' );
+			// Match the per-site error shape maybe_output_wpcom_failed_sites_table() renders (an object with
+			// an `errors` property), so a failed batch does not raise a TypeError there.
+			$batch_error  = (object) array( 'errors' => array( 'refresh_batch_failed' => array( 'The batch refresh request failed (e.g. timeout).' ) ) );
+			$unrefreshed += \array_fill_keys( $chunk, $batch_error );
 			continue;
 		}
 		$any_batch = true;

--- a/includes/functions-wpcom.php
+++ b/includes/functions-wpcom.php
@@ -167,6 +167,38 @@ function get_wpcom_sites_atlantis_status_batch( array $site_ids_or_urls, ?array 
 }
 
 /**
+ * Forces an update of a single plugin across a batch of WPCOM/Jetpack sites.
+ *
+ * Proxies the OpsOasis batch endpoint, which calls the WPCOM v1.2 plugin update endpoint on each
+ * site. The update self-refreshes the site's update cache and installs from the plugin's own update
+ * source (wp.org, or a custom `Update URI` such as GitHub), so it is not subject to the ~12h
+ * dashboard cache. It only upgrades sites where a newer version is available; sites already current
+ * report "No update needed" and are returned as successes with an unchanged version.
+ *
+ * @param   array      $site_ids_or_urls The list of site domains or numeric WPCOM IDs.
+ * @param   string     $plugin           The plugin identifier in `folder/file` form without the
+ *                                        `.php` suffix (e.g. `a8csp-atlantis/a8csp-atlantis`).
+ * @param   array|null $errors           The list of errors that occurred during the request.
+ *
+ * @return  stdClass[]|null  Per-site update result keyed by site ID (with `version` and `log`).
+ */
+function update_wpcom_site_plugins_batch( array $site_ids_or_urls, string $plugin, ?array &$errors = null ): ?array {
+	$results = API_Helper::make_wpcom_request(
+		'sites/batch/plugin-update',
+		'POST',
+		array(
+			'sites'  => $site_ids_or_urls,
+			'plugin' => $plugin,
+		)
+	);
+	if ( is_null( $results ) ) {
+		return null;
+	}
+
+	return parse_batch_response( $results, $errors );
+}
+
+/**
  * Returns the stats for a WPCOM or Jetpack Connected site.
  *
  * @param   string      $site_id_or_url The site URL or WordPress.com site ID.

--- a/includes/functions-wpcom.php
+++ b/includes/functions-wpcom.php
@@ -259,6 +259,495 @@ function force_check_wpcom_site_plugins_batch( array $site_ids_or_urls, ?array &
 }
 
 /**
+ * Number of sites per batch when force-installing or refreshing (each is a real per-site tunnelled call).
+ * Matches the server-side `maxItems` on the OpsOasis batch routes.
+ */
+const WPCOM_PLUGIN_UPDATE_BATCH_SIZE = 30;
+
+/**
+ * Normalizes a version string for comparison (drops a leading `v`).
+ *
+ * @param   string $version The version string.
+ *
+ * @return  string
+ */
+function normalize_version_string( string $version ): string {
+	return \ltrim( \trim( $version ), 'vV' );
+}
+
+/**
+ * Normalizes a URL or host to a bare lowercase host for comparison.
+ *
+ * @param   string $value The URL or host to normalize.
+ *
+ * @return  string
+ */
+function normalize_wpcom_site_host( string $value ): string {
+	$value = \strtolower( \trim( $value ) );
+	$value = \preg_replace( '#^https?://#', '', $value );
+	$value = \preg_replace( '#/.*$#', '', $value );
+
+	return $value;
+}
+
+/**
+ * Reads the first column of a CSV file.
+ *
+ * @param   string $path The path to the CSV file.
+ *
+ * @return  string[]
+ *
+ * @throws  \RuntimeException If the file cannot be opened.
+ */
+function read_wpcom_sites_csv_first_column( string $path ): array {
+	$handle = \fopen( $path, 'r' );
+	if ( false === $handle ) {
+		throw new \RuntimeException( "Could not open the sites file `$path`." );
+	}
+
+	$values = array();
+	while ( false !== ( $row = \fgetcsv( $handle, 0, ',', '"', '' ) ) ) {
+		if ( isset( $row[0] ) ) {
+			$values[] = $row[0];
+		}
+	}
+	\fclose( $handle );
+
+	return $values;
+}
+
+/**
+ * Parses a `--sites` value into a list of requested site identifiers.
+ *
+ * The value is either a path to a CSV file (first column holds the site URLs) or a comma-separated list
+ * of URLs and/or numeric WPCOM IDs. Blank and implausible entries (such as a CSV header row) are dropped.
+ *
+ * @param   string $spec The raw sites value.
+ *
+ * @return  string[]
+ */
+function parse_wpcom_site_identifiers( string $spec ): array {
+	$raw = \is_file( $spec ) ? read_wpcom_sites_csv_first_column( $spec ) : \explode( ',', $spec );
+
+	$identifiers = array();
+	foreach ( $raw as $value ) {
+		$value = \trim( (string) $value );
+		if ( '' === $value || ( ! \is_numeric( $value ) && ! \str_contains( $value, '.' ) ) ) {
+			continue;
+		}
+		$identifiers[ $value ] = $value;
+	}
+
+	return \array_values( $identifiers );
+}
+
+/**
+ * Finds the fleet key for a single requested identifier, by numeric WPCOM ID or by host.
+ *
+ * @param   string $identifier The requested site URL or numeric WPCOM ID.
+ * @param   array  $all_sites  The connected Jetpack sites, keyed by WPCOM ID.
+ *
+ * @return  int|string|null The matching fleet key, or null when no site matches.
+ */
+function match_wpcom_site( string $identifier, array $all_sites ): int|string|null {
+	if ( \is_numeric( $identifier ) ) {
+		foreach ( $all_sites as $key => $site ) {
+			if ( (string) $site->userblog_id === $identifier ) {
+				return $key;
+			}
+		}
+	}
+
+	$needle = normalize_wpcom_site_host( $identifier );
+	if ( '' !== $needle ) {
+		foreach ( $all_sites as $key => $site ) {
+			if ( normalize_wpcom_site_host( (string) ( $site->siteurl ?? '' ) ) === $needle ) {
+				return $key;
+			}
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Matches the requested identifiers against the connected fleet.
+ *
+ * @param   string[] $identifiers The requested site URLs and/or numeric WPCOM IDs.
+ * @param   array    $all_sites   The connected Jetpack sites, keyed by WPCOM ID.
+ *
+ * @return  array A two-element list: the matched sites keyed by WPCOM ID, and the unmatched identifiers.
+ */
+function resolve_wpcom_sites_from_identifiers( array $identifiers, array $all_sites ): array {
+	$matched   = array();
+	$unmatched = array();
+
+	foreach ( $identifiers as $identifier ) {
+		$key = match_wpcom_site( $identifier, $all_sites );
+		if ( \is_null( $key ) ) {
+			$unmatched[] = $identifier;
+			continue;
+		}
+		$matched[ $key ] = $all_sites[ $key ];
+	}
+
+	return array( $matched, $unmatched );
+}
+
+/**
+ * Checks whether the plugin data matches the search term exactly.
+ *
+ * @param   \stdClass $plugin_data The plugin data.
+ * @param   string    $term        The search term.
+ * @param   string    $folder      The plugin folder.
+ * @param   string    $file        The plugin main file (without `.php`).
+ *
+ * @return  boolean
+ */
+function is_exact_wpcom_plugin_match( \stdClass $plugin_data, string $term, string $folder, string $file ): bool {
+	return $term === $plugin_data->TextDomain // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+		|| $term === $folder
+		|| $term === $file;
+}
+
+/**
+ * Reads the plugin version from a package zip's header, downloading it locally first.
+ *
+ * @param   string $package_url The URL of the plugin zip to read.
+ *
+ * @return  string|null The version, or null if the (successfully downloaded) package has no readable version.
+ *
+ * @throws  \RuntimeException If a local temp file cannot be created, or the package URL cannot be downloaded
+ *                           (curl error or non-2xx response) — force-installing an unfetchable URL would
+ *                           fail on every site.
+ */
+function read_wpcom_plugin_package_version( string $package_url ): ?string {
+	$tmp = \tempnam( \sys_get_temp_dir(), 't51pkg' );
+	if ( false === $tmp ) {
+		throw new \RuntimeException( 'Could not create a local temporary file to download the package into.' );
+	}
+
+	$handle = \fopen( $tmp, 'wb' );
+	if ( false === $handle ) {
+		\unlink( $tmp );
+		throw new \RuntimeException( 'Could not open a local temporary file to download the package into.' );
+	}
+
+	$curl = \curl_init( $package_url );
+	\curl_setopt_array(
+		$curl,
+		array(
+			\CURLOPT_FILE           => $handle,
+			\CURLOPT_FOLLOWLOCATION => true,
+			\CURLOPT_TIMEOUT        => 60,
+		)
+	);
+	$downloaded = \curl_exec( $curl );
+	$http_code  = (int) \curl_getinfo( $curl, \CURLINFO_RESPONSE_CODE );
+	$curl_error = \curl_error( $curl );
+	\curl_close( $curl );
+	\fclose( $handle );
+
+	// A bad package URL is a hard error: don't silently fall back to a claimed version and push a URL that
+	// already failed to fetch locally out to the whole fleet.
+	if ( false === $downloaded || $http_code < 200 || $http_code >= 300 ) {
+		\unlink( $tmp );
+		$detail = '' !== $curl_error ? $curl_error : "HTTP $http_code";
+		throw new \RuntimeException( "Could not download the package from `$package_url` ($detail)." );
+	}
+
+	$version = null;
+	if ( \class_exists( '\ZipArchive' ) ) {
+		$zip = new \ZipArchive();
+		if ( true === $zip->open( $tmp ) ) {
+			for ( $index = 0; $index < $zip->numFiles; $index++ ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				$name = (string) $zip->getNameIndex( $index );
+				if ( ! \preg_match( '#^[^/]+/[^/]+\.php$#', $name ) ) {
+					continue; // Only top-level PHP files inside the plugin folder.
+				}
+				$contents = $zip->getFromIndex( $index, 8192 );
+				if ( false === $contents || false === \stripos( $contents, 'Plugin Name:' ) ) {
+					continue;
+				}
+				if ( \preg_match( '/^[ \t\/*#@]*Version:\s*(\S+)/mi', $contents, $matches ) ) {
+					$version = \trim( $matches[1] );
+					break;
+				}
+			}
+			$zip->close();
+		}
+	}
+
+	\unlink( $tmp );
+
+	return $version;
+}
+
+/**
+ * Validates the cross-option rules for a plugin update / force-install request.
+ *
+ * @param   boolean     $force       Whether force-install is requested.
+ * @param   string|null $package     The package zip URL, if any.
+ * @param   boolean     $reinstall   Whether same-version reinstall is requested.
+ * @param   boolean     $downgrade   Whether downgrade is requested.
+ * @param   boolean     $refresh     Whether a pre-update refresh is requested.
+ * @param   string|null $environment The environment filter, if any.
+ *
+ * @return  void
+ *
+ * @throws  \InvalidArgumentException If any option combination is invalid.
+ */
+function validate_wpcom_plugin_update_options( bool $force, ?string $package, bool $reinstall, bool $downgrade, bool $refresh, ?string $environment ): void {
+	if ( $force && empty( $package ) ) {
+		throw new \InvalidArgumentException( 'The --force option requires --package <zip-url> (e.g. a GitHub release asset URL).' );
+	}
+	if ( ! $force && ! empty( $package ) ) {
+		throw new \InvalidArgumentException( 'The --package option only applies to --force.' );
+	}
+	if ( ! $force && $reinstall ) {
+		throw new \InvalidArgumentException( 'The --reinstall option only applies to --force.' );
+	}
+	if ( ! $force && $downgrade ) {
+		throw new \InvalidArgumentException( 'The --downgrade option only applies to --force.' );
+	}
+	if ( $refresh && $force ) {
+		throw new \InvalidArgumentException( 'The --refresh option applies to the detection-based update path and has no effect with --force (which bypasses update detection). Use one or the other.' );
+	}
+	if ( ! \is_null( $environment ) && ! \in_array( $environment, array( 'staging', 'production' ), true ) ) {
+		throw new \InvalidArgumentException( 'The --environment option must be either `staging` or `production`.' );
+	}
+}
+
+/**
+ * Resolves sites + plugin into a target/plan structure for a plugin update or force-install.
+ *
+ * Pure of console output. Reproduces the resolve -> environment filter -> inventory -> match -> plan flow.
+ * In force mode it tags each target with a `plan` of `install`/`current`/`ahead` per the version rules
+ * (below target installs; equal skips unless `$reinstall`; ahead skips unless `$downgrade`).
+ *
+ * @param   string      $plugin      The plugin term (matched against folder / main file / textdomain).
+ * @param   string      $sites_spec  `all`, a comma-separated list of URLs/IDs, or a CSV path.
+ * @param   string|null $environment Optional `staging`/`production` URL filter.
+ * @param   boolean     $force       Whether force-install is requested (enables the version plan).
+ * @param   string|null $package     The package zip URL (required in force mode).
+ * @param   string|null $release     Fallback target version when the package has no readable header.
+ * @param   boolean     $reinstall   Whether to also install equal-version sites.
+ * @param   boolean     $downgrade   Whether to also install ahead-version sites (roll back).
+ *
+ * @return  array{targets: array, target_version: ?string, unqueryable: array, unmatched: array, sites: array, fetched_count: int, matched_count: int, env_before: int, env_after: int}
+ *
+ * @throws  \InvalidArgumentException If no sites match or none survive the environment filter.
+ * @throws  \RuntimeException         If the fleet, the inventory, or the package version cannot be resolved.
+ */
+function build_wpcom_plugin_update_plan( string $plugin, string $sites_spec, ?string $environment, bool $force, ?string $package, ?string $release, bool $reinstall, bool $downgrade ): array {
+	$all_sites = get_wpcom_jetpack_sites();
+	if ( \is_null( $all_sites ) ) {
+		throw new \RuntimeException( 'Could not fetch the connected Jetpack sites from WPCOM.' );
+	}
+	$fetched_count = \count( $all_sites );
+
+	$unmatched = array();
+	if ( 'all' === \strtolower( \trim( $sites_spec ) ) ) {
+		$sites = $all_sites;
+	} else {
+		[ $matched, $unmatched ] = resolve_wpcom_sites_from_identifiers( parse_wpcom_site_identifiers( $sites_spec ), $all_sites );
+		if ( empty( $matched ) ) {
+			throw new \InvalidArgumentException( 'None of the requested sites were found in the connected Jetpack fleet.' );
+		}
+		$sites = $matched;
+	}
+	$matched_count = \count( $sites );
+	$env_before    = $matched_count;
+
+	if ( ! \is_null( $environment ) ) {
+		$keep_staging = 'staging' === $environment;
+		$sites        = \array_filter(
+			$sites,
+			static function ( $site ) use ( $keep_staging ) {
+				$is_staging = false !== \stripos( (string) ( $site->siteurl ?? '' ), 'staging' );
+				return $keep_staging ? $is_staging : ! $is_staging;
+			}
+		);
+		if ( empty( $sites ) ) {
+			throw new \InvalidArgumentException( "No sites remain after the `$environment` environment filter." );
+		}
+	}
+	$env_after = \count( $sites );
+
+	$plugins = get_wpcom_site_plugins_batch( \array_column( $sites, 'userblog_id' ), $errors );
+	if ( \is_null( $plugins ) ) {
+		throw new \RuntimeException( 'Could not fetch the installed plugins for the requested sites from WPCOM.' );
+	}
+	$unqueryable = \is_array( $errors ) ? $errors : array();
+
+	$targets = array();
+	foreach ( $plugins as $site_id => $site_plugins ) {
+		foreach ( $site_plugins as $plugin_file => $plugin_data ) {
+			if ( ! is_exact_wpcom_plugin_match( $plugin_data, $plugin, \dirname( $plugin_file ), \basename( $plugin_file, '.php' ) ) ) {
+				continue;
+			}
+			$targets[ $site_id ] = array(
+				'name'      => \preg_replace( '/\.php$/', '', $plugin_file ),
+				'folder'    => \dirname( $plugin_file ),
+				'installed' => (string) $plugin_data->Version, // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
+				'siteurl'   => (string) ( $sites[ $site_id ]->siteurl ?? '' ),
+			);
+			break; // One match per site is enough.
+		}
+	}
+
+	$target_version = null;
+	if ( $force && ! empty( $targets ) ) {
+		$target_version = read_wpcom_plugin_package_version( (string) $package ) ?? $release;
+		if ( empty( $target_version ) ) {
+			throw new \RuntimeException( 'Could not read the plugin version from the package. Pass --release <version> so already-current and ahead sites can be detected and skipped, or check the --package URL.' );
+		}
+
+		foreach ( $targets as $site_id => $target ) {
+			$comparison = \version_compare( normalize_version_string( $target['installed'] ), normalize_version_string( $target_version ) );
+			if ( $comparison > 0 && ! $downgrade ) {
+				$targets[ $site_id ]['plan'] = 'ahead';   // Newer build; never overwritten unless downgrade.
+			} elseif ( 0 === $comparison && ! $reinstall ) {
+				$targets[ $site_id ]['plan'] = 'current'; // Already at the target; skip unless reinstall.
+			} else {
+				$targets[ $site_id ]['plan'] = 'install'; // Below target, or ahead+downgrade, or equal+reinstall.
+			}
+		}
+	}
+
+	return array(
+		'targets'        => $targets,
+		'target_version' => $target_version,
+		'unqueryable'    => $unqueryable,
+		'unmatched'      => $unmatched,
+		'sites'          => $sites,
+		'fetched_count'  => $fetched_count,
+		'matched_count'  => $matched_count,
+		'env_before'     => $env_before,
+		'env_after'      => $env_after,
+	);
+}
+
+/**
+ * Runs a fresh update-check (Atlantis lever) on the given sites, in batches.
+ *
+ * @param   int[]         $site_ids The site IDs to refresh.
+ * @param   callable|null $progress Optional progress emitter: `fn( string $message ): void`.
+ *
+ * @return  array{refreshed_count: int, total: int, unreachable: array, unrefreshed: array}
+ */
+function run_wpcom_plugin_update_refresh( array $site_ids, ?callable $progress = null ): array {
+	$emit   = static fn( string $message ) => \is_callable( $progress ) ? $progress( $message ) : null;
+	$chunks = \array_chunk( $site_ids, WPCOM_PLUGIN_UPDATE_BATCH_SIZE );
+	$total  = \count( $chunks );
+	$emit( '<fg=magenta;options=bold>Refreshing the update-check on ' . \count( $site_ids ) . ' site(s)…</>' );
+
+	$results     = array();
+	$errors      = array();
+	$unrefreshed = array();
+	$any_batch   = false;
+	foreach ( $chunks as $index => $chunk ) {
+		if ( $total > 1 ) {
+			$emit( '<comment>Batch ' . ( $index + 1 ) . "/$total: refreshing " . \count( $chunk ) . ' site(s)…</comment>' );
+		}
+		$chunk_results = force_check_wpcom_site_plugins_batch( $chunk, $chunk_errors );
+		if ( \is_null( $chunk_results ) ) {
+			$emit( '<comment>⚠ The refresh request failed for this batch.</comment>' );
+			$unrefreshed += \array_fill_keys( $chunk, 'The batch refresh request failed (e.g. timeout).' );
+			continue;
+		}
+		$any_batch = true;
+		$results  += $chunk_results;
+		$errors   += $chunk_errors ?? array();
+	}
+
+	if ( ! $any_batch ) {
+		$emit( '<comment>⚠ No refresh batch succeeded; proceeding anyway (sites that already detected the release will still update).</comment>' );
+	}
+
+	$notes = array();
+	if ( \count( $errors ) > 0 ) {
+		$notes[] = \count( $errors ) . ' could not be reached (no Atlantis or connection down)';
+	}
+	if ( \count( $unrefreshed ) > 0 ) {
+		$notes[] = \count( $unrefreshed ) . ' were in a failed batch and not re-checked';
+	}
+	$suffix = empty( $notes ) ? '' : '; ' . \implode( '; ', $notes ) . ' and may not detect the release';
+	$emit( '<comment>Refreshed ' . \count( $results ) . ' of ' . \count( $site_ids ) . ' site(s)' . $suffix . '.</comment>' );
+
+	return array(
+		'refreshed_count' => \count( $results ),
+		'total'           => \count( $site_ids ),
+		'unreachable'     => $errors,
+		'unrefreshed'     => $unrefreshed,
+	);
+}
+
+/**
+ * Executes a built plan: update or force-install on the planned sites. (Refresh, when requested, is a
+ * separate step the caller runs first via run_wpcom_plugin_update_refresh().)
+ *
+ * Pure of direct console writes — progress is emitted only via the optional callback.
+ *
+ * @param   array         $plan     A plan from build_wpcom_plugin_update_plan().
+ * @param   boolean       $force    Whether to force-install from $package (vs the detection update).
+ * @param   string|null   $package  The package zip URL (force mode).
+ * @param   callable|null $progress Optional progress emitter: `fn( string $message ): void`.
+ *
+ * @return  array{results: array, errors: array}
+ */
+function execute_wpcom_plugin_update_plan( array $plan, bool $force, ?string $package, ?callable $progress = null ): array {
+	$emit    = static fn( string $message ) => \is_callable( $progress ) ? $progress( $message ) : null;
+	$targets = $plan['targets'];
+
+	$results = array();
+	$errors  = array();
+	if ( $force ) {
+		// Group by plugin folder (the replace slug); near-always a single group. Only `install` sites.
+		$groups = array();
+		foreach ( $targets as $site_id => $target ) {
+			if ( 'install' === ( $target['plan'] ?? 'install' ) ) {
+				$groups[ $target['folder'] ][] = $site_id;
+			}
+		}
+		foreach ( $groups as $slug => $site_ids ) {
+			$chunks = \array_chunk( $site_ids, WPCOM_PLUGIN_UPDATE_BATCH_SIZE );
+			$total  = \count( $chunks );
+			foreach ( $chunks as $index => $chunk ) {
+				$emit( '<comment>Batch ' . ( $index + 1 ) . "/$total: force-installing on " . \count( $chunk ) . ' site(s)…</comment>' );
+				$chunk_results = replace_wpcom_site_plugins_batch( $chunk, $slug, (string) $package, $chunk_errors );
+				if ( \is_null( $chunk_results ) ) {
+					$emit( '<error>The force-install request failed for this batch.</error>' );
+					continue;
+				}
+				$results += $chunk_results;
+				$errors  += $chunk_errors ?? array();
+			}
+		}
+	} else {
+		// Group by plugin identifier (near-always a single group) and update each group in one batch call.
+		$groups = array();
+		foreach ( $targets as $site_id => $target ) {
+			$groups[ $target['name'] ][] = $site_id;
+		}
+		foreach ( $groups as $plugin_name => $site_ids ) {
+			$group_results = update_wpcom_site_plugins_batch( $site_ids, $plugin_name, $group_errors );
+			if ( \is_null( $group_results ) ) {
+				$emit( "<error>The update request failed for plugin `$plugin_name`.</error>" );
+				continue;
+			}
+			$results += $group_results;
+			$errors  += $group_errors ?? array();
+		}
+	}
+
+	return array(
+		'results' => $results,
+		'errors'  => $errors,
+	);
+}
+
+/**
  * Returns the stats for a WPCOM or Jetpack Connected site.
  *
  * @param   string      $site_id_or_url The site URL or WordPress.com site ID.

--- a/mcp/Team51McpTools.php
+++ b/mcp/Team51McpTools.php
@@ -2390,6 +2390,140 @@ final class Team51McpTools {
 		return $server ? (array) $server : array( 'error' => 'Failed to create DeployHQ project server.' );
 	}
 
+	/**
+	 * Update, or force-install, a plugin across connected Jetpack sites (wraps `jetpack:plugin-update`).
+	 *
+	 * DEFAULTS TO A DRY RUN — nothing is changed unless `dry_run` is explicitly set to false. High risk:
+	 * with `force` this overwrites the plugin in place from `package`; with `downgrade` it rolls sites that
+	 * are AHEAD of the package back to it. Calls the same shared planner/executor the CLI command uses, so
+	 * the audited version-gating / no-downgrade guard is the single source of truth. Returns a structured
+	 * plan (and, when applied, per-site results) rather than a text blob.
+	 *
+	 * @param string      $plugin      The plugin term, matched exactly against folder / main file / textdomain.
+	 * @param string      $sites       `all`, a comma-separated list of site URLs and/or numeric WPCOM IDs, or a CSV path. Required — never implicitly all.
+	 * @param string|null $environment Optional environment filter: `staging` (only URLs containing "staging") or `production` (skips them).
+	 * @param string|null $release     Optional version being published; used as the target-version fallback when the package has no readable header.
+	 * @param bool        $refresh     Force a fresh update-check (Atlantis lever) before the detection-based update. Ignored with `force`.
+	 * @param bool        $force       Force-install from `package`, bypassing update detection. Requires `package`.
+	 * @param string|null $package     Public zip URL to force-install (server-side download). Required with `force`.
+	 * @param bool        $reinstall   With `force`, also overwrite sites already at the package version.
+	 * @param bool        $downgrade   With `force`, also overwrite sites NEWER than the package — roll them back. Destructive.
+	 * @param bool        $dry_run     Plan only, without changing anything. Defaults to true for safety.
+	 *
+	 * @return array The plan summary (and per-site results when applied), or an `error` entry.
+	 */
+	#[McpTool(
+		name: 'jetpack_plugin_update',
+		annotations: new ToolAnnotations(
+			title: 'Update / Force-Install a Plugin Across Sites (High Risk)',
+			readOnlyHint: false,
+			destructiveHint: true,
+			idempotentHint: false,
+			openWorldHint: true,
+		)
+	)]
+	public function jetpack_plugin_update(
+		string $plugin,
+		string $sites,
+		?string $environment = null,
+		?string $release = null,
+		bool $refresh = false,
+		bool $force = false,
+		?string $package = null,
+		bool $reinstall = false,
+		bool $downgrade = false,
+		bool $dry_run = true
+	): array {
+		$identity_error = self::ensure_identity();
+		if ( $identity_error ) {
+			return $identity_error;
+		}
+
+		// Resolve + plan via the SAME shared functions the CLI command uses (single source of the
+		// audited no-downgrade guard). Option/validation errors come back as a structured error.
+		try {
+			validate_wpcom_plugin_update_options( $force, $package, $reinstall, $downgrade, $refresh, $environment );
+			$plan = build_wpcom_plugin_update_plan( $plugin, $sites, $environment, $force, $package, $release, $reinstall, $downgrade );
+		} catch ( \Throwable $throwable ) {
+			return array( 'error' => $throwable->getMessage() );
+		}
+
+		$plan_rows = array();
+		$counts    = array(
+			'install' => 0,
+			'current' => 0,
+			'ahead'   => 0,
+		);
+		foreach ( $plan['targets'] as $site_id => $target ) {
+			$bucket      = $target['plan'] ?? ( $force ? 'install' : 'update' );
+			$plan_rows[] = array(
+				'site_id'   => $site_id,
+				'site_url'  => $target['siteurl'],
+				'installed' => $target['installed'],
+				'plan'      => $bucket,
+			);
+			if ( isset( $counts[ $bucket ] ) ) {
+				++$counts[ $bucket ];
+			}
+		}
+
+		$response = array(
+			'dry_run'        => $dry_run,
+			'plugin'         => $plugin,
+			'target_version' => $plan['target_version'],
+			'fetched_count'  => $plan['fetched_count'],
+			'matched_count'  => $plan['matched_count'],
+			'targeted_count' => \count( $plan['targets'] ),
+			'plan_counts'    => $counts,
+			'plan'           => $plan_rows,
+			'unqueryable'    => \array_keys( $plan['unqueryable'] ),
+			'unmatched'      => $plan['unmatched'],
+		);
+
+		if ( $dry_run ) {
+			$response['note'] = 'Dry run: no sites were changed. Set dry_run=false to apply.';
+			return $response;
+		}
+
+		// Apply: refresh first (detection path only), then update / force-install via the shared executor.
+		if ( $refresh && ! $force ) {
+			$response['refresh'] = run_wpcom_plugin_update_refresh( \array_keys( $plan['targets'] ) );
+		}
+		$execution = execute_wpcom_plugin_update_plan( $plan, $force, $package );
+
+		$results = array();
+		foreach ( $plan['targets'] as $site_id => $target ) {
+			$was = $target['installed'];
+			if ( isset( $execution['errors'][ $site_id ] ) ) {
+				$results[] = array(
+					'site_id'  => $site_id,
+					'site_url' => $target['siteurl'],
+					'was'      => $was,
+					'result'   => 'failed',
+					'error'    => encode_json_content( $execution['errors'][ $site_id ]->errors ?? $execution['errors'][ $site_id ] ),
+				);
+			} elseif ( isset( $execution['results'][ $site_id ] ) ) {
+				$results[] = array(
+					'site_id'  => $site_id,
+					'site_url' => $target['siteurl'],
+					'was'      => $was,
+					'now'      => (string) ( $execution['results'][ $site_id ]->version ?? $was ),
+					'result'   => 'applied',
+				);
+			} else {
+				$results[] = array(
+					'site_id'  => $site_id,
+					'site_url' => $target['siteurl'],
+					'was'      => $was,
+					'result'   => $target['plan'] ?? 'skipped',
+				);
+			}
+		}
+		$response['results'] = $results;
+
+		return $response;
+	}
+
 	#[McpTool( name: 'jetpack_connection_triage' )]
 	public function jetpack_connection_triage( ?string $csv_path = null ): array {
 		$identity_error = self::ensure_identity();

--- a/mcp/Team51McpTools.php
+++ b/mcp/Team51McpTools.php
@@ -2449,22 +2449,19 @@ final class Team51McpTools {
 		}
 
 		$plan_rows = array();
-		$counts    = array(
-			'install' => 0,
-			'current' => 0,
-			'ahead'   => 0,
-		);
+		$counts    = array();
 		foreach ( $plan['targets'] as $site_id => $target ) {
-			$bucket      = $target['plan'] ?? ( $force ? 'install' : 'update' );
-			$plan_rows[] = array(
+			// Detection-path targets carry no `plan` key; count them under `update` so the counts sum to
+			// targeted_count and a client does not read all-zeros as "nothing to update".
+			$bucket            = $target['plan'] ?? ( $force ? 'install' : 'update' );
+			$plan_rows[]       = array(
 				'site_id'   => $site_id,
 				'site_url'  => $target['siteurl'],
+				'plugin'    => $target['name'],
 				'installed' => $target['installed'],
 				'plan'      => $bucket,
 			);
-			if ( isset( $counts[ $bucket ] ) ) {
-				++$counts[ $bucket ];
-			}
+			$counts[ $bucket ] = ( $counts[ $bucket ] ?? 0 ) + 1;
 		}
 
 		$response = array(
@@ -2486,10 +2483,16 @@ final class Team51McpTools {
 		}
 
 		// Apply: refresh first (detection path only), then update / force-install via the shared executor.
-		if ( $refresh && ! $force ) {
-			$response['refresh'] = run_wpcom_plugin_update_refresh( \array_keys( $plan['targets'] ) );
+		// Wrapped so the tool returns a structured error rather than throwing (add-mcp-tool.md §4).
+		try {
+			if ( $refresh && ! $force ) {
+				$response['refresh'] = run_wpcom_plugin_update_refresh( \array_keys( $plan['targets'] ) );
+			}
+			$execution = execute_wpcom_plugin_update_plan( $plan, $force, $package );
+		} catch ( \Throwable $throwable ) {
+			$response['error'] = $throwable->getMessage();
+			return $response;
 		}
-		$execution = execute_wpcom_plugin_update_plan( $plan, $force, $package );
 
 		$results = array();
 		foreach ( $plan['targets'] as $site_id => $target ) {

--- a/mcp/Team51McpTools.php
+++ b/mcp/Team51McpTools.php
@@ -2391,23 +2391,19 @@ final class Team51McpTools {
 	}
 
 	/**
-	 * Update, or force-install, a plugin across connected Jetpack sites (wraps `jetpack:plugin-update`).
+	 * Update a plugin across connected Jetpack sites (wraps `jetpack:plugin-update`).
 	 *
-	 * DEFAULTS TO A DRY RUN — nothing is changed unless `dry_run` is explicitly set to false. High risk:
-	 * with `force` this overwrites the plugin in place from `package`; with `downgrade` it rolls sites that
-	 * are AHEAD of the package back to it. Calls the same shared planner/executor the CLI command uses, so
-	 * the audited version-gating / no-downgrade guard is the single source of truth. Returns a structured
-	 * plan (and, when applied, per-site results) rather than a text blob.
+	 * DEFAULTS TO A DRY RUN — nothing is changed unless `dry_run` is explicitly set to false. Updates each
+	 * targeted site via the WPCOM plugin update endpoint (the detection path): a site only moves forward to
+	 * a version its own update source already offers. Optionally forces a fresh update-check first via the
+	 * Atlantis lever. Calls the same shared planner/executor the CLI command uses. Returns a structured plan
+	 * (and, when applied, per-site results) rather than a text blob.
 	 *
 	 * @param string      $plugin      The plugin term, matched exactly against folder / main file / textdomain.
 	 * @param string      $sites       `all`, a comma-separated list of site URLs and/or numeric WPCOM IDs, or a CSV path. Required — never implicitly all.
 	 * @param string|null $environment Optional environment filter: `staging` (only URLs containing "staging") or `production` (skips them).
-	 * @param string|null $release     Optional version being published; used as the target-version fallback when the package has no readable header.
-	 * @param bool        $refresh     Force a fresh update-check (Atlantis lever) before the detection-based update. Ignored with `force`.
-	 * @param bool        $force       Force-install from `package`, bypassing update detection. Requires `package`.
-	 * @param string|null $package     Public zip URL to force-install (server-side download). Required with `force`.
-	 * @param bool        $reinstall   With `force`, also overwrite sites already at the package version.
-	 * @param bool        $downgrade   With `force`, also overwrite sites NEWER than the package — roll them back. Destructive.
+	 * @param string|null $release     Optional version being published; when set, each site is reported as updated / current / ahead / behind relative to it.
+	 * @param bool        $refresh     Force a fresh update-check (Atlantis lever) before the detection-based update.
 	 * @param bool        $dry_run     Plan only, without changing anything. Defaults to true for safety.
 	 *
 	 * @return array The plan summary (and per-site results when applied), or an `error` entry.
@@ -2415,7 +2411,7 @@ final class Team51McpTools {
 	#[McpTool(
 		name: 'jetpack_plugin_update',
 		annotations: new ToolAnnotations(
-			title: 'Update / Force-Install a Plugin Across Sites (High Risk)',
+			title: 'Update a Plugin Across Sites',
 			readOnlyHint: false,
 			destructiveHint: true,
 			idempotentHint: false,
@@ -2428,10 +2424,6 @@ final class Team51McpTools {
 		?string $environment = null,
 		?string $release = null,
 		bool $refresh = false,
-		bool $force = false,
-		?string $package = null,
-		bool $reinstall = false,
-		bool $downgrade = false,
 		bool $dry_run = true
 	): array {
 		$identity_error = self::ensure_identity();
@@ -2439,11 +2431,11 @@ final class Team51McpTools {
 			return $identity_error;
 		}
 
-		// Resolve + plan via the SAME shared functions the CLI command uses (single source of the
-		// audited no-downgrade guard). Option/validation errors come back as a structured error.
+		// Resolve + plan via the SAME shared functions the CLI command uses. Option/validation errors
+		// come back as a structured error.
 		try {
-			validate_wpcom_plugin_update_options( $force, $package, $reinstall, $downgrade, $refresh, $environment );
-			$plan = build_wpcom_plugin_update_plan( $plugin, $sites, $environment, $force, $package, $release, $reinstall, $downgrade );
+			validate_wpcom_plugin_update_options( $environment );
+			$plan = build_wpcom_plugin_update_plan( $plugin, $sites, $environment );
 		} catch ( \Throwable $throwable ) {
 			return array( 'error' => $throwable->getMessage() );
 		}
@@ -2451,23 +2443,19 @@ final class Team51McpTools {
 		$plan_rows = array();
 		$counts    = array();
 		foreach ( $plan['targets'] as $site_id => $target ) {
-			// Detection-path targets carry no `plan` key; count them under `update` so the counts sum to
-			// targeted_count and a client does not read all-zeros as "nothing to update".
-			$bucket            = $target['plan'] ?? ( $force ? 'install' : 'update' );
-			$plan_rows[]       = array(
+			$plan_rows[]      = array(
 				'site_id'   => $site_id,
 				'site_url'  => $target['siteurl'],
 				'plugin'    => $target['name'],
 				'installed' => $target['installed'],
-				'plan'      => $bucket,
+				'plan'      => 'update',
 			);
-			$counts[ $bucket ] = ( $counts[ $bucket ] ?? 0 ) + 1;
+			$counts['update'] = ( $counts['update'] ?? 0 ) + 1;
 		}
 
 		$response = array(
 			'dry_run'        => $dry_run,
 			'plugin'         => $plugin,
-			'target_version' => $plan['target_version'],
 			'fetched_count'  => $plan['fetched_count'],
 			'matched_count'  => $plan['matched_count'],
 			'targeted_count' => \count( $plan['targets'] ),
@@ -2482,13 +2470,13 @@ final class Team51McpTools {
 			return $response;
 		}
 
-		// Apply: refresh first (detection path only), then update / force-install via the shared executor.
+		// Apply: refresh first (optional), then update via the shared executor.
 		// Wrapped so the tool returns a structured error rather than throwing (add-mcp-tool.md §4).
 		try {
-			if ( $refresh && ! $force ) {
+			if ( $refresh ) {
 				$response['refresh'] = run_wpcom_plugin_update_refresh( \array_keys( $plan['targets'] ) );
 			}
-			$execution = execute_wpcom_plugin_update_plan( $plan, $force, $package );
+			$execution = execute_wpcom_plugin_update_plan( $plan );
 		} catch ( \Throwable $throwable ) {
 			$response['error'] = $throwable->getMessage();
 			return $response;
@@ -2518,7 +2506,7 @@ final class Team51McpTools {
 					'site_id'  => $site_id,
 					'site_url' => $target['siteurl'],
 					'was'      => $was,
-					'result'   => $target['plan'] ?? 'skipped',
+					'result'   => 'skipped',
 				);
 			}
 		}

--- a/mcp/Team51McpTools.php
+++ b/mcp/Team51McpTools.php
@@ -2494,19 +2494,25 @@ final class Team51McpTools {
 					'error'    => encode_json_content( $execution['errors'][ $site_id ]->errors ?? $execution['errors'][ $site_id ] ),
 				);
 			} elseif ( isset( $execution['results'][ $site_id ] ) ) {
+				$now       = (string) ( $execution['results'][ $site_id ]->version ?? $was );
 				$results[] = array(
 					'site_id'  => $site_id,
 					'site_url' => $target['siteurl'],
 					'was'      => $was,
-					'now'      => (string) ( $execution['results'][ $site_id ]->version ?? $was ),
-					'result'   => 'applied',
+					'now'      => $now,
+					// Classify against $release so a client verifying a rollout gets updated/current/ahead/behind
+					// (a site the release has not reached succeeds with an unchanged version and reads `behind`).
+					'result'   => classify_wpcom_plugin_update_result( $was, $now, $release ),
 				);
 			} else {
+				// Reachable only when the batch request returned null (a genuine failure) now that force mode's
+				// intentional skips are gone; report it as failed so the MCP tool and the CLI agree.
 				$results[] = array(
 					'site_id'  => $site_id,
 					'site_url' => $target['siteurl'],
 					'was'      => $was,
-					'result'   => 'skipped',
+					'result'   => 'failed',
+					'error'    => 'The update request failed for this site\'s batch.',
 				);
 			}
 		}


### PR DESCRIPTION
## Summary

Adds `team51 jetpack:plugin-update <slug>` — force-updates a given plugin across every connected Jetpack site where it is installed, in one command. This replaces the painfully slow "SSH into each site and run `wp plugin update`" approach and sidesteps the WPCOM dashboard's ~12h update-detection lag.

Each site is updated through the WPCOM **v1.2** plugin update endpoint (via the companion OpsOasis batch endpoint), which self-refreshes the update cache and installs from the plugin's **own update source** — wp.org for public plugins, a custom `Update URI` (e.g. GitHub) for custom plugins like Atlantis. Verified end-to-end: a downgraded Atlantis pulled its new release straight from GitHub.

## Changes

- **`commands/Jetpack_Plugin_Update.php`** — new command. Fetches the fleet (`get_wpcom_jetpack_sites`), finds every site with an **exact** slug match, derives each site's plugin identifier, and updates them via a batch call. Reports `Site | Was | Now | Result` (updated / current / failed) and exits non-zero on any failure.
- **`includes/functions-wpcom.php`** — `update_wpcom_site_plugins_batch()` helper (mirrors `get_wpcom_sites_atlantis_status_batch`).

## Options

- `--site <id|domain>` — limit to one site (canary before the fleet).
- `--min-version <x>` — only update sites whose installed version is below `x`.
- `--dry-run` — list target sites without updating.
- `--yes` — skip the confirmation prompt.

## Notes

- Matching is **exact-only** (folder / main file / textdomain) — partial matching on a fleet-wide write is intentionally not supported.
- The update only fires where a newer version is available, so publish the release before running. Same-version re-pushes report "No update needed".

## Dependency

Requires the companion OpsOasis endpoint: **a8cteam51/opsoasis#390** (must be deployed before this command works).

## Testing

```
team51 --dev jetpack:plugin-update hello-dolly --site atlantis-qa-production.mystagingwebsite.com --dry-run
team51 --dev jetpack:plugin-update a8csp-atlantis --site atlantis-qa-production.mystagingwebsite.com
team51 --dev jetpack:plugin-update a8csp-atlantis
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)