### PR TITLE
Harden Safety Net install during site duplication

### DIFF
--- a/.agents/skills/connection-helpers.md
+++ b/.agents/skills/connection-helpers.md
@@ -74,11 +74,17 @@ This retries `get_ssh_connection()` (which also verifies the server responds to 
 
 ### 3. SFTP path convention
 
-Pressable/WPCOM sites use `htdocs` as the web root. Paths are absolute from the connection root:
+Pressable/WPCOM sites use `htdocs` as the web root. Over **SFTP**, paths are absolute from the connection root:
 
 - `/htdocs/wp-content/mu-plugins/`
 - `/htdocs/wp-content/plugins/`
 - `/htdocs/wp-config.php`
+
+This absolute form is the SFTP root only. An SSH `exec()` starts a fresh shell at the login directory, where the
+layout may be the home-relative `htdocs` or the absolute `/htdocs` — both exist in the wild — so SSH callers must
+resolve the prefix instead of hardcoding `/htdocs`. See `get_ssh_site_root_path()` in
+`includes/functions-safety-net.php`, or the relative-then-absolute probe in
+`commands/Pressable_Site_Plugins_Download.php`.
 
 ### 4. SSH exec output and exit status
 
@@ -115,6 +121,13 @@ Connection helpers obtain credentials via OpsOasis:
 - **WPCOM**: `get_wpcom_site_ssh_username()` + `rotate_wpcom_site_sftp_user_password()`
 
 Credentials are cached per `$site_identifier` during the request. Do not call these directly from commands; use the connection helpers.
+
+The one credential-adjacent call a command may make itself is `Pressable_Connection_Helper::ensure_sftp_user( $site_id )`:
+opening a connection deliberately does **not** provision the concierge collaborator (that is a write, and read-only
+commands must not grant access as a side effect). A command that provisions a site — e.g. `Pressable_Site_Clone` —
+calls it once, explicitly, before connecting. It looks the SFTP user up a few times, then creates the collaborator and
+polls for the user to appear. A `false` return is a warning that SSH may not work yet, not by itself a reason to stop:
+Pressable provisions users asynchronously, and the SSH wait re-queries on every pass.
 
 ## When to Use Which
 

--- a/.agents/skills/connection-helpers.md
+++ b/.agents/skills/connection-helpers.md
@@ -65,9 +65,12 @@ Right after cloning or creating a site, the server may accept connections but no
 
 ```php
 $ssh = wait_on_pressable_site_ssh( $site_id, $output );
+if ( \is_null( $ssh ) ) {
+    // The site never became reachable — handle it; do not proceed as though it had.
+}
 ```
 
-This loops until `get_ssh_connection()` succeeds and the server responds to `ls -la`. SFTP is typically ready sooner than SSH for new sites.
+This retries `get_ssh_connection()` (which also verifies the server responds to `ls -la`) up to `$max_attempts` times (default 60, 5 seconds apart), then reports the timeout and returns `null` — callers must handle that. SFTP is typically ready sooner than SSH for new sites.
 
 ### 3. SFTP path convention
 
@@ -93,13 +96,16 @@ For streaming/callback style, `exec()` can accept a callback. See `Pressable_Sit
 
 ```php
 $result = $sftp->put(
-    '/htdocs/wp-content/mu-plugins/load-safety-net.php',
-    file_get_contents( __DIR__ . '/../scaffold/load-safety-net.php' )
+    '/htdocs/wp-content/uploads/example.png',
+    file_get_contents( $local_path )
 );
 if ( ! $result ) {
     // Upload failed
 }
 ```
+
+For writing a small text file over an existing SSH connection, a quoted heredoc avoids opening a second
+(SFTP) connection — see `write_safety_net_loader()` in `includes/functions-safety-net.php` for the pattern.
 
 ### 6. Credential handling (internal)
 
@@ -132,5 +138,5 @@ See `connection-helper-pressable.php` and `connection-helper-wpcom.php` for refe
 
 ## Example Commands
 
-- **SSH**: `Pressable_Site_Clone`, `Pressable_Site_WP_CLI_Command_Run`, `Pressable_Site_Shell_Open`, `WPCOM_Site_WP_CLI_Command_Run`
-- **SFTP**: `Pressable_Site_Clone` (SafetyNet loader), `Pressable_Site_Icon_Upload`, `WPCOM_Site_Clone`, `GitHub_Pattern_To_Repo_Export`
+- **SSH**: `Pressable_Site_Clone` (SafetyNet install + loader via heredoc), `Pressable_Site_WP_CLI_Command_Run`, `Pressable_Site_Shell_Open`, `WPCOM_Site_WP_CLI_Command_Run`
+- **SFTP**: `Pressable_Site_Icon_Upload`, `Pressable_Site_Plugins_Download`, `GitHub_Pattern_To_Repo_Export`

--- a/.agents/skills/connection-helpers.md
+++ b/.agents/skills/connection-helpers.md
@@ -90,7 +90,7 @@ if ( 0 !== $exit_code ) {
 }
 ```
 
-For streaming/callback style, `exec()` can accept a callback. See `Pressable_Site_Clone.php` for examples.
+For streaming/callback style, `exec()` can accept a callback. See `Pressable_Site_WP_CLI_Command_Run.php` or `SSH_Worker.php` for examples.
 
 ### 5. SFTP put
 
@@ -138,5 +138,5 @@ See `connection-helper-pressable.php` and `connection-helper-wpcom.php` for refe
 
 ## Example Commands
 
-- **SSH**: `Pressable_Site_Clone` (SafetyNet install + loader via heredoc), `Pressable_Site_WP_CLI_Command_Run`, `Pressable_Site_Shell_Open`, `WPCOM_Site_WP_CLI_Command_Run`
+- **SSH**: `includes/functions-safety-net.php` (SafetyNet install + loader via heredoc, used by both clone commands), `Pressable_Site_WP_CLI_Command_Run`, `Pressable_Site_Shell_Open`, `WPCOM_Site_WP_CLI_Command_Run`
 - **SFTP**: `Pressable_Site_Icon_Upload`, `Pressable_Site_Plugins_Download`, `GitHub_Pattern_To_Repo_Export`

--- a/commands/Pressable_Site_Clone.php
+++ b/commands/Pressable_Site_Clone.php
@@ -235,11 +235,7 @@ final class Pressable_Site_Clone extends Command {
 		if ( $this->skip_safety_net ) {
 			$output->writeln( '<comment>Skipping the installation of SafetyNet as a mu-plugin.</comment>' );
 		} else {
-			$safety_net_installed = maybe_install_safety_net(
-				$ssh_connection,
-				$output,
-				static fn( string $command ) => run_pressable_site_wp_cli_command( $site_clone->id, $command )
-			);
+			$safety_net_installed = maybe_install_safety_net( $ssh_connection, $output );
 		}
 		$ssh_connection?->disconnect();
 
@@ -259,8 +255,10 @@ final class Pressable_Site_Clone extends Command {
 		run_pressable_site_wp_cli_command( $site_clone->id, 'cache flush' );
 
 		// Asking the clone itself is only meaningful once it answers on its own URL, which the search-replace
-		// above is what makes true. A site that reports itself scrubbed is protected whatever the files showed.
-		if ( ! $this->skip_safety_net && ! $safety_net_installed ) {
+		// above is what makes true. The file check only proves the files are present; this endpoint is the
+		// authoritative signal that Safety Net actually booted and scrubbed, so it decides the final verdict
+		// on every run - not just when the files were missing.
+		if ( ! $this->skip_safety_net ) {
 			$safety_net_installed = is_safety_net_confirmed_via_http( $site_clone->url );
 		}
 

--- a/commands/Pressable_Site_Clone.php
+++ b/commands/Pressable_Site_Clone.php
@@ -235,9 +235,20 @@ final class Pressable_Site_Clone extends Command {
 		);
 		run_pressable_site_wp_cli_command( $site_clone->id, 'config set WP_ENVIRONMENT_TYPE development --type=constant' );
 
+		// This constant is what makes Safety Net treat the clone as non-production and scrub it, so its
+		// outcome is read from the reply - the runner's exit code only covers the connection - and named in
+		// the final banner if it failed.
+		$environment_output = (string) ( $GLOBALS['wp_cli_output'] ?? '' );
+		$environment_set    = ! is_wp_cli_error_output( $environment_output ) && is_wp_cli_success_output( $environment_output );
+
 		if ( $this->skip_safety_net ) {
 			$output->writeln( '<comment>Skipping the installation of SafetyNet as a mu-plugin.</comment>' );
 		} else {
+			// The wait above can expire on a site that becomes reachable moments later - the steps in between
+			// open their own connections and may already have succeeded - so the install gets one fresh
+			// attempt instead of inheriting a stale null.
+			$ssh_connection ??= \Pressable_Connection_Helper::get_ssh_connection( $site_clone->id );
+
 			maybe_install_safety_net( $ssh_connection, $output );
 		}
 		$ssh_connection?->disconnect();
@@ -268,7 +279,7 @@ final class Pressable_Site_Clone extends Command {
 		// above is what makes true. The file check only proves the files are present; this endpoint is the
 		// authoritative signal that Safety Net actually booted and scrubbed, so it decides the final verdict
 		// on every run - not just when the files were missing.
-		$safety_net_installed = $this->skip_safety_net ? true : is_safety_net_confirmed_via_http( $site_clone->url );
+		$safety_net_installed = $this->skip_safety_net ? true : is_safety_net_confirmed_via_http( $site_clone->url, $output );
 
 		if ( true !== $safety_net_installed ) {
 			$headline = \is_null( $safety_net_installed )
@@ -277,6 +288,9 @@ final class Pressable_Site_Clone extends Command {
 
 			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
 			$output->writeln( "<error>$headline</error>" );
+			if ( ! $environment_set ) {
+				$output->writeln( '<error>    Setting WP_ENVIRONMENT_TYPE failed, which alone keeps Safety Net from scrubbing.</error>' );
+			}
 			$output->writeln( '<error>    Treat the clone as holding unscrubbed production data until you have checked it.</error>' );
 			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
 			return Command::FAILURE;

--- a/commands/Pressable_Site_Clone.php
+++ b/commands/Pressable_Site_Clone.php
@@ -235,7 +235,7 @@ final class Pressable_Site_Clone extends Command {
 		if ( $this->skip_safety_net ) {
 			$output->writeln( '<comment>Skipping the installation of SafetyNet as a mu-plugin.</comment>' );
 		} else {
-			$safety_net_installed = maybe_install_safety_net( $ssh_connection, $output );
+			maybe_install_safety_net( $ssh_connection, $output );
 		}
 		$ssh_connection?->disconnect();
 

--- a/commands/Pressable_Site_Clone.php
+++ b/commands/Pressable_Site_Clone.php
@@ -213,6 +213,10 @@ final class Pressable_Site_Clone extends Command {
 			return Command::FAILURE;
 		}
 
+		// A clone does not always inherit the concierge collaborator, and without it every SSH and SFTP
+		// connection below fails with `SFTP user not found.`
+		\Pressable_Connection_Helper::ensure_sftp_user( $site_clone->id );
+
 		$ssh_connection = wait_on_pressable_site_ssh( $site_clone->id, $output );
 
 		// Run a few commands to set up the site.

--- a/commands/Pressable_Site_Clone.php
+++ b/commands/Pressable_Site_Clone.php
@@ -231,7 +231,6 @@ final class Pressable_Site_Clone extends Command {
 		);
 		run_pressable_site_wp_cli_command( $site_clone->id, 'config set WP_ENVIRONMENT_TYPE development --type=constant' );
 
-		$safety_net_installed = true;
 		if ( $this->skip_safety_net ) {
 			$output->writeln( '<comment>Skipping the installation of SafetyNet as a mu-plugin.</comment>' );
 		} else {
@@ -258,12 +257,13 @@ final class Pressable_Site_Clone extends Command {
 		// above is what makes true. The file check only proves the files are present; this endpoint is the
 		// authoritative signal that Safety Net actually booted and scrubbed, so it decides the final verdict
 		// on every run - not just when the files were missing.
-		if ( ! $this->skip_safety_net ) {
-			$safety_net_installed = is_safety_net_confirmed_via_http( $site_clone->url );
-		}
+		$safety_net_installed = $this->skip_safety_net ? true : is_safety_net_confirmed_via_http( $site_clone->url );
 
 		if ( Command::SUCCESS !== $rotate_status ) {
-			$output->writeln( '<comment>⚠  Heads up: the WP user password rotation did not complete cleanly. See the warning above for what to record or retry.</comment>' );
+			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
+			$output->writeln( '<error>⚠  The WP user password rotation did not complete cleanly.</error>' );
+			$output->writeln( '<error>    See the warning above for the password to record or the rotation to retry.</error>' );
+			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
 		}
 
 		if ( true !== $safety_net_installed ) {

--- a/commands/Pressable_Site_Clone.php
+++ b/commands/Pressable_Site_Clone.php
@@ -215,14 +215,15 @@ final class Pressable_Site_Clone extends Command {
 
 		// A clone does not always inherit the concierge collaborator, and without it every SSH and SFTP
 		// connection below fails with `SFTP user not found.`
-		$sftp_user_ready = \Pressable_Connection_Helper::ensure_sftp_user( $site_clone->id );
-		if ( ! $sftp_user_ready ) {
-			$output->writeln( "<error>No usable SFTP user for $site_clone->url. The steps below that need SSH will fail.</error>" );
+		if ( ! \Pressable_Connection_Helper::ensure_sftp_user( $site_clone->id ) ) {
+			$output->writeln( "<error>No usable SFTP user for $site_clone->url yet. Still waiting for one; the steps below that need SSH will fail if it does not appear.</error>" );
 		}
 
-		// Without credentials the wait cannot succeed, so it is cut short: the run should end at the reason
-		// above rather than five minutes later at a timeout.
-		$ssh_connection = wait_on_pressable_site_ssh( $site_clone->id, $output, $sftp_user_ready ? 60 : 6 );
+		// The wait keeps its full budget even after that warning. A failure to confirm the SFTP user does not
+		// mean one will never appear - Pressable provisions them asynchronously, and the wait re-queries every
+		// pass - so cutting it short here would strand a clone that was moments from being reachable, holding
+		// unscrubbed production data. The reason is already on screen; the budget is the safety margin.
+		$ssh_connection = wait_on_pressable_site_ssh( $site_clone->id, $output );
 
 		// Run a few commands to set up the site.
 		$rotate_status = run_app_command(

--- a/commands/Pressable_Site_Clone.php
+++ b/commands/Pressable_Site_Clone.php
@@ -215,7 +215,9 @@ final class Pressable_Site_Clone extends Command {
 
 		// A clone does not always inherit the concierge collaborator, and without it every SSH and SFTP
 		// connection below fails with `SFTP user not found.`
-		\Pressable_Connection_Helper::ensure_sftp_user( $site_clone->id );
+		if ( ! \Pressable_Connection_Helper::ensure_sftp_user( $site_clone->id ) ) {
+			$output->writeln( "<error>No usable SFTP user for $site_clone->url. The steps below that need SSH will fail.</error>" );
+		}
 
 		$ssh_connection = wait_on_pressable_site_ssh( $site_clone->id, $output );
 
@@ -263,7 +265,7 @@ final class Pressable_Site_Clone extends Command {
 		}
 
 		if ( Command::SUCCESS !== $rotate_status ) {
-			$output->writeln( '<comment>⚠  Heads up: 1Password sync did not complete during this run. See the warning above for the password to record manually.</comment>' );
+			$output->writeln( '<comment>⚠  Heads up: the WP user password rotation did not complete cleanly. See the warning above for what to record or retry.</comment>' );
 		}
 
 		if ( true !== $safety_net_installed ) {

--- a/commands/Pressable_Site_Clone.php
+++ b/commands/Pressable_Site_Clone.php
@@ -262,10 +262,14 @@ final class Pressable_Site_Clone extends Command {
 			$output->writeln( '<comment>⚠  Heads up: 1Password sync did not complete during this run. See the warning above for the password to record manually.</comment>' );
 		}
 
-		if ( ! $safety_net_installed ) {
+		if ( true !== $safety_net_installed ) {
+			$headline = \is_null( $safety_net_installed )
+				? "⚠  Could not verify SafetyNet on $site_clone->url."
+				: "⚠  SafetyNet is NOT installed on $site_clone->url.";
+
 			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
-			$output->writeln( "<error>⚠  SafetyNet is NOT installed on $site_clone->url.</error>" );
-			$output->writeln( '<error>    The clone still holds unscrubbed production data. Install it manually before sharing the site.</error>' );
+			$output->writeln( "<error>$headline</error>" );
+			$output->writeln( '<error>    Treat the clone as holding unscrubbed production data until you have checked it.</error>' );
 			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
 			return Command::FAILURE;
 		}

--- a/commands/Pressable_Site_Clone.php
+++ b/commands/Pressable_Site_Clone.php
@@ -225,47 +225,15 @@ final class Pressable_Site_Clone extends Command {
 		);
 		run_pressable_site_wp_cli_command( $site_clone->id, 'config set WP_ENVIRONMENT_TYPE development --type=constant' );
 
+		$safety_net_installed = true;
 		if ( $this->skip_safety_net ) {
 			$output->writeln( '<comment>Skipping the installation of SafetyNet as a mu-plugin.</comment>' );
-		} elseif ( \is_null( $ssh_connection ) ) {
-			$output->writeln( '<error>Failed to connect to the site via SSH. Cannot install SafetyNet!</error>' );
 		} else {
-			// SafetyNet could already be installed if the site was cloned from a template that had it installed.
-			$safety_net_installed = false;
-			$ssh_connection->exec(
-				'ls htdocs/wp-content/mu-plugins',
-				function ( $stream ) use ( &$safety_net_installed, $output ) {
-					if ( str_contains( $stream, 'safety-net' ) ) {
-						$output->writeln( '<comment>SafetyNet is already installed as a mu-plugin. Skipping installation...</comment>' );
-						$safety_net_installed = true;
-					}
-				}
+			$safety_net_installed = maybe_install_safety_net(
+				$ssh_connection,
+				$output,
+				static fn( string $command ) => run_pressable_site_wp_cli_command( $site_clone->id, $command )
 			);
-
-			if ( ! $safety_net_installed ) {
-				run_pressable_site_wp_cli_command( $site_clone->id, 'plugin install https://github.com/a8cteam51/safety-net/releases/latest/download/safety-net.zip' );
-				$ssh_connection->exec( 'mv -f htdocs/wp-content/plugins/safety-net htdocs/wp-content/mu-plugins/safety-net' );
-				$ssh_connection->exec(
-					'ls htdocs/wp-content/mu-plugins',
-					function ( $stream ) use ( $site_clone, $output ) {
-						if ( ! str_contains( $stream, 'safety-net' ) ) {
-							$output->writeln( '<error>Failed to install SafetyNet!</error>' );
-						}
-						if ( ! str_contains( $stream, 'load-safety-net.php' ) ) {
-							$sftp_connection = \Pressable_Connection_Helper::get_sftp_connection( $site_clone->id );
-							if ( \is_null( $sftp_connection ) ) {
-								$output->writeln( '<error>Failed to connect to the site via SFTP. Cannot copy SafetyNet loader!</error>' );
-							} else {
-								$result = $sftp_connection->put( '/htdocs/wp-content/mu-plugins/load-safety-net.php', file_get_contents( __DIR__ . '/../scaffold/load-safety-net.php' ) );
-								if ( ! $result ) {
-									$output->writeln( '<error>Failed to copy the SafetyNet loader!</error>' );
-								}
-							}
-							$sftp_connection?->disconnect();
-						}
-					}
-				);
-			}
 		}
 		$ssh_connection?->disconnect();
 
@@ -284,8 +252,22 @@ final class Pressable_Site_Clone extends Command {
 		run_pressable_site_wp_cli_command( $site_clone->id, "search-replace {$this->site->url} $site_clone->url" );
 		run_pressable_site_wp_cli_command( $site_clone->id, 'cache flush' );
 
+		// Asking the clone itself is only meaningful once it answers on its own URL, which the search-replace
+		// above is what makes true. A site that reports itself scrubbed is protected whatever the files showed.
+		if ( ! $this->skip_safety_net && ! $safety_net_installed ) {
+			$safety_net_installed = is_safety_net_confirmed_via_http( $site_clone->url );
+		}
+
 		if ( Command::SUCCESS !== $rotate_status ) {
 			$output->writeln( '<comment>⚠  Heads up: 1Password sync did not complete during this run. See the warning above for the password to record manually.</comment>' );
+		}
+
+		if ( ! $safety_net_installed ) {
+			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
+			$output->writeln( "<error>⚠  SafetyNet is NOT installed on $site_clone->url.</error>" );
+			$output->writeln( '<error>    The clone still holds unscrubbed production data. Install it manually before sharing the site.</error>' );
+			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
+			return Command::FAILURE;
 		}
 
 		return Command::SUCCESS;

--- a/commands/Pressable_Site_Clone.php
+++ b/commands/Pressable_Site_Clone.php
@@ -215,11 +215,14 @@ final class Pressable_Site_Clone extends Command {
 
 		// A clone does not always inherit the concierge collaborator, and without it every SSH and SFTP
 		// connection below fails with `SFTP user not found.`
-		if ( ! \Pressable_Connection_Helper::ensure_sftp_user( $site_clone->id ) ) {
+		$sftp_user_ready = \Pressable_Connection_Helper::ensure_sftp_user( $site_clone->id );
+		if ( ! $sftp_user_ready ) {
 			$output->writeln( "<error>No usable SFTP user for $site_clone->url. The steps below that need SSH will fail.</error>" );
 		}
 
-		$ssh_connection = wait_on_pressable_site_ssh( $site_clone->id, $output );
+		// Without credentials the wait cannot succeed, so it is cut short: the run should end at the reason
+		// above rather than five minutes later at a timeout.
+		$ssh_connection = wait_on_pressable_site_ssh( $site_clone->id, $output, $sftp_user_ready ? 60 : 6 );
 
 		// Run a few commands to set up the site.
 		$rotate_status = run_app_command(

--- a/commands/Pressable_Site_Clone.php
+++ b/commands/Pressable_Site_Clone.php
@@ -253,18 +253,18 @@ final class Pressable_Site_Clone extends Command {
 		run_pressable_site_wp_cli_command( $site_clone->id, "search-replace {$this->site->url} $site_clone->url" );
 		run_pressable_site_wp_cli_command( $site_clone->id, 'cache flush' );
 
-		// Asking the clone itself is only meaningful once it answers on its own URL, which the search-replace
-		// above is what makes true. The file check only proves the files are present; this endpoint is the
-		// authoritative signal that Safety Net actually booted and scrubbed, so it decides the final verdict
-		// on every run - not just when the files were missing.
-		$safety_net_installed = $this->skip_safety_net ? true : is_safety_net_confirmed_via_http( $site_clone->url );
-
 		if ( Command::SUCCESS !== $rotate_status ) {
 			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
 			$output->writeln( '<error>⚠  The WP user password rotation did not complete cleanly.</error>' );
 			$output->writeln( '<error>    See the warning above for the password to record or the rotation to retry.</error>' );
 			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
 		}
+
+		// Asking the clone itself is only meaningful once it answers on its own URL, which the search-replace
+		// above is what makes true. The file check only proves the files are present; this endpoint is the
+		// authoritative signal that Safety Net actually booted and scrubbed, so it decides the final verdict
+		// on every run - not just when the files were missing.
+		$safety_net_installed = $this->skip_safety_net ? true : is_safety_net_confirmed_via_http( $site_clone->url );
 
 		if ( true !== $safety_net_installed ) {
 			$headline = \is_null( $safety_net_installed )

--- a/commands/Pressable_Site_Create.php
+++ b/commands/Pressable_Site_Create.php
@@ -153,8 +153,9 @@ final class Pressable_Site_Create extends Command {
 		);
 
 		// The runner's exit code only says whether the connection worked, never how the remote `wp` ended, so
-		// the install's real outcome is read from the captured reply: WP-CLI prints a `Success:` line when it
-		// installed, and its absence also catches a `wp` killed before printing anything.
+		// the install's real outcome is read from the captured reply. Both checks are deliberate: the missing
+		// Success: line catches a `wp` killed before printing anything, and the Error: scan catches an
+		// activation fatal that arrives after the install's own Success: line already printed.
 		$atlantis_output = (string) ( $GLOBALS['wp_cli_output'] ?? '' );
 		if ( Command::SUCCESS === $atlantis_status && ( is_wp_cli_error_output( $atlantis_output ) || ! is_wp_cli_success_output( $atlantis_output ) ) ) {
 			$atlantis_status = Command::FAILURE;

--- a/commands/Pressable_Site_Create.php
+++ b/commands/Pressable_Site_Create.php
@@ -133,7 +133,11 @@ final class Pressable_Site_Create extends Command {
 			return Command::FAILURE;
 		}
 
-		wait_on_pressable_site_ssh( $site->id, $output )?->disconnect();
+		// This wait used to block until the site answered, so everything below it could assume SSH worked. It
+		// is bounded now, so the outcome has to be carried to the end: the setup steps that need SSH cannot
+		// succeed without it, and the command must not report success as though they had.
+		$ssh_connection = wait_on_pressable_site_ssh( $site->id, $output );
+		$ssh_connection?->disconnect();
 
 		// Run a few commands to set up the site.
 		$rotate_status = run_app_command(
@@ -166,6 +170,14 @@ final class Pressable_Site_Create extends Command {
 					}
 				}
 			}
+		}
+
+		if ( \is_null( $ssh_connection ) ) {
+			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
+			$output->writeln( "<error>⚠  Site $this->name (ID $site->id) was created but never became reachable over SSH.</error>" );
+			$output->writeln( '<error>    The setup steps that need SSH did not run. Finish them manually.</error>' );
+			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
+			return Command::FAILURE;
 		}
 
 		$output->writeln( "<fg=green;options=bold>Site $this->name created successfully.</>" );

--- a/commands/Pressable_Site_Create.php
+++ b/commands/Pressable_Site_Create.php
@@ -172,6 +172,12 @@ final class Pressable_Site_Create extends Command {
 			}
 		}
 
+		// Printed before the reachability verdict: an unreachable site is exactly when the rotation is most
+		// likely to have failed, and its pointer to a possibly-unrecorded password must not be skipped.
+		if ( Command::SUCCESS !== $rotate_status ) {
+			$output->writeln( '<comment>⚠  Heads up: 1Password sync did not complete during this run. See the warning above for the password to record manually.</comment>' );
+		}
+
 		if ( \is_null( $ssh_connection ) ) {
 			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
 			$output->writeln( "<error>⚠  Site $this->name (ID $site->id) was created but never became reachable over SSH.</error>" );
@@ -181,10 +187,6 @@ final class Pressable_Site_Create extends Command {
 		}
 
 		$output->writeln( "<fg=green;options=bold>Site $this->name created successfully.</>" );
-
-		if ( Command::SUCCESS !== $rotate_status ) {
-			$output->writeln( '<comment>⚠  Heads up: 1Password sync did not complete during this run. See the warning above for the password to record manually.</comment>' );
-		}
 
 		return Command::SUCCESS;
 	}

--- a/commands/Pressable_Site_Create.php
+++ b/commands/Pressable_Site_Create.php
@@ -152,6 +152,14 @@ final class Pressable_Site_Create extends Command {
 			'plugin install https://github.com/a8cteam51/a8csp-atlantis/releases/latest/download/a8csp-atlantis.zip --activate',
 		);
 
+		// The runner's exit code only says whether the connection worked, never how the remote `wp` ended, so
+		// the install's real outcome is read from the captured reply: WP-CLI prints a `Success:` line when it
+		// installed, and its absence also catches a `wp` killed before printing anything.
+		$atlantis_output = (string) ( $GLOBALS['wp_cli_output'] ?? '' );
+		if ( Command::SUCCESS === $atlantis_status && ( is_wp_cli_error_output( $atlantis_output ) || ! \str_contains( $atlantis_output, 'Success:' ) ) ) {
+			$atlantis_status = Command::FAILURE;
+		}
+
 		// Create a DeployHQ project and server for the site.
 		if ( ! \is_null( $this->gh_repository ) ) {
 			$deployhq_project = create_deployhq_project_for_pressable_site( $site, $this->gh_repository, $this->name );

--- a/commands/Pressable_Site_Create.php
+++ b/commands/Pressable_Site_Create.php
@@ -147,7 +147,7 @@ final class Pressable_Site_Create extends Command {
 				'--user' => 'concierge@wordpress.com',
 			)
 		);
-		run_pressable_site_wp_cli_command(
+		$atlantis_status = run_pressable_site_wp_cli_command(
 			$site->id,
 			'plugin install https://github.com/a8cteam51/a8csp-atlantis/releases/latest/download/a8csp-atlantis.zip --activate',
 		);
@@ -181,10 +181,16 @@ final class Pressable_Site_Create extends Command {
 			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
 		}
 
-		if ( \is_null( $ssh_connection ) ) {
+		// The expired wait alone proves nothing about the steps that followed - each opens its own connection,
+		// and a site can become reachable after the wait gives up - so the verdict rests on what actually
+		// happened to the captured SSH-dependent setup step, with the wait's outcome as context.
+		if ( Command::SUCCESS !== $atlantis_status ) {
 			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
-			$output->writeln( "<error>⚠  Site $this->name (ID $site->id) was created but never became reachable over SSH.</error>" );
-			$output->writeln( '<error>    The setup steps that need SSH did not run. Finish them manually.</error>' );
+			$output->writeln( "<error>⚠  Site $this->name (ID $site->id) was created, but installing the a8csp-atlantis plugin failed.</error>" );
+			if ( \is_null( $ssh_connection ) ) {
+				$output->writeln( '<error>    The site did not accept SSH connections during setup; it may still be provisioning.</error>' );
+			}
+			$output->writeln( '<error>    Install the plugin manually.</error>' );
 			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
 			return Command::FAILURE;
 		}

--- a/commands/Pressable_Site_Create.php
+++ b/commands/Pressable_Site_Create.php
@@ -156,7 +156,7 @@ final class Pressable_Site_Create extends Command {
 		// the install's real outcome is read from the captured reply: WP-CLI prints a `Success:` line when it
 		// installed, and its absence also catches a `wp` killed before printing anything.
 		$atlantis_output = (string) ( $GLOBALS['wp_cli_output'] ?? '' );
-		if ( Command::SUCCESS === $atlantis_status && ( is_wp_cli_error_output( $atlantis_output ) || ! \str_contains( $atlantis_output, 'Success:' ) ) ) {
+		if ( Command::SUCCESS === $atlantis_status && ( is_wp_cli_error_output( $atlantis_output ) || ! is_wp_cli_success_output( $atlantis_output ) ) ) {
 			$atlantis_status = Command::FAILURE;
 		}
 

--- a/commands/Pressable_Site_Create.php
+++ b/commands/Pressable_Site_Create.php
@@ -175,7 +175,10 @@ final class Pressable_Site_Create extends Command {
 		// Printed before the reachability verdict: an unreachable site is exactly when the rotation is most
 		// likely to have failed, and its pointer to a possibly-unrecorded password must not be skipped.
 		if ( Command::SUCCESS !== $rotate_status ) {
-			$output->writeln( '<comment>⚠  Heads up: 1Password sync did not complete during this run. See the warning above for the password to record manually.</comment>' );
+			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
+			$output->writeln( '<error>⚠  The WP user password rotation did not complete cleanly.</error>' );
+			$output->writeln( '<error>    See the warning above for the password to record or the rotation to retry.</error>' );
+			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
 		}
 
 		if ( \is_null( $ssh_connection ) ) {

--- a/commands/Pressable_Site_Icon_Upload.php
+++ b/commands/Pressable_Site_Icon_Upload.php
@@ -69,7 +69,11 @@ final class Pressable_Site_Icon_Upload extends Command {
 		}
 
 		$output->writeln( '<comment>Getting site icon URL...</comment>' );
-		run_pressable_site_wp_cli_command( $this->site->id, "--skip-themes --skip-plugins eval 'echo get_site_icon_url(180);'", true );
+		$wp_cli_status = run_pressable_site_wp_cli_command( $this->site->id, "--skip-themes --skip-plugins eval 'echo get_site_icon_url(180);'", true );
+		if ( Command::SUCCESS !== $wp_cli_status ) {
+			$output->writeln( '<error>Could not reach the site over SSH to read the icon URL. Aborting.</error>' );
+			return Command::FAILURE;
+		}
 
 		// The captured reply may carry notices or warnings ahead of the URL, which is always the last line.
 		$output_lines  = preg_split( '/\R/', trim( (string) ( $GLOBALS['wp_cli_output'] ?? '' ) ) );

--- a/commands/Pressable_Site_Icon_Upload.php
+++ b/commands/Pressable_Site_Icon_Upload.php
@@ -71,7 +71,9 @@ final class Pressable_Site_Icon_Upload extends Command {
 		$output->writeln( '<comment>Getting site icon URL...</comment>' );
 		run_pressable_site_wp_cli_command( $this->site->id, "--skip-themes --skip-plugins eval 'echo get_site_icon_url(180);'", true );
 
-		$site_icon_url = $GLOBALS['wp_cli_output'];
+		// The captured reply may carry notices or warnings ahead of the URL, which is always the last line.
+		$output_lines  = preg_split( '/\R/', trim( (string) ( $GLOBALS['wp_cli_output'] ?? '' ) ) );
+		$site_icon_url = trim( (string) end( $output_lines ) );
 		if ( ! filter_var( $site_icon_url, FILTER_VALIDATE_URL ) ) {
 			$output->writeln( '<error>Site has no icon set. Aborting.</error>' );
 			return Command::FAILURE;

--- a/commands/Pressable_Site_Icon_Upload.php
+++ b/commands/Pressable_Site_Icon_Upload.php
@@ -75,6 +75,14 @@ final class Pressable_Site_Icon_Upload extends Command {
 			return Command::FAILURE;
 		}
 
+		// A fatal inside the eval is a broken site, not a site without an icon - reported as such so the
+		// operator keeps investigating.
+		if ( is_wp_cli_error_output( $GLOBALS['wp_cli_output'] ?? null ) ) {
+			$output->writeln( '<error>Reading the site icon URL failed:</error>' );
+			$output->writeln( '<error>' . \Symfony\Component\Console\Formatter\OutputFormatter::escape( trim( (string) ( $GLOBALS['wp_cli_output'] ?? '' ) ) ) . '</error>' );
+			return Command::FAILURE;
+		}
+
 		// The captured reply may carry notices or warnings ahead of the URL, which is always the last line.
 		$output_lines  = preg_split( '/\R/', trim( (string) ( $GLOBALS['wp_cli_output'] ?? '' ) ) );
 		$site_icon_url = trim( (string) end( $output_lines ) );

--- a/commands/Pressable_Site_WP_CLI_Command_Run.php
+++ b/commands/Pressable_Site_WP_CLI_Command_Run.php
@@ -116,11 +116,11 @@ final class Pressable_Site_WP_CLI_Command_Run extends Command {
 	protected function execute( InputInterface $input, OutputInterface $output ): int {
 		$failed = false;
 
-		// Callers read the output of the command they just ran out of this global, so a run that produces none
-		// must not leave the previous run's output behind for them to pick up.
-		$GLOBALS['wp_cli_output'] = null;
-
 		foreach ( $this->sites as $site ) {
+			// Callers read the output of the command they just ran out of this global, so a site that produces
+			// none - or that cannot be reached at all - must not leave the previous site's output behind.
+			$GLOBALS['wp_cli_output'] = null;
+
 			$output->writeln( "<fg=magenta;options=bold>Running the command `wp $this->wp_command` on $site->displayName (ID $site->id, URL $site->url).</>" );
 
 			$ssh = \Pressable_Connection_Helper::get_ssh_connection( $site->id );

--- a/commands/Pressable_Site_WP_CLI_Command_Run.php
+++ b/commands/Pressable_Site_WP_CLI_Command_Run.php
@@ -118,8 +118,9 @@ final class Pressable_Site_WP_CLI_Command_Run extends Command {
 
 		foreach ( $this->sites as $site ) {
 			// Callers read the output of the command they just ran out of this global, so a site that produces
-			// none - or that cannot be reached at all - must not leave the previous site's output behind.
-			$GLOBALS['wp_cli_output'] = null;
+			// none - or that cannot be reached at all - must not leave the previous site's output behind. The
+			// callback below appends because phpseclib delivers the reply one packet at a time.
+			$GLOBALS['wp_cli_output'] = '';
 
 			$output->writeln( "<fg=magenta;options=bold>Running the command `wp $this->wp_command` on $site->displayName (ID $site->id, URL $site->url).</>" );
 
@@ -138,7 +139,7 @@ final class Pressable_Site_WP_CLI_Command_Run extends Command {
 				$ssh->exec(
 					"wp $this->wp_command",
 					function ( string $str ): void {
-						$GLOBALS['wp_cli_output'] = $str;
+						$GLOBALS['wp_cli_output'] .= $str;
 						if ( ! $this->skip_output ) {
 							echo "$str\n";
 						}

--- a/commands/Pressable_Site_WP_CLI_Command_Run.php
+++ b/commands/Pressable_Site_WP_CLI_Command_Run.php
@@ -114,12 +114,19 @@ final class Pressable_Site_WP_CLI_Command_Run extends Command {
 	 * {@inheritDoc}
 	 */
 	protected function execute( InputInterface $input, OutputInterface $output ): int {
+		$failed = false;
+
+		// Callers read the output of the command they just ran out of this global, so a run that produces none
+		// must not leave the previous run's output behind for them to pick up.
+		$GLOBALS['wp_cli_output'] = null;
+
 		foreach ( $this->sites as $site ) {
 			$output->writeln( "<fg=magenta;options=bold>Running the command `wp $this->wp_command` on $site->displayName (ID $site->id, URL $site->url).</>" );
 
 			$ssh = \Pressable_Connection_Helper::get_ssh_connection( $site->id );
 			if ( \is_null( $ssh ) ) {
 				$output->writeln( '<error>Could not connect to the SSH server.</error>' );
+				$failed = true;
 				continue;
 			}
 
@@ -139,13 +146,14 @@ final class Pressable_Site_WP_CLI_Command_Run extends Command {
 				);
 			} catch ( \RuntimeException $exception ) {
 				$output->writeln( "<error>Something went wrong. Please double-check if things worked out. This is what we know: {$exception->getMessage()}</error>" );
+				$failed = true;
 				continue;
 			} finally {
 				$ssh->disconnect();
 			}
 		}
 
-		return Command::SUCCESS;
+		return $failed ? Command::FAILURE : Command::SUCCESS;
 	}
 
 	// endregion

--- a/commands/Pressable_Site_WP_User_Password_Rotate.php
+++ b/commands/Pressable_Site_WP_User_Password_Rotate.php
@@ -137,7 +137,7 @@ final class Pressable_Site_WP_User_Password_Rotate extends Command {
 	 * @noinspection DisconnectedForeachInstructionInspection
 	 */
 	protected function execute( InputInterface $input, OutputInterface $output ): int {
-		$sync_failures = array();
+		$failures = array();
 
 		foreach ( $this->sites as $site ) {
 			$output->writeln( "<fg=magenta;options=bold>Rotating the WP user password of $this->wp_user_email on $site->displayName (ID $site->id, URL $site->url).</>" );
@@ -146,6 +146,7 @@ final class Pressable_Site_WP_User_Password_Rotate extends Command {
 			$credentials = $this->rotate_site_wp_user_password( $output, $site->id );
 			if ( \is_null( $credentials ) ) {
 				$output->writeln( '<error>Failed to rotate the WP user password.</error>' );
+				$failures[] = $site->displayName; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Pressable API field, not ours.
 				continue;
 			}
 
@@ -160,14 +161,14 @@ final class Pressable_Site_WP_User_Password_Rotate extends Command {
 				$output->writeln( '<error>    Record this password before it scrolls off:</error>' );
 				$output->writeln( "<fg=yellow;options=bold>    $credentials->password</>" );
 				$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
-				$sync_failures[] = $site->displayName; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- 1Password API field, not ours.
+				$failures[] = $site->displayName; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- 1Password API field, not ours.
 				continue;
 			}
 
 			$output->writeln( '<fg=green;options=bold>WP user password updated in 1Password.</>' );
 		}
 
-		return empty( $sync_failures ) ? Command::SUCCESS : Command::FAILURE;
+		return empty( $failures ) ? Command::SUCCESS : Command::FAILURE;
 	}
 
 	// endregion

--- a/commands/Pressable_Site_WP_User_Password_Rotate.php
+++ b/commands/Pressable_Site_WP_User_Password_Rotate.php
@@ -161,7 +161,7 @@ final class Pressable_Site_WP_User_Password_Rotate extends Command {
 				$output->writeln( '<error>    Record this password before it scrolls off:</error>' );
 				$output->writeln( "<fg=yellow;options=bold>    $credentials->password</>" );
 				$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
-				$failures[] = $site->displayName; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- 1Password API field, not ours.
+				$failures[] = $site->displayName; // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase -- Pressable API field, not ours.
 				continue;
 			}
 

--- a/commands/WPCOM_Site_Clone.php
+++ b/commands/WPCOM_Site_Clone.php
@@ -220,7 +220,13 @@ final class WPCOM_Site_Clone extends Command {
 					$deployment_failed = true;
 				}
 			} else {
-				$output->writeln( '<comment>Jetpack user token not regenerated. Skipping deployment of GitHub repository. Manual deployment will be needed.</comment>' );
+				// A requested deployment that was skipped is still a deployment that did not happen, and the
+				// run must not exit 0 as though it had.
+				$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
+				$output->writeln( '<error>⚠  Jetpack user token not regenerated. Skipping deployment of the GitHub repository.</error>' );
+				$output->writeln( '<error>    Deploy it manually.</error>' );
+				$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
+				$deployment_failed = true;
 			}
 		}
 

--- a/commands/WPCOM_Site_Clone.php
+++ b/commands/WPCOM_Site_Clone.php
@@ -235,10 +235,14 @@ final class WPCOM_Site_Clone extends Command {
 			$output->writeln( '<comment>⚠  Heads up: 1Password sync did not complete during this run. See the warning above for the password to record manually.</comment>' );
 		}
 
-		if ( ! $safety_net_installed ) {
+		if ( true !== $safety_net_installed ) {
+			$headline = \is_null( $safety_net_installed )
+				? "⚠  Could not verify SafetyNet on $staging_site_https_url."
+				: "⚠  SafetyNet is NOT installed on $staging_site_https_url.";
+
 			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
-			$output->writeln( "<error>⚠  SafetyNet is NOT installed on $staging_site_https_url.</error>" );
-			$output->writeln( '<error>    The staging site still holds unscrubbed production data. Install it manually before sharing the site.</error>' );
+			$output->writeln( "<error>$headline</error>" );
+			$output->writeln( '<error>    Treat the staging site as holding unscrubbed production data until you have checked it.</error>' );
 			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
 			return Command::FAILURE;
 		}

--- a/commands/WPCOM_Site_Clone.php
+++ b/commands/WPCOM_Site_Clone.php
@@ -183,7 +183,6 @@ final class WPCOM_Site_Clone extends Command {
 		run_wpcom_site_wp_cli_command( $staging_site->id, "search-replace {$this->site->URL} $staging_site_https_url" );
 		run_wpcom_site_wp_cli_command( $staging_site->id, 'cache flush' );
 
-		$safety_net_installed = true;
 		if ( $this->skip_safety_net ) {
 			$output->writeln( '<comment>Skipping the installation of SafetyNet as a mu-plugin.</comment>' );
 		} else {
@@ -222,15 +221,16 @@ final class WPCOM_Site_Clone extends Command {
 		}
 
 		if ( Command::SUCCESS !== $rotate_status ) {
-			$output->writeln( '<comment>⚠  Heads up: the WP user password rotation did not complete cleanly. See the warning above for what to record or retry.</comment>' );
+			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
+			$output->writeln( '<error>⚠  The WP user password rotation did not complete cleanly.</error>' );
+			$output->writeln( '<error>    See the warning above for the password to record or the rotation to retry.</error>' );
+			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
 		}
 
 		// Checked last - after the Jetpack token regeneration and the repository deployment that writes into
 		// wp-content - so the verdict reflects the site as it is handed off. The endpoint is the authoritative
 		// signal that Safety Net actually booted and scrubbed, so it decides on every run.
-		if ( ! $this->skip_safety_net ) {
-			$safety_net_installed = is_safety_net_confirmed_via_http( $staging_site_https_url );
-		}
+		$safety_net_installed = $this->skip_safety_net ? true : is_safety_net_confirmed_via_http( $staging_site_https_url );
 
 		if ( true !== $safety_net_installed ) {
 			$headline = \is_null( $safety_net_installed )

--- a/commands/WPCOM_Site_Clone.php
+++ b/commands/WPCOM_Site_Clone.php
@@ -229,8 +229,6 @@ final class WPCOM_Site_Clone extends Command {
 			}
 		}
 
-		$output->writeln( "<fg=green;options=bold>Staging site created successfully at $staging_site_https_url.</>" );
-
 		if ( Command::SUCCESS !== $rotate_status ) {
 			$output->writeln( '<comment>⚠  Heads up: 1Password sync did not complete during this run. See the warning above for the password to record manually.</comment>' );
 		}
@@ -246,6 +244,8 @@ final class WPCOM_Site_Clone extends Command {
 			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
 			return Command::FAILURE;
 		}
+
+		$output->writeln( "<fg=green;options=bold>Staging site created successfully at $staging_site_https_url.</>" );
 
 		return Command::SUCCESS;
 	}

--- a/commands/WPCOM_Site_Clone.php
+++ b/commands/WPCOM_Site_Clone.php
@@ -183,45 +183,18 @@ final class WPCOM_Site_Clone extends Command {
 		run_wpcom_site_wp_cli_command( $staging_site->id, "search-replace {$this->site->URL} $staging_site_https_url" );
 		run_wpcom_site_wp_cli_command( $staging_site->id, 'cache flush' );
 
+		$safety_net_installed = true;
 		if ( $this->skip_safety_net ) {
 			$output->writeln( '<comment>Skipping the installation of SafetyNet as a mu-plugin.</comment>' );
-		} elseif ( \is_null( $ssh_connection ) ) {
-			$output->writeln( '<error>Failed to connect to the site via SSH. Cannot install SafetyNet!</error>' );
 		} else {
-			// SafetyNet could already be installed if the site was cloned from a template that had it installed.
-			$safety_net_installed = false;
-			$ssh_connection->exec(
-				'ls htdocs/wp-content/mu-plugins',
-				function ( $stream ) use ( &$safety_net_installed, $output ) {
-					if ( str_contains( $stream, 'safety-net' ) ) {
-						$output->writeln( '<comment>SafetyNet is already installed as a mu-plugin. Skipping installation...</comment>' );
-						$safety_net_installed = true;
-					}
-				}
+			$safety_net_installed = maybe_install_safety_net(
+				$ssh_connection,
+				$output,
+				static fn( string $command ) => run_wpcom_site_wp_cli_command( $transfer->blog_id, $command )
 			);
-
 			if ( ! $safety_net_installed ) {
-				run_wpcom_site_wp_cli_command( $transfer->blog_id, 'plugin install https://github.com/a8cteam51/safety-net/releases/latest/download/safety-net.zip' );
-				$ssh_connection->exec( 'mv -f htdocs/wp-content/plugins/safety-net htdocs/wp-content/mu-plugins/safety-net' );
-				$ssh_connection->exec(
-					'ls htdocs/wp-content/mu-plugins',
-					function ( $stream ) use ( $staging_site, $output ) {
-						if ( ! str_contains( $stream, 'safety-net' ) ) {
-							$output->writeln( '<error>Failed to install SafetyNet!</error>' );
-						}
-						if ( ! str_contains( $stream, 'load-safety-net.php' ) ) {
-							$sftp = \WPCOM_Connection_Helper::get_sftp_connection( $staging_site->id );
-							if ( \is_null( $sftp ) ) {
-								$output->writeln( '<error>Failed to connect to the site via SFTP. Cannot copy SafetyNet loader!</error>' );
-							} else {
-								$result = $sftp->put( '/htdocs/wp-content/mu-plugins/load-safety-net.php', file_get_contents( __DIR__ . '/../scaffold/load-safety-net.php' ) );
-								if ( ! $result ) {
-									$output->writeln( '<error>Failed to copy the SafetyNet loader!</error>' );
-								}
-							}
-						}
-					}
-				);
+				// A site that reports itself scrubbed is protected whatever the files showed.
+				$safety_net_installed = is_safety_net_confirmed_via_http( $staging_site_https_url );
 			}
 		}
 
@@ -260,6 +233,14 @@ final class WPCOM_Site_Clone extends Command {
 
 		if ( Command::SUCCESS !== $rotate_status ) {
 			$output->writeln( '<comment>⚠  Heads up: 1Password sync did not complete during this run. See the warning above for the password to record manually.</comment>' );
+		}
+
+		if ( ! $safety_net_installed ) {
+			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
+			$output->writeln( "<error>⚠  SafetyNet is NOT installed on $staging_site_https_url.</error>" );
+			$output->writeln( '<error>    The staging site still holds unscrubbed production data. Install it manually before sharing the site.</error>' );
+			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
+			return Command::FAILURE;
 		}
 
 		return Command::SUCCESS;

--- a/commands/WPCOM_Site_Clone.php
+++ b/commands/WPCOM_Site_Clone.php
@@ -188,10 +188,6 @@ final class WPCOM_Site_Clone extends Command {
 			$output->writeln( '<comment>Skipping the installation of SafetyNet as a mu-plugin.</comment>' );
 		} else {
 			maybe_install_safety_net( $ssh_connection, $output );
-
-			// The file check only proves the files are present; this endpoint is the authoritative signal that
-			// Safety Net actually booted and scrubbed, so it decides the final verdict on every run.
-			$safety_net_installed = is_safety_net_confirmed_via_http( $staging_site_https_url );
 		}
 
 		$ssh_connection?->disconnect();
@@ -227,6 +223,13 @@ final class WPCOM_Site_Clone extends Command {
 
 		if ( Command::SUCCESS !== $rotate_status ) {
 			$output->writeln( '<comment>⚠  Heads up: the WP user password rotation did not complete cleanly. See the warning above for what to record or retry.</comment>' );
+		}
+
+		// Checked last - after the Jetpack token regeneration and the repository deployment that writes into
+		// wp-content - so the verdict reflects the site as it is handed off. The endpoint is the authoritative
+		// signal that Safety Net actually booted and scrubbed, so it decides on every run.
+		if ( ! $this->skip_safety_net ) {
+			$safety_net_installed = is_safety_net_confirmed_via_http( $staging_site_https_url );
 		}
 
 		if ( true !== $safety_net_installed ) {

--- a/commands/WPCOM_Site_Clone.php
+++ b/commands/WPCOM_Site_Clone.php
@@ -190,6 +190,7 @@ final class WPCOM_Site_Clone extends Command {
 			$safety_net_installed = maybe_install_safety_net(
 				$ssh_connection,
 				$output,
+				// `blog_id` on the completed transfer is the staging site's own blog ID.
 				static fn( string $command ) => run_wpcom_site_wp_cli_command( $transfer->blog_id, $command )
 			);
 			if ( ! $safety_net_installed ) {
@@ -230,7 +231,7 @@ final class WPCOM_Site_Clone extends Command {
 		}
 
 		if ( Command::SUCCESS !== $rotate_status ) {
-			$output->writeln( '<comment>⚠  Heads up: 1Password sync did not complete during this run. See the warning above for the password to record manually.</comment>' );
+			$output->writeln( '<comment>⚠  Heads up: the WP user password rotation did not complete cleanly. See the warning above for what to record or retry.</comment>' );
 		}
 
 		if ( true !== $safety_net_installed ) {

--- a/commands/WPCOM_Site_Clone.php
+++ b/commands/WPCOM_Site_Clone.php
@@ -180,12 +180,24 @@ final class WPCOM_Site_Clone extends Command {
 		);
 
 		run_wpcom_site_wp_cli_command( $staging_site->id, 'config set WP_ENVIRONMENT_TYPE development --type=constant' );
+
+		// This constant is what makes Safety Net treat the site as non-production and scrub it, so its
+		// outcome is read from the reply - the runner's exit code only covers the connection - and named in
+		// the final banner if it failed.
+		$environment_output = (string) ( $GLOBALS['wp_cli_output'] ?? '' );
+		$environment_set    = ! is_wp_cli_error_output( $environment_output ) && is_wp_cli_success_output( $environment_output );
+
 		run_wpcom_site_wp_cli_command( $staging_site->id, "search-replace {$this->site->URL} $staging_site_https_url" );
 		run_wpcom_site_wp_cli_command( $staging_site->id, 'cache flush' );
 
 		if ( $this->skip_safety_net ) {
 			$output->writeln( '<comment>Skipping the installation of SafetyNet as a mu-plugin.</comment>' );
 		} else {
+			// The wait above can expire on a site that becomes reachable moments later - the steps in between
+			// open their own connections and may already have succeeded - so the install gets one fresh
+			// attempt instead of inheriting a stale null.
+			$ssh_connection ??= \WPCOM_Connection_Helper::get_ssh_connection( $staging_site->id );
+
 			maybe_install_safety_net( $ssh_connection, $output );
 		}
 
@@ -240,7 +252,7 @@ final class WPCOM_Site_Clone extends Command {
 		// Checked last - after the Jetpack token regeneration and the repository deployment that writes into
 		// wp-content - so the verdict reflects the site as it is handed off. The endpoint is the authoritative
 		// signal that Safety Net actually booted and scrubbed, so it decides on every run.
-		$safety_net_installed = $this->skip_safety_net ? true : is_safety_net_confirmed_via_http( $staging_site_https_url );
+		$safety_net_installed = $this->skip_safety_net ? true : is_safety_net_confirmed_via_http( $staging_site_https_url, $output );
 
 		if ( true !== $safety_net_installed ) {
 			$headline = \is_null( $safety_net_installed )
@@ -249,6 +261,9 @@ final class WPCOM_Site_Clone extends Command {
 
 			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
 			$output->writeln( "<error>$headline</error>" );
+			if ( ! $environment_set ) {
+				$output->writeln( '<error>    Setting WP_ENVIRONMENT_TYPE failed, which alone keeps Safety Net from scrubbing.</error>' );
+			}
 			$output->writeln( '<error>    Treat the staging site as holding unscrubbed production data until you have checked it.</error>' );
 			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
 			return Command::FAILURE;

--- a/commands/WPCOM_Site_Clone.php
+++ b/commands/WPCOM_Site_Clone.php
@@ -191,6 +191,8 @@ final class WPCOM_Site_Clone extends Command {
 
 		$ssh_connection?->disconnect();
 
+		$deployment_failed = false;
+
 		// Ping site to regenerate Jetpack user token. This will cause an error and the token will be regenerated.
 		$regenerated = wait_until_jetpack_token_regenerated( $staging_site->id, $output );
 
@@ -212,8 +214,10 @@ final class WPCOM_Site_Clone extends Command {
 					)
 				);
 				if ( Command::SUCCESS !== $status ) {
+					// Reported here but returned at the end: the SafetyNet verdict below must run - and be
+					// heard - even when the deployment failed.
 					$output->writeln( '<error>Failed to create the repository.</error>' );
-					return Command::FAILURE;
+					$deployment_failed = true;
 				}
 			} else {
 				$output->writeln( '<comment>Jetpack user token not regenerated. Skipping deployment of GitHub repository. Manual deployment will be needed.</comment>' );
@@ -241,6 +245,10 @@ final class WPCOM_Site_Clone extends Command {
 			$output->writeln( "<error>$headline</error>" );
 			$output->writeln( '<error>    Treat the staging site as holding unscrubbed production data until you have checked it.</error>' );
 			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
+			return Command::FAILURE;
+		}
+
+		if ( $deployment_failed ) {
 			return Command::FAILURE;
 		}
 

--- a/commands/WPCOM_Site_Clone.php
+++ b/commands/WPCOM_Site_Clone.php
@@ -187,16 +187,11 @@ final class WPCOM_Site_Clone extends Command {
 		if ( $this->skip_safety_net ) {
 			$output->writeln( '<comment>Skipping the installation of SafetyNet as a mu-plugin.</comment>' );
 		} else {
-			$safety_net_installed = maybe_install_safety_net(
-				$ssh_connection,
-				$output,
-				// `blog_id` on the completed transfer is the staging site's own blog ID.
-				static fn( string $command ) => run_wpcom_site_wp_cli_command( $transfer->blog_id, $command )
-			);
-			if ( ! $safety_net_installed ) {
-				// A site that reports itself scrubbed is protected whatever the files showed.
-				$safety_net_installed = is_safety_net_confirmed_via_http( $staging_site_https_url );
-			}
+			maybe_install_safety_net( $ssh_connection, $output );
+
+			// The file check only proves the files are present; this endpoint is the authoritative signal that
+			// Safety Net actually booted and scrubbed, so it decides the final verdict on every run.
+			$safety_net_installed = is_safety_net_confirmed_via_http( $staging_site_https_url );
 		}
 
 		$ssh_connection?->disconnect();

--- a/commands/WPCOM_Site_Create.php
+++ b/commands/WPCOM_Site_Create.php
@@ -162,6 +162,14 @@ final class WPCOM_Site_Create extends Command {
 			'plugin install https://github.com/a8cteam51/a8csp-atlantis/releases/latest/download/a8csp-atlantis.zip --activate',
 		);
 
+		// The runner's exit code only says whether the connection worked, never how the remote `wp` ended, so
+		// the install's real outcome is read from the captured reply: WP-CLI prints a `Success:` line when it
+		// installed, and its absence also catches a `wp` killed before printing anything.
+		$atlantis_output = (string) ( $GLOBALS['wp_cli_output'] ?? '' );
+		if ( Command::SUCCESS === $atlantis_status && ( is_wp_cli_error_output( $atlantis_output ) || ! \str_contains( $atlantis_output, 'Success:' ) ) ) {
+			$atlantis_status = Command::FAILURE;
+		}
+
 		// Printed before anything that can end the run early - the repository connect below returns FAILURE on
 		// its own, and the reachability verdict follows - so the pointer to a possibly-unrecorded password is
 		// never dropped.
@@ -169,6 +177,19 @@ final class WPCOM_Site_Create extends Command {
 			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
 			$output->writeln( '<error>⚠  The WP user password rotation did not complete cleanly.</error>' );
 			$output->writeln( '<error>    See the warning above for the password to record or the rotation to retry.</error>' );
+			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
+		}
+
+		// Reported before the repository connect below, whose own failure returns early: a run where both
+		// failed must name both. The expired wait alone proves nothing about this step - it opened its own
+		// connection - so the wait's outcome is context, and the verdict itself lands at the end.
+		if ( Command::SUCCESS !== $atlantis_status ) {
+			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
+			$output->writeln( "<error>⚠  Site $this->name (ID $transfer->blog_id) was created, but installing the a8csp-atlantis plugin failed.</error>" );
+			if ( \is_null( $ssh_connection ) ) {
+				$output->writeln( '<error>    The site did not accept SSH connections during setup; it may still be provisioning.</error>' );
+			}
+			$output->writeln( '<error>    Install the plugin manually.</error>' );
 			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
 		}
 
@@ -190,17 +211,7 @@ final class WPCOM_Site_Create extends Command {
 			}
 		}
 
-		// The expired wait alone proves nothing about the steps that followed - each opens its own connection,
-		// and a site can become reachable after the wait gives up - so the verdict rests on what actually
-		// happened to the captured SSH-dependent setup step, with the wait's outcome as context.
 		if ( Command::SUCCESS !== $atlantis_status ) {
-			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
-			$output->writeln( "<error>⚠  Site $this->name (ID $transfer->blog_id) was created, but installing the a8csp-atlantis plugin failed.</error>" );
-			if ( \is_null( $ssh_connection ) ) {
-				$output->writeln( '<error>    The site did not accept SSH connections during setup; it may still be provisioning.</error>' );
-			}
-			$output->writeln( '<error>    Install the plugin manually.</error>' );
-			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
 			return Command::FAILURE;
 		}
 

--- a/commands/WPCOM_Site_Create.php
+++ b/commands/WPCOM_Site_Create.php
@@ -180,6 +180,12 @@ final class WPCOM_Site_Create extends Command {
 			}
 		}
 
+		// Printed before the reachability verdict: an unreachable site is exactly when the rotation is most
+		// likely to have failed, and its pointer to a possibly-unrecorded password must not be skipped.
+		if ( Command::SUCCESS !== $rotate_status ) {
+			$output->writeln( '<comment>⚠  Heads up: 1Password sync did not complete during this run. See the warning above for the password to record manually.</comment>' );
+		}
+
 		if ( \is_null( $ssh_connection ) ) {
 			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
 			$output->writeln( "<error>⚠  Site $this->name (ID $transfer->blog_id) was created but never became reachable over SSH.</error>" );
@@ -189,10 +195,6 @@ final class WPCOM_Site_Create extends Command {
 		}
 
 		$output->writeln( "<fg=green;options=bold>Site $this->name created successfully.</>" );
-
-		if ( Command::SUCCESS !== $rotate_status ) {
-			$output->writeln( '<comment>⚠  Heads up: 1Password sync did not complete during this run. See the warning above for the password to record manually.</comment>' );
-		}
 
 		return Command::SUCCESS;
 	}

--- a/commands/WPCOM_Site_Create.php
+++ b/commands/WPCOM_Site_Create.php
@@ -135,7 +135,11 @@ final class WPCOM_Site_Create extends Command {
 			return Command::FAILURE;
 		}
 
-		wait_on_wpcom_site_ssh( $transfer->blog_id, $output )?->disconnect();
+		// This wait used to block until the site answered, so everything below it could assume SSH worked. It
+		// is bounded now, so the outcome has to be carried to the end: the setup steps that need SSH cannot
+		// succeed without it, and the command must not report success as though they had.
+		$ssh_connection = wait_on_wpcom_site_ssh( $transfer->blog_id, $output );
+		$ssh_connection?->disconnect();
 
 		// The site is ready but the API doesn't support setting the name during creation so we have to update it.
 		$update = update_wpcom_site( $transfer->blog_id, array( 'blogname' => "$this->name-production" ) );
@@ -174,6 +178,14 @@ final class WPCOM_Site_Create extends Command {
 				$output->writeln( '<error>Site was created, but connecting the GitHub deployment (including webhook setup) failed.</error>' );
 				return Command::FAILURE;
 			}
+		}
+
+		if ( \is_null( $ssh_connection ) ) {
+			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
+			$output->writeln( "<error>⚠  Site $this->name (ID $transfer->blog_id) was created but never became reachable over SSH.</error>" );
+			$output->writeln( '<error>    The setup steps that need SSH did not run. Finish them manually.</error>' );
+			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
+			return Command::FAILURE;
 		}
 
 		$output->writeln( "<fg=green;options=bold>Site $this->name created successfully.</>" );

--- a/commands/WPCOM_Site_Create.php
+++ b/commands/WPCOM_Site_Create.php
@@ -163,8 +163,9 @@ final class WPCOM_Site_Create extends Command {
 		);
 
 		// The runner's exit code only says whether the connection worked, never how the remote `wp` ended, so
-		// the install's real outcome is read from the captured reply: WP-CLI prints a `Success:` line when it
-		// installed, and its absence also catches a `wp` killed before printing anything.
+		// the install's real outcome is read from the captured reply. Both checks are deliberate: the missing
+		// Success: line catches a `wp` killed before printing anything, and the Error: scan catches an
+		// activation fatal that arrives after the install's own Success: line already printed.
 		$atlantis_output = (string) ( $GLOBALS['wp_cli_output'] ?? '' );
 		if ( Command::SUCCESS === $atlantis_status && ( is_wp_cli_error_output( $atlantis_output ) || ! is_wp_cli_success_output( $atlantis_output ) ) ) {
 			$atlantis_status = Command::FAILURE;

--- a/commands/WPCOM_Site_Create.php
+++ b/commands/WPCOM_Site_Create.php
@@ -166,7 +166,7 @@ final class WPCOM_Site_Create extends Command {
 		// the install's real outcome is read from the captured reply: WP-CLI prints a `Success:` line when it
 		// installed, and its absence also catches a `wp` killed before printing anything.
 		$atlantis_output = (string) ( $GLOBALS['wp_cli_output'] ?? '' );
-		if ( Command::SUCCESS === $atlantis_status && ( is_wp_cli_error_output( $atlantis_output ) || ! \str_contains( $atlantis_output, 'Success:' ) ) ) {
+		if ( Command::SUCCESS === $atlantis_status && ( is_wp_cli_error_output( $atlantis_output ) || ! is_wp_cli_success_output( $atlantis_output ) ) ) {
 			$atlantis_status = Command::FAILURE;
 		}
 

--- a/commands/WPCOM_Site_Create.php
+++ b/commands/WPCOM_Site_Create.php
@@ -157,7 +157,7 @@ final class WPCOM_Site_Create extends Command {
 				'--user' => 'concierge@wordpress.com',
 			)
 		);
-		run_wpcom_site_wp_cli_command(
+		$atlantis_status = run_wpcom_site_wp_cli_command(
 			$transfer->blog_id,
 			'plugin install https://github.com/a8cteam51/a8csp-atlantis/releases/latest/download/a8csp-atlantis.zip --activate',
 		);
@@ -190,10 +190,16 @@ final class WPCOM_Site_Create extends Command {
 			}
 		}
 
-		if ( \is_null( $ssh_connection ) ) {
+		// The expired wait alone proves nothing about the steps that followed - each opens its own connection,
+		// and a site can become reachable after the wait gives up - so the verdict rests on what actually
+		// happened to the captured SSH-dependent setup step, with the wait's outcome as context.
+		if ( Command::SUCCESS !== $atlantis_status ) {
 			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
-			$output->writeln( "<error>⚠  Site $this->name (ID $transfer->blog_id) was created but never became reachable over SSH.</error>" );
-			$output->writeln( '<error>    The setup steps that need SSH did not run. Finish them manually.</error>' );
+			$output->writeln( "<error>⚠  Site $this->name (ID $transfer->blog_id) was created, but installing the a8csp-atlantis plugin failed.</error>" );
+			if ( \is_null( $ssh_connection ) ) {
+				$output->writeln( '<error>    The site did not accept SSH connections during setup; it may still be provisioning.</error>' );
+			}
+			$output->writeln( '<error>    Install the plugin manually.</error>' );
 			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
 			return Command::FAILURE;
 		}

--- a/commands/WPCOM_Site_Create.php
+++ b/commands/WPCOM_Site_Create.php
@@ -162,6 +162,16 @@ final class WPCOM_Site_Create extends Command {
 			'plugin install https://github.com/a8cteam51/a8csp-atlantis/releases/latest/download/a8csp-atlantis.zip --activate',
 		);
 
+		// Printed before anything that can end the run early - the repository connect below returns FAILURE on
+		// its own, and the reachability verdict follows - so the pointer to a possibly-unrecorded password is
+		// never dropped.
+		if ( Command::SUCCESS !== $rotate_status ) {
+			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
+			$output->writeln( '<error>⚠  The WP user password rotation did not complete cleanly.</error>' );
+			$output->writeln( '<error>    See the warning above for the password to record or the rotation to retry.</error>' );
+			$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
+		}
+
 		// Create a GitHub Deployment project for the site.
 		if ( ! \is_null( $this->gh_repository ) ) {
 			$status = run_app_command(
@@ -178,12 +188,6 @@ final class WPCOM_Site_Create extends Command {
 				$output->writeln( '<error>Site was created, but connecting the GitHub deployment (including webhook setup) failed.</error>' );
 				return Command::FAILURE;
 			}
-		}
-
-		// Printed before the reachability verdict: an unreachable site is exactly when the rotation is most
-		// likely to have failed, and its pointer to a possibly-unrecorded password must not be skipped.
-		if ( Command::SUCCESS !== $rotate_status ) {
-			$output->writeln( '<comment>⚠  Heads up: 1Password sync did not complete during this run. See the warning above for the password to record manually.</comment>' );
 		}
 
 		if ( \is_null( $ssh_connection ) ) {

--- a/commands/WPCOM_Site_WP_CLI_Command_Run.php
+++ b/commands/WPCOM_Site_WP_CLI_Command_Run.php
@@ -98,8 +98,9 @@ final class WPCOM_Site_WP_CLI_Command_Run extends Command {
 		$output->writeln( "<fg=magenta;options=bold>Running the command `wp $this->wp_command` on {$this->site->name} (ID {$this->site->ID}, URL {$this->site->URL}).</>" );
 
 		// Callers read the output of the command they just ran out of this global, so a run that produces none
-		// must not leave the previous run's output behind for them to pick up.
-		$GLOBALS['wp_cli_output'] = null;
+		// must not leave the previous run's output behind for them to pick up. The callback below appends
+		// because phpseclib delivers the reply one packet at a time.
+		$GLOBALS['wp_cli_output'] = '';
 
 		$ssh = \WPCOM_Connection_Helper::get_ssh_connection( $this->site->ID );
 		if ( \is_null( $ssh ) ) {
@@ -114,7 +115,7 @@ final class WPCOM_Site_WP_CLI_Command_Run extends Command {
 			$ssh->exec(
 				"wp $this->wp_command",
 				function ( string $str ): void {
-					$GLOBALS['wp_cli_output'] = $str;
+					$GLOBALS['wp_cli_output'] .= $str;
 					if ( ! $this->skip_output ) {
 						echo "$str\n";
 					}

--- a/commands/WPCOM_Site_WP_CLI_Command_Run.php
+++ b/commands/WPCOM_Site_WP_CLI_Command_Run.php
@@ -97,6 +97,10 @@ final class WPCOM_Site_WP_CLI_Command_Run extends Command {
 	protected function execute( InputInterface $input, OutputInterface $output ): int {
 		$output->writeln( "<fg=magenta;options=bold>Running the command `wp $this->wp_command` on {$this->site->name} (ID {$this->site->ID}, URL {$this->site->URL}).</>" );
 
+		// Callers read the output of the command they just ran out of this global, so a run that produces none
+		// must not leave the previous run's output behind for them to pick up.
+		$GLOBALS['wp_cli_output'] = null;
+
 		$ssh = \WPCOM_Connection_Helper::get_ssh_connection( $this->site->ID );
 		if ( \is_null( $ssh ) ) {
 			$output->writeln( '<error>Could not connect to the SSH server.</error>' );

--- a/commands/WPCOM_Site_WP_User_Delete.php
+++ b/commands/WPCOM_Site_WP_User_Delete.php
@@ -210,7 +210,13 @@ final class WPCOM_Site_WP_User_Delete extends Command {
 				exit( 1 );
 			}
 
-			$site_admins = decode_json_content( $GLOBALS['wp_cli_output'] ?? '' );
+			$wp_cli_output = $GLOBALS['wp_cli_output'] ?? null;
+			if ( ! is_string( $wp_cli_output ) || '' === trim( $wp_cli_output ) ) {
+				$output->writeln( "<error>Failed to decode administrator users for site ID {$ssh_user_data['id']} using SSH.</error>" );
+				exit( 1 );
+			}
+
+			$site_admins = decode_json_content( $wp_cli_output );
 			if ( null === $site_admins ) {
 				$output->writeln( "<error>Failed to decode administrator users for site ID {$ssh_user_data['id']} using SSH.</error>" );
 				exit( 1 );

--- a/commands/WPCOM_Site_WP_User_Delete.php
+++ b/commands/WPCOM_Site_WP_User_Delete.php
@@ -216,7 +216,21 @@ final class WPCOM_Site_WP_User_Delete extends Command {
 				exit( 1 );
 			}
 
-			$site_admins = decode_json_content( $wp_cli_output );
+			// The accumulated reply may carry notices or warnings around the JSON, so the payload is the line
+			// that decodes - not the reply as a whole.
+			$site_admins = null;
+			foreach ( \preg_split( '/\R/', trim( $wp_cli_output ) ) as $output_line ) {
+				$output_line = trim( $output_line );
+				if ( '' === $output_line || ( ! \str_starts_with( $output_line, '[' ) && ! \str_starts_with( $output_line, '{' ) ) ) {
+					continue;
+				}
+
+				$site_admins = \json_decode( $output_line );
+				if ( null !== $site_admins ) {
+					break;
+				}
+			}
+
 			if ( null === $site_admins ) {
 				$output->writeln( "<error>Failed to decode administrator users for site ID {$ssh_user_data['id']} using SSH.</error>" );
 				exit( 1 );

--- a/commands/WPCOM_Site_WP_User_Delete.php
+++ b/commands/WPCOM_Site_WP_User_Delete.php
@@ -210,7 +210,7 @@ final class WPCOM_Site_WP_User_Delete extends Command {
 				exit( 1 );
 			}
 
-			$site_admins = decode_json_content( $GLOBALS['wp_cli_output'] );
+			$site_admins = decode_json_content( $GLOBALS['wp_cli_output'] ?? '' );
 			if ( null === $site_admins ) {
 				$output->writeln( "<error>Failed to decode administrator users for site ID {$ssh_user_data['id']} using SSH.</error>" );
 				exit( 1 );

--- a/commands/WPCOM_Site_WP_User_Password_Rotate.php
+++ b/commands/WPCOM_Site_WP_User_Password_Rotate.php
@@ -133,7 +133,7 @@ final class WPCOM_Site_WP_User_Password_Rotate extends Command {
 	 * @noinspection DisconnectedForeachInstructionInspection
 	 */
 	protected function execute( InputInterface $input, OutputInterface $output ): int {
-		$sync_failures = array();
+		$failures = array();
 
 		foreach ( $this->sites as $site ) {
 			if ( empty( $site->name ) ) {
@@ -150,6 +150,7 @@ final class WPCOM_Site_WP_User_Password_Rotate extends Command {
 			$credentials = $this->rotate_site_wp_user_password( $output, $site->ID );
 			if ( \is_null( $credentials ) ) {
 				$output->writeln( '<error>Failed to rotate the WP user password.</error>' );
+				$failures[] = $site->name;
 				continue;
 			}
 
@@ -164,14 +165,14 @@ final class WPCOM_Site_WP_User_Password_Rotate extends Command {
 				$output->writeln( '<error>    Record this password before it scrolls off:</error>' );
 				$output->writeln( "<fg=yellow;options=bold>    $credentials->password</>" );
 				$output->writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
-				$sync_failures[] = $site->name;
+				$failures[] = $site->name;
 				continue;
 			}
 
 			$output->writeln( '<fg=green;options=bold>WP user password updated in 1Password.</>' );
 		}
 
-		return empty( $sync_failures ) ? Command::SUCCESS : Command::FAILURE;
+		return empty( $failures ) ? Command::SUCCESS : Command::FAILURE;
 	}
 
 	// endregion

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
       "includes/functions-github.php",
       "includes/functions-jetpack.php",
       "includes/functions-pressable.php",
+      "includes/functions-safety-net.php",
       "includes/functions-wporg.php",
       "includes/functions-wpcom.php",
       "includes/parallel-process.php",

--- a/includes/abstract-connection-helper.php
+++ b/includes/abstract-connection-helper.php
@@ -19,6 +19,11 @@ abstract class Abstract_Connection_Helper {
 	 */
 	public const SFTP_HOST = null;
 
+	/**
+	 * The connection and read timeout, in seconds, that connections are built with.
+	 */
+	public const SSH_TIMEOUT = 10;
+
 	// endregion
 
 	// region METHODS
@@ -58,7 +63,7 @@ abstract class Abstract_Connection_Helper {
 			return null;
 		}
 
-		$connection = new SSH2( static::SSH_HOST );
+		$connection = new SSH2( static::SSH_HOST, 22, static::SSH_TIMEOUT );
 		if ( ! $connection->login( $credentials->username, $credentials->password ) ) {
 			$connection->isConnected() && $connection->disconnect();
 			return null;

--- a/includes/connection-helper-pressable.php
+++ b/includes/connection-helper-pressable.php
@@ -16,6 +16,11 @@ final class Pressable_Connection_Helper extends Abstract_Connection_Helper {
 	 */
 	public const SFTP_HOST = 'sftp.pressable.com';
 
+	/**
+	 * The email of the collaborator whose SFTP user the CLI connects as.
+	 */
+	private const SFTP_USER_EMAIL = 'concierge@wordpress.com';
+
 	// endregion
 
 	// region HELPERS
@@ -27,9 +32,13 @@ final class Pressable_Connection_Helper extends Abstract_Connection_Helper {
 		static $cache = array();
 
 		if ( empty( $cache[ $site_identifier ] ) ) {
-			$sftp_user = get_pressable_site_sftp_user( $site_identifier, 'concierge@wordpress.com' );
+			$sftp_user = get_pressable_site_sftp_user( $site_identifier, self::SFTP_USER_EMAIL );
 			if ( \is_null( $sftp_user ) ) {
-				console_writeln( '❌ Could not find the Pressable site SFTP user.' );
+				// Callers retry in a loop, so the reason is reported once by the provisioning attempt rather
+				// than on every pass.
+				$sftp_user = self::provision_sftp_user( $site_identifier );
+			}
+			if ( \is_null( $sftp_user ) ) {
 				return null;
 			}
 
@@ -37,6 +46,45 @@ final class Pressable_Connection_Helper extends Abstract_Connection_Helper {
 		}
 
 		return $cache[ $site_identifier ];
+	}
+
+	/**
+	 * Creates the concierge collaborator on a site and waits for its SFTP user to be provisioned.
+	 *
+	 * A freshly cloned site does not always inherit the collaborator, which used to leave every SSH and SFTP
+	 * connection to it failing with `SFTP user not found.` until someone added the collaborator by hand.
+	 * Creation is attempted only once per site because callers retry `get_credentials()` in a loop.
+	 *
+	 * @param   string $site_identifier The site to provision the SFTP user on.
+	 *
+	 * @return  stdClass|null
+	 */
+	private static function provision_sftp_user( string $site_identifier ): ?stdClass {
+		static $attempted = array();
+
+		if ( isset( $attempted[ $site_identifier ] ) ) {
+			return null;
+		}
+		$attempted[ $site_identifier ] = true;
+
+		console_writeln( '⏳ No Pressable SFTP user found for ' . self::SFTP_USER_EMAIL . '. Creating the collaborator...' );
+		if ( \is_null( create_pressable_site_collaborator( $site_identifier, self::SFTP_USER_EMAIL ) ) ) {
+			console_writeln( '❌ Could not create the Pressable site collaborator.' );
+			return null;
+		}
+
+		// Pressable provisions the SFTP user asynchronously, so it is not returned by the API right away.
+		for ( $attempt = 1; $attempt <= 6; $attempt++ ) {
+			\sleep( 5 );
+
+			$sftp_user = get_pressable_site_sftp_user( $site_identifier, self::SFTP_USER_EMAIL );
+			if ( ! \is_null( $sftp_user ) ) {
+				return $sftp_user;
+			}
+		}
+
+		console_writeln( '❌ The Pressable site SFTP user was created but did not become available in time.' );
+		return null;
 	}
 
 	// endregion

--- a/includes/connection-helper-pressable.php
+++ b/includes/connection-helper-pressable.php
@@ -21,6 +21,11 @@ final class Pressable_Connection_Helper extends Abstract_Connection_Helper {
 	 */
 	private const SFTP_USER_EMAIL = 'concierge@wordpress.com';
 
+	/**
+	 * How many lookups may fail before the collaborator is assumed missing rather than still provisioning.
+	 */
+	private const SFTP_USER_LOOKUP_GRACE_ATTEMPTS = 3;
+
 	// endregion
 
 	// region HELPERS
@@ -38,6 +43,7 @@ final class Pressable_Connection_Helper extends Abstract_Connection_Helper {
 				// than on every pass.
 				$sftp_user = self::provision_sftp_user( $site_identifier );
 			}
+
 			if ( \is_null( $sftp_user ) ) {
 				return null;
 			}
@@ -53,19 +59,23 @@ final class Pressable_Connection_Helper extends Abstract_Connection_Helper {
 	 *
 	 * A freshly cloned site does not always inherit the collaborator, which used to leave every SSH and SFTP
 	 * connection to it failing with `SFTP user not found.` until someone added the collaborator by hand.
-	 * Creation is attempted only once per site because callers retry `get_credentials()` in a loop.
+	 *
+	 * The far more common reason for that error is simply that the clone's own SFTP user has not finished
+	 * provisioning yet - it usually appears within a few seconds - so the first lookups are allowed to fail
+	 * before concluding the collaborator is missing and creating one. Creation is then attempted only once
+	 * per site, because callers retry `get_credentials()` in a loop.
 	 *
 	 * @param   string $site_identifier The site to provision the SFTP user on.
 	 *
 	 * @return  stdClass|null
 	 */
 	private static function provision_sftp_user( string $site_identifier ): ?stdClass {
-		static $attempted = array();
+		static $lookup_failures = array();
 
-		if ( isset( $attempted[ $site_identifier ] ) ) {
+		$lookup_failures[ $site_identifier ] = ( $lookup_failures[ $site_identifier ] ?? 0 ) + 1;
+		if ( self::SFTP_USER_LOOKUP_GRACE_ATTEMPTS !== $lookup_failures[ $site_identifier ] ) {
 			return null;
 		}
-		$attempted[ $site_identifier ] = true;
 
 		console_writeln( '⏳ No Pressable SFTP user found for ' . self::SFTP_USER_EMAIL . '. Creating the collaborator...' );
 		if ( \is_null( create_pressable_site_collaborator( $site_identifier, self::SFTP_USER_EMAIL ) ) ) {

--- a/includes/connection-helper-pressable.php
+++ b/includes/connection-helper-pressable.php
@@ -26,6 +26,11 @@ final class Pressable_Connection_Helper extends Abstract_Connection_Helper {
 	 */
 	private const SFTP_USER_LOOKUP_GRACE_ATTEMPTS = 3;
 
+	/**
+	 * How many times to re-check for the SFTP user after creating the collaborator.
+	 */
+	private const SFTP_USER_PROVISION_ATTEMPTS = 6;
+
 	// endregion
 
 	// region HELPERS
@@ -61,20 +66,32 @@ final class Pressable_Connection_Helper extends Abstract_Connection_Helper {
 	 * connection to it failing with `SFTP user not found.` until someone added the collaborator by hand.
 	 *
 	 * The far more common reason for that error is simply that the clone's own SFTP user has not finished
-	 * provisioning yet - it usually appears within a few seconds - so the first lookups are allowed to fail
-	 * before concluding the collaborator is missing and creating one. Creation is then attempted only once
-	 * per site, because callers retry `get_credentials()` in a loop.
+	 * provisioning yet - it usually appears within a few seconds - so the lookup is retried here before
+	 * concluding the collaborator is missing. The grace is spent inside this call rather than across repeated
+	 * `get_credentials()` calls, because most callers open a single connection and never retry.
+	 *
+	 * Runs at most once per site: the one caller that does retry in a loop must not create a collaborator per
+	 * pass, and must not pay for the grace again once it has been spent.
 	 *
 	 * @param   string $site_identifier The site to provision the SFTP user on.
 	 *
 	 * @return  stdClass|null
 	 */
 	private static function provision_sftp_user( string $site_identifier ): ?stdClass {
-		static $lookup_failures = array();
+		static $attempted = array();
 
-		$lookup_failures[ $site_identifier ] = ( $lookup_failures[ $site_identifier ] ?? 0 ) + 1;
-		if ( self::SFTP_USER_LOOKUP_GRACE_ATTEMPTS !== $lookup_failures[ $site_identifier ] ) {
+		if ( isset( $attempted[ $site_identifier ] ) ) {
 			return null;
+		}
+		$attempted[ $site_identifier ] = true;
+
+		for ( $attempt = 1; $attempt < self::SFTP_USER_LOOKUP_GRACE_ATTEMPTS; $attempt++ ) {
+			\sleep( 5 );
+
+			$sftp_user = get_pressable_site_sftp_user( $site_identifier, self::SFTP_USER_EMAIL );
+			if ( ! \is_null( $sftp_user ) ) {
+				return $sftp_user;
+			}
 		}
 
 		console_writeln( '⏳ No Pressable SFTP user found for ' . self::SFTP_USER_EMAIL . '. Creating the collaborator...' );
@@ -84,7 +101,7 @@ final class Pressable_Connection_Helper extends Abstract_Connection_Helper {
 		}
 
 		// Pressable provisions the SFTP user asynchronously, so it is not returned by the API right away.
-		for ( $attempt = 1; $attempt <= 6; $attempt++ ) {
+		for ( $attempt = 1; $attempt <= self::SFTP_USER_PROVISION_ATTEMPTS; $attempt++ ) {
 			\sleep( 5 );
 
 			$sftp_user = get_pressable_site_sftp_user( $site_identifier, self::SFTP_USER_EMAIL );

--- a/includes/connection-helper-pressable.php
+++ b/includes/connection-helper-pressable.php
@@ -22,14 +22,48 @@ final class Pressable_Connection_Helper extends Abstract_Connection_Helper {
 	private const SFTP_USER_EMAIL = 'concierge@wordpress.com';
 
 	/**
-	 * How many lookups may fail before the collaborator is assumed missing rather than still provisioning.
-	 */
-	private const SFTP_USER_LOOKUP_GRACE_ATTEMPTS = 3;
-
-	/**
 	 * How many times to re-check for the SFTP user after creating the collaborator.
 	 */
 	private const SFTP_USER_PROVISION_ATTEMPTS = 6;
+
+	// endregion
+
+	// region METHODS
+
+	/**
+	 * Makes sure the site has an SFTP user for the concierge collaborator, creating one if it does not.
+	 *
+	 * Opening a connection deliberately does not do this: creating a collaborator is a write, and granting
+	 * access to a site should not be a side effect of a read-only command connecting to it. Commands that
+	 * provision a site call this once, explicitly, before they start connecting.
+	 *
+	 * @param   string $site_identifier The site to provision the SFTP user on.
+	 *
+	 * @return  boolean  Whether the site has an SFTP user for the concierge collaborator.
+	 */
+	public static function ensure_sftp_user( string $site_identifier ): bool {
+		if ( ! \is_null( get_pressable_site_sftp_user( $site_identifier, self::SFTP_USER_EMAIL ) ) ) {
+			return true;
+		}
+
+		console_writeln( '⏳ No Pressable SFTP user found for ' . self::SFTP_USER_EMAIL . '. Creating the collaborator...' );
+		if ( \is_null( create_pressable_site_collaborator( $site_identifier, self::SFTP_USER_EMAIL ) ) ) {
+			console_writeln( '❌ Could not create the Pressable site collaborator.' );
+			return false;
+		}
+
+		// Pressable provisions the SFTP user asynchronously, so it is not returned by the API right away.
+		for ( $attempt = 1; $attempt <= self::SFTP_USER_PROVISION_ATTEMPTS; $attempt++ ) {
+			\sleep( 5 );
+
+			if ( ! \is_null( get_pressable_site_sftp_user( $site_identifier, self::SFTP_USER_EMAIL ) ) ) {
+				return true;
+			}
+		}
+
+		console_writeln( '❌ The Pressable site SFTP user was created but did not become available in time.' );
+		return false;
+	}
 
 	// endregion
 
@@ -39,17 +73,19 @@ final class Pressable_Connection_Helper extends Abstract_Connection_Helper {
 	 * {@inheritdoc}
 	 */
 	protected static function get_credentials( string $site_identifier ): ?stdClass {
-		static $cache = array();
+		static $cache    = array();
+		static $reported = array();
 
 		if ( empty( $cache[ $site_identifier ] ) ) {
 			$sftp_user = get_pressable_site_sftp_user( $site_identifier, self::SFTP_USER_EMAIL );
 			if ( \is_null( $sftp_user ) ) {
-				// Callers retry in a loop, so the reason is reported once by the provisioning attempt rather
-				// than on every pass.
-				$sftp_user = self::provision_sftp_user( $site_identifier );
-			}
+				// Reported once per site: the caller waiting on a new site retries this in a loop, and the
+				// reason does not change between passes.
+				if ( ! isset( $reported[ $site_identifier ] ) ) {
+					$reported[ $site_identifier ] = true;
+					console_writeln( '❌ Could not find the Pressable site SFTP user.' );
+				}
 
-			if ( \is_null( $sftp_user ) ) {
 				return null;
 			}
 
@@ -57,61 +93,6 @@ final class Pressable_Connection_Helper extends Abstract_Connection_Helper {
 		}
 
 		return $cache[ $site_identifier ];
-	}
-
-	/**
-	 * Creates the concierge collaborator on a site and waits for its SFTP user to be provisioned.
-	 *
-	 * A freshly cloned site does not always inherit the collaborator, which used to leave every SSH and SFTP
-	 * connection to it failing with `SFTP user not found.` until someone added the collaborator by hand.
-	 *
-	 * The far more common reason for that error is simply that the clone's own SFTP user has not finished
-	 * provisioning yet - it usually appears within a few seconds - so the lookup is retried here before
-	 * concluding the collaborator is missing. The grace is spent inside this call rather than across repeated
-	 * `get_credentials()` calls, because most callers open a single connection and never retry.
-	 *
-	 * Runs at most once per site: the one caller that does retry in a loop must not create a collaborator per
-	 * pass, and must not pay for the grace again once it has been spent.
-	 *
-	 * @param   string $site_identifier The site to provision the SFTP user on.
-	 *
-	 * @return  stdClass|null
-	 */
-	private static function provision_sftp_user( string $site_identifier ): ?stdClass {
-		static $attempted = array();
-
-		if ( isset( $attempted[ $site_identifier ] ) ) {
-			return null;
-		}
-		$attempted[ $site_identifier ] = true;
-
-		for ( $attempt = 1; $attempt < self::SFTP_USER_LOOKUP_GRACE_ATTEMPTS; $attempt++ ) {
-			\sleep( 5 );
-
-			$sftp_user = get_pressable_site_sftp_user( $site_identifier, self::SFTP_USER_EMAIL );
-			if ( ! \is_null( $sftp_user ) ) {
-				return $sftp_user;
-			}
-		}
-
-		console_writeln( '⏳ No Pressable SFTP user found for ' . self::SFTP_USER_EMAIL . '. Creating the collaborator...' );
-		if ( \is_null( create_pressable_site_collaborator( $site_identifier, self::SFTP_USER_EMAIL ) ) ) {
-			console_writeln( '❌ Could not create the Pressable site collaborator.' );
-			return null;
-		}
-
-		// Pressable provisions the SFTP user asynchronously, so it is not returned by the API right away.
-		for ( $attempt = 1; $attempt <= self::SFTP_USER_PROVISION_ATTEMPTS; $attempt++ ) {
-			\sleep( 5 );
-
-			$sftp_user = get_pressable_site_sftp_user( $site_identifier, self::SFTP_USER_EMAIL );
-			if ( ! \is_null( $sftp_user ) ) {
-				return $sftp_user;
-			}
-		}
-
-		console_writeln( '❌ The Pressable site SFTP user was created but did not become available in time.' );
-		return null;
 	}
 
 	// endregion

--- a/includes/connection-helper-pressable.php
+++ b/includes/connection-helper-pressable.php
@@ -22,6 +22,11 @@ final class Pressable_Connection_Helper extends Abstract_Connection_Helper {
 	private const SFTP_USER_EMAIL = 'concierge@wordpress.com';
 
 	/**
+	 * How many times to look for an existing SFTP user before concluding the collaborator is missing.
+	 */
+	private const SFTP_USER_LOOKUP_ATTEMPTS = 3;
+
+	/**
 	 * How many times to re-check for the SFTP user after creating the collaborator.
 	 */
 	private const SFTP_USER_PROVISION_ATTEMPTS = 6;
@@ -42,8 +47,17 @@ final class Pressable_Connection_Helper extends Abstract_Connection_Helper {
 	 * @return  boolean  Whether the site has an SFTP user for the concierge collaborator.
 	 */
 	public static function ensure_sftp_user( string $site_identifier ): bool {
-		if ( ! \is_null( get_pressable_site_sftp_user( $site_identifier, self::SFTP_USER_EMAIL ) ) ) {
-			return true;
+		// Callers run this right after a site is created, which is exactly when a site that did inherit the
+		// collaborator has not had its SFTP user provisioned yet. Without this grace the normal path would
+		// treat one missed lookup as proof the collaborator is absent and POST a duplicate.
+		for ( $attempt = 1; $attempt <= self::SFTP_USER_LOOKUP_ATTEMPTS; $attempt++ ) {
+			if ( ! \is_null( get_pressable_site_sftp_user( $site_identifier, self::SFTP_USER_EMAIL ) ) ) {
+				return true;
+			}
+
+			if ( $attempt < self::SFTP_USER_LOOKUP_ATTEMPTS ) {
+				\sleep( 5 );
+			}
 		}
 
 		console_writeln( '⏳ No Pressable SFTP user found for ' . self::SFTP_USER_EMAIL . '. Creating the collaborator...' );

--- a/includes/functions-pressable.php
+++ b/includes/functions-pressable.php
@@ -380,10 +380,10 @@ function rotate_pressable_site_wp_user_password( string $site_id_or_url, string 
 
 		// Whenever output was captured but no credentials are returned - a garbled token, or a connection that
 		// broke after the reset already ran and printed one - that output is the only copy of whatever the
-		// site now uses, so it is surfaced rather than dropped. A fatal WP-CLI error is the exception: it
-		// means the reset never ran, so there is no credential to preserve and the caller's failure message
-		// covers it.
-		if ( is_null( $credentials ) && '' !== trim( (string) ( $GLOBALS['wp_cli_output'] ?? '' ) ) && ! is_wp_cli_error_output( $GLOBALS['wp_cli_output'] ) ) {
+		// site now uses, so it is surfaced rather than dropped. Suppressed only when a fatal WP-CLI error is
+		// present AND no token was recoverable: that combination means the reset never ran, whereas an error
+		// alongside a token means it did and the token must not be lost.
+		if ( is_null( $credentials ) && '' !== trim( (string) ( $GLOBALS['wp_cli_output'] ?? '' ) ) && ( ! is_null( $password ) || ! is_wp_cli_error_output( $GLOBALS['wp_cli_output'] ) ) ) {
 			report_unreadable_wp_cli_password( $user, $GLOBALS['wp_cli_output'] );
 		}
 	}

--- a/includes/functions-pressable.php
+++ b/includes/functions-pressable.php
@@ -369,10 +369,6 @@ function rotate_pressable_site_wp_user_password( string $site_id_or_url, string 
 		$exit_code = run_pressable_site_wp_cli_command( $site_id_or_url, "user reset-password $user --skip-email --porcelain", true );
 		$password  = parse_wp_cli_porcelain_password( $GLOBALS['wp_cli_output'] ?? null );
 
-		if ( Command::SUCCESS === $exit_code && is_null( $password ) ) {
-			report_unreadable_wp_cli_password( $user, $GLOBALS['wp_cli_output'] ?? null );
-		}
-
 		// The password is only trusted when WP-CLI actually printed one. Without this an unreachable site, or
 		// a reset that failed and printed an error instead, overwrites a good 1Password entry.
 		$credentials = ( Command::SUCCESS === $exit_code && ! is_null( $password ) )
@@ -381,6 +377,13 @@ function rotate_pressable_site_wp_user_password( string $site_id_or_url, string 
 				'password' => $password,
 			)
 			: null;
+
+		// Whenever output was captured but no credentials are returned - a garbled token, or a connection that
+		// broke after the reset already ran and printed one - that output is the only copy of whatever the
+		// site now uses, so it is surfaced rather than dropped.
+		if ( is_null( $credentials ) && '' !== trim( (string) ( $GLOBALS['wp_cli_output'] ?? '' ) ) ) {
+			report_unreadable_wp_cli_password( $user, $GLOBALS['wp_cli_output'] );
+		}
 	}
 
 	return $credentials;

--- a/includes/functions-pressable.php
+++ b/includes/functions-pressable.php
@@ -380,8 +380,10 @@ function rotate_pressable_site_wp_user_password( string $site_id_or_url, string 
 
 		// Whenever output was captured but no credentials are returned - a garbled token, or a connection that
 		// broke after the reset already ran and printed one - that output is the only copy of whatever the
-		// site now uses, so it is surfaced rather than dropped.
-		if ( is_null( $credentials ) && '' !== trim( (string) ( $GLOBALS['wp_cli_output'] ?? '' ) ) ) {
+		// site now uses, so it is surfaced rather than dropped. A fatal WP-CLI error is the exception: it
+		// means the reset never ran, so there is no credential to preserve and the caller's failure message
+		// covers it.
+		if ( is_null( $credentials ) && '' !== trim( (string) ( $GLOBALS['wp_cli_output'] ?? '' ) ) && ! is_wp_cli_error_output( $GLOBALS['wp_cli_output'] ) ) {
 			report_unreadable_wp_cli_password( $user, $GLOBALS['wp_cli_output'] );
 		}
 	}

--- a/includes/functions-pressable.php
+++ b/includes/functions-pressable.php
@@ -365,7 +365,8 @@ function rotate_pressable_site_wp_user_password( string $site_id_or_url, string 
 	$site_id_or_url = pressable_maybe_resolve_site_alias( $site_id_or_url );
 	$credentials    = API_Helper::make_pressable_request( "site-wp-users/$site_id_or_url/$user/rotate-password", 'POST' );
 	if ( is_null( $credentials ) || is_null( $credentials->password ) ) {
-		$exit_code = run_pressable_site_wp_cli_command( $site_id_or_url, "user reset-password $user --skip-email --porcelain" );
+		// Skipping the output keeps the freshly reset password out of the console and any log capturing it.
+		$exit_code = run_pressable_site_wp_cli_command( $site_id_or_url, "user reset-password $user --skip-email --porcelain", true );
 		$password  = is_string( $GLOBALS['wp_cli_output'] ?? null ) ? trim( $GLOBALS['wp_cli_output'] ) : '';
 
 		// The password is only trusted when WP-CLI actually printed one. Without this an unreachable site

--- a/includes/functions-pressable.php
+++ b/includes/functions-pressable.php
@@ -366,14 +366,16 @@ function rotate_pressable_site_wp_user_password( string $site_id_or_url, string 
 	$credentials    = API_Helper::make_pressable_request( "site-wp-users/$site_id_or_url/$user/rotate-password", 'POST' );
 	if ( is_null( $credentials ) || is_null( $credentials->password ) ) {
 		$exit_code = run_pressable_site_wp_cli_command( $site_id_or_url, "user reset-password $user --skip-email --porcelain" );
-		if ( Command::SUCCESS === $exit_code ) {
-			$credentials = (object) array(
+		$password  = is_string( $GLOBALS['wp_cli_output'] ?? null ) ? trim( $GLOBALS['wp_cli_output'] ) : '';
+
+		// The password is only trusted when WP-CLI actually printed one. Without this an unreachable site
+		// yields an empty password that then overwrites a good 1Password entry.
+		$credentials = ( Command::SUCCESS === $exit_code && '' !== $password )
+			? (object) array(
 				'username' => $user,
-				'password' => $GLOBALS['wp_cli_output'],
-			);
-		} else {
-			$credentials = null;
-		}
+				'password' => $password,
+			)
+			: null;
 	}
 
 	return $credentials;
@@ -494,17 +496,19 @@ function wait_on_pressable_site_state( string $site_id_or_url, string $state, Ou
  *
  * @param   string          $site_id_or_url The ID or URL of the Pressable site to check the state of.
  * @param   OutputInterface $output         The output instance.
+ * @param   integer         $max_attempts   The maximum number of connection attempts, 5 seconds apart.
  *
  * @return  SSH2|null
  */
-function wait_on_pressable_site_ssh( string $site_id_or_url, OutputInterface $output ): ?SSH2 {
+function wait_on_pressable_site_ssh( string $site_id_or_url, OutputInterface $output, int $max_attempts = 60 ): ?SSH2 {
 	$site_id_or_url = pressable_maybe_resolve_site_alias( $site_id_or_url );
 	$output->writeln( "<comment>Waiting for Pressable site $site_id_or_url to accept SSH connections.</comment>" );
 
 	$progress_bar = new ProgressBar( $output );
 	$progress_bar->start();
 
-	for ( $try = 0, $delay = 5; true; $try++ ) { // Infinite loop until SSH connection is established.
+	$ssh_connection = null;
+	for ( $try = 0, $delay = 5; $try < $max_attempts; $try++ ) {
 		$ssh_connection = Pressable_Connection_Helper::get_ssh_connection( $site_id_or_url );
 		if ( ! is_null( $ssh_connection ) ) {
 			break;
@@ -516,6 +520,10 @@ function wait_on_pressable_site_ssh( string $site_id_or_url, OutputInterface $ou
 
 	$progress_bar->finish();
 	$output->writeln( '' ); // Empty line for UX purposes.
+
+	if ( is_null( $ssh_connection ) ) {
+		$output->writeln( "<error>Pressable site $site_id_or_url did not accept SSH connections after $max_attempts attempts.</error>" );
+	}
 
 	return $ssh_connection;
 }

--- a/includes/functions-pressable.php
+++ b/includes/functions-pressable.php
@@ -369,6 +369,10 @@ function rotate_pressable_site_wp_user_password( string $site_id_or_url, string 
 		$exit_code = run_pressable_site_wp_cli_command( $site_id_or_url, "user reset-password $user --skip-email --porcelain", true );
 		$password  = parse_wp_cli_porcelain_password( $GLOBALS['wp_cli_output'] ?? null );
 
+		if ( Command::SUCCESS === $exit_code && is_null( $password ) ) {
+			report_unreadable_wp_cli_password( $user, $GLOBALS['wp_cli_output'] ?? null );
+		}
+
 		// The password is only trusted when WP-CLI actually printed one. Without this an unreachable site, or
 		// a reset that failed and printed an error instead, overwrites a good 1Password entry.
 		$credentials = ( Command::SUCCESS === $exit_code && ! is_null( $password ) )
@@ -466,19 +470,24 @@ function create_pressable_site_clone( string $site_id_or_url, string $name, ?str
  * @param   string          $site_id_or_url The ID or URL of the Pressable site to check the state of.
  * @param   string          $state          The state to wait for the site to exit.
  * @param   OutputInterface $output         The output instance.
- * @param   integer         $max_attempts   The maximum number of state checks before giving up.
+ * @param   integer         $max_wait_seconds How long to keep checking before giving up.
  *
  * @return  stdClass|null
  */
-function wait_on_pressable_site_state( string $site_id_or_url, string $state, OutputInterface $output, int $max_attempts = 120 ): ?stdClass {
+function wait_on_pressable_site_state( string $site_id_or_url, string $state, OutputInterface $output, int $max_wait_seconds = 1200 ): ?stdClass {
 	$site_id_or_url = pressable_maybe_resolve_site_alias( $site_id_or_url );
 	$output->writeln( "<comment>Waiting for Pressable site $site_id_or_url to exit $state state.</comment>" );
 
 	$progress_bar = new ProgressBar( $output );
 	$progress_bar->start();
 
+	// The poll interval differs per state, so the budget is wall-clock rather than a number of attempts -
+	// otherwise the same attempt count would mean a very different amount of patience for each state.
+	$delay        = 'deploying' === $state ? 3 : 10;
+	$max_attempts = (int) ceil( $max_wait_seconds / $delay );
+
 	$exited = false;
-	for ( $try = 0, $delay = 'deploying' === $state ? 3 : 10; $try < $max_attempts; $try++ ) {
+	for ( $try = 0; $try < $max_attempts; $try++ ) {
 		$site = get_pressable_site( $site_id_or_url );
 		if ( is_null( $site ) || $state !== $site->state ) {
 			$exited = true;
@@ -493,7 +502,8 @@ function wait_on_pressable_site_state( string $site_id_or_url, string $state, Ou
 	$output->writeln( '' ); // Empty line for UX purposes.
 
 	if ( ! $exited ) {
-		$output->writeln( "<error>Pressable site $site_id_or_url did not exit $state state after $max_attempts checks.</error>" );
+		$minutes = (int) round( $max_wait_seconds / 60 );
+		$output->writeln( "<error>Pressable site $site_id_or_url did not exit $state state within $minutes minutes. The site exists and may still be provisioning.</error>" );
 		return null;
 	}
 

--- a/includes/functions-pressable.php
+++ b/includes/functions-pressable.php
@@ -491,12 +491,22 @@ function wait_on_pressable_site_state( string $site_id_or_url, string $state, Ou
 	$delay        = 'deploying' === $state ? 3 : 10;
 	$max_attempts = (int) ceil( $max_wait_seconds / $delay );
 
-	$exited = false;
+	// A transient failed lookup is retried rather than treated as terminal - one null from the API against a
+	// freshly created site must not throw away the whole budget - and only a few in a row give up.
+	$exited       = false;
+	$null_lookups = 0;
 	for ( $try = 0; $try < $max_attempts; $try++ ) {
 		$site = get_pressable_site( $site_id_or_url );
-		if ( is_null( $site ) || $state !== $site->state ) {
-			$exited = true;
-			break;
+		if ( is_null( $site ) ) {
+			if ( 3 <= ++$null_lookups ) {
+				break;
+			}
+		} else {
+			$null_lookups = 0;
+			if ( $state !== $site->state ) {
+				$exited = true;
+				break;
+			}
 		}
 
 		$progress_bar->advance();
@@ -508,7 +518,11 @@ function wait_on_pressable_site_state( string $site_id_or_url, string $state, Ou
 
 	if ( ! $exited ) {
 		$minutes = (int) round( $max_wait_seconds / 60 );
-		$output->writeln( "<error>Pressable site $site_id_or_url did not exit $state state within $minutes minutes. The site exists and may still be provisioning.</error>" );
+		$output->writeln(
+			3 <= $null_lookups
+				? "<error>Pressable site $site_id_or_url could not be looked up ($null_lookups consecutive failed lookups).</error>"
+				: "<error>Pressable site $site_id_or_url did not exit $state state within $minutes minutes. The site exists and may still be provisioning.</error>"
+		);
 		return null;
 	}
 

--- a/includes/functions-pressable.php
+++ b/includes/functions-pressable.php
@@ -367,11 +367,11 @@ function rotate_pressable_site_wp_user_password( string $site_id_or_url, string 
 	if ( is_null( $credentials ) || is_null( $credentials->password ) ) {
 		// Skipping the output keeps the freshly reset password out of the console and any log capturing it.
 		$exit_code = run_pressable_site_wp_cli_command( $site_id_or_url, "user reset-password $user --skip-email --porcelain", true );
-		$password  = is_string( $GLOBALS['wp_cli_output'] ?? null ) ? trim( $GLOBALS['wp_cli_output'] ) : '';
+		$password  = parse_wp_cli_porcelain_password( $GLOBALS['wp_cli_output'] ?? null );
 
-		// The password is only trusted when WP-CLI actually printed one. Without this an unreachable site
-		// yields an empty password that then overwrites a good 1Password entry.
-		$credentials = ( Command::SUCCESS === $exit_code && '' !== $password )
+		// The password is only trusted when WP-CLI actually printed one. Without this an unreachable site, or
+		// a reset that failed and printed an error instead, overwrites a good 1Password entry.
+		$credentials = ( Command::SUCCESS === $exit_code && ! is_null( $password ) )
 			? (object) array(
 				'username' => $user,
 				'password' => $password,
@@ -466,19 +466,22 @@ function create_pressable_site_clone( string $site_id_or_url, string $name, ?str
  * @param   string          $site_id_or_url The ID or URL of the Pressable site to check the state of.
  * @param   string          $state          The state to wait for the site to exit.
  * @param   OutputInterface $output         The output instance.
+ * @param   integer         $max_attempts   The maximum number of state checks before giving up.
  *
  * @return  stdClass|null
  */
-function wait_on_pressable_site_state( string $site_id_or_url, string $state, OutputInterface $output ): ?stdClass {
+function wait_on_pressable_site_state( string $site_id_or_url, string $state, OutputInterface $output, int $max_attempts = 120 ): ?stdClass {
 	$site_id_or_url = pressable_maybe_resolve_site_alias( $site_id_or_url );
 	$output->writeln( "<comment>Waiting for Pressable site $site_id_or_url to exit $state state.</comment>" );
 
 	$progress_bar = new ProgressBar( $output );
 	$progress_bar->start();
 
-	for ( $try = 0, $delay = 'deploying' === $state ? 3 : 10; true; $try++ ) {
+	$exited = false;
+	for ( $try = 0, $delay = 'deploying' === $state ? 3 : 10; $try < $max_attempts; $try++ ) {
 		$site = get_pressable_site( $site_id_or_url );
 		if ( is_null( $site ) || $state !== $site->state ) {
+			$exited = true;
 			break;
 		}
 
@@ -488,6 +491,11 @@ function wait_on_pressable_site_state( string $site_id_or_url, string $state, Ou
 
 	$progress_bar->finish();
 	$output->writeln( '' ); // Empty line for UX purposes.
+
+	if ( ! $exited ) {
+		$output->writeln( "<error>Pressable site $site_id_or_url did not exit $state state after $max_attempts checks.</error>" );
+		return null;
+	}
 
 	return $site;
 }

--- a/includes/functions-safety-net.php
+++ b/includes/functions-safety-net.php
@@ -95,16 +95,20 @@ function install_safety_net_files( SSH2 $ssh_connection, ?string &$failure_outpu
 	// fallback names are created with `set -C`/`mkdir`, so a pre-existing target aborts the allocation instead
 	// of being written through; an unusable target reports 126 rather than silently failing the download.
 	//
-	// The archive is unpacked into a staging directory and swapped in only once the unpack has succeeded, so
-	// a host without `unzip` - or a corrupt archive - never destroys an installed copy it cannot replace. The
-	// swap also clears the destination first, because `unzip -o`/`mv` into an existing directory merge rather
-	// than replace and would leave files from an older release behind.
+	// The archive is unpacked into a staging directory and swapped in only once the staged copy is proven to
+	// be the replacement: `unzip` exiting 0 does not guarantee a `safety-net/` root (a re-rooted release
+	// archive extracts cleanly without one), so the directory itself is tested before anything is destroyed,
+	// and the mu-plugins parent is created first because `mv` - unlike the `unzip -d` this replaced - does
+	// not create it. The swap clears the destination because `unzip -o`/`mv` into an existing directory merge
+	// rather than replace and would leave files from an older release behind.
 	$result = $ssh_connection->exec(
 		'ZIP=$(mktemp 2>/dev/null) || { ZIP=/tmp/safety-net.$$.zip ; ( set -C ; : > "$ZIP" ) 2>/dev/null || ZIP="" ; }'
 		. ' ; DIR=$(mktemp -d 2>/dev/null) || { DIR=/tmp/safety-net-stage.$$ ; mkdir "$DIR" 2>/dev/null || DIR="" ; }'
 		. ' ; if [ -z "$ZIP" ] || [ -z "$DIR" ] ; then INSTALL=126 ; rm -rf "$ZIP" "$DIR" 2>/dev/null ; else'
 		. " { curl -fsSL '" . SAFETY_NET_ZIP_URL . '\' -o "$ZIP"'
 		. ' && unzip -o -q "$ZIP" -d "$DIR/"'
+		. ' && test -d "$DIR/safety-net"'
+		. " && mkdir -p '$mu_plugins'"
 		. " && rm -rf '$mu_plugins/safety-net'"
 		. ' && mv -f "$DIR/safety-net" \'' . $mu_plugins . '/safety-net\' ; } 2>&1'
 		. ' ; INSTALL=$?'

--- a/includes/functions-safety-net.php
+++ b/includes/functions-safety-net.php
@@ -92,19 +92,23 @@ function install_safety_net_files( SSH2 $ssh_connection, ?string &$failure_outpu
 
 	// The archive lands at a mktemp-allocated path rather than a fixed, predictable one that anything else
 	// with write access to /tmp could pre-create between the download and the unpack. If mktemp is missing the
-	// fallback name is created under `set -C`, so a pre-existing file aborts the allocation instead of being
-	// written through; an unusable target reports 126 rather than silently failing the download.
+	// fallback names are created with `set -C`/`mkdir`, so a pre-existing target aborts the allocation instead
+	// of being written through; an unusable target reports 126 rather than silently failing the download.
 	//
-	// The stale plugin directory is cleared only after the archive is in hand, and before the unpack, because
-	// `unzip -o` merges into whatever is already there and would leave files from an older release behind.
+	// The archive is unpacked into a staging directory and swapped in only once the unpack has succeeded, so
+	// a host without `unzip` - or a corrupt archive - never destroys an installed copy it cannot replace. The
+	// swap also clears the destination first, because `unzip -o`/`mv` into an existing directory merge rather
+	// than replace and would leave files from an older release behind.
 	$result = $ssh_connection->exec(
 		'ZIP=$(mktemp 2>/dev/null) || { ZIP=/tmp/safety-net.$$.zip ; ( set -C ; : > "$ZIP" ) 2>/dev/null || ZIP="" ; }'
-		. ' ; if [ -z "$ZIP" ] ; then INSTALL=126 ; else'
+		. ' ; DIR=$(mktemp -d 2>/dev/null) || { DIR=/tmp/safety-net-stage.$$ ; mkdir "$DIR" 2>/dev/null || DIR="" ; }'
+		. ' ; if [ -z "$ZIP" ] || [ -z "$DIR" ] ; then INSTALL=126 ; rm -rf "$ZIP" "$DIR" 2>/dev/null ; else'
 		. " { curl -fsSL '" . SAFETY_NET_ZIP_URL . '\' -o "$ZIP"'
+		. ' && unzip -o -q "$ZIP" -d "$DIR/"'
 		. " && rm -rf '$mu_plugins/safety-net'"
-		. ' && unzip -o -q "$ZIP" -d \'' . $mu_plugins . '/\' ; } 2>&1'
+		. ' && mv -f "$DIR/safety-net" \'' . $mu_plugins . '/safety-net\' ; } 2>&1'
 		. ' ; INSTALL=$?'
-		. ' ; rm -f "$ZIP"'
+		. ' ; rm -rf "$ZIP" "$DIR"'
 		. ' ; fi'
 		. ' ; echo "INSTALL:${INSTALL}"'
 	);
@@ -288,25 +292,30 @@ function maybe_install_safety_net( ?SSH2 $ssh_connection, OutputInterface $outpu
 		$ssh_connection->setTimeout( 600 );
 
 		// Run on the connection directly: the exit codes below are the remote ones, so each step reports its
-		// own failure. getExitStatus() returns false when the server sent no exit-status message, which is
-		// not a failure - reporting it as `exit code ` would read as one.
+		// own failure. getExitStatus() returns false when the channel closed without an exit-status message -
+		// which is what a signal kill produces, the SIGSYS case this fallback exists for - so that outcome is
+		// named rather than treated as success.
 		$ssh_connection->exec( 'wp plugin install ' . SAFETY_NET_ZIP_URL );
 		$install_code = $ssh_connection->getExitStatus();
-		if ( false !== $install_code && 0 !== $install_code ) {
+		if ( false === $install_code ) {
+			$output->writeln( '<error>Installing SafetyNet through WP-CLI returned no exit status; it may have been killed.</error>' );
+		} elseif ( 0 !== $install_code ) {
 			$output->writeln( "<error>Installing SafetyNet through WP-CLI failed with exit code $install_code.</error>" );
 		}
 
 		// `mv` moves the source *into* an existing destination directory rather than replacing it, which would
 		// nest the plugin one level too deep - and exit 0 while doing so. The destination is cleared first,
 		// but only once the source is known to exist, so a failed install never destroys what is already
-		// there without a replacement.
+		// there without a replacement. A missing source is reported as such, not as a failed move.
 		$site_root   = get_ssh_site_root_path( $ssh_connection );
 		$plugin_src  = "$site_root/wp-content/plugins/safety-net";
 		$plugin_dest = "$site_root/wp-content/mu-plugins/safety-net";
 
-		$ssh_connection->exec( "test -d '$plugin_src' && rm -rf '$plugin_dest' && mv -f '$plugin_src' '$plugin_dest'" );
-		$move_code = $ssh_connection->getExitStatus();
-		if ( false !== $move_code && 0 !== $move_code ) {
+		$move_output = $ssh_connection->exec( "if test -d '$plugin_src' ; then rm -rf '$plugin_dest' && mv -f '$plugin_src' '$plugin_dest' ; else echo 'MOVE:skipped' ; fi" );
+		$move_code   = $ssh_connection->getExitStatus();
+		if ( is_string( $move_output ) && str_contains( $move_output, 'MOVE:skipped' ) ) {
+			$output->writeln( '<comment>Nothing to move into mu-plugins: WP-CLI did not produce the plugin directory.</comment>' );
+		} elseif ( false !== $move_code && 0 !== $move_code ) {
 			$output->writeln( "<error>Moving SafetyNet into mu-plugins failed with exit code $move_code.</error>" );
 		}
 

--- a/includes/functions-safety-net.php
+++ b/includes/functions-safety-net.php
@@ -212,8 +212,11 @@ function maybe_install_safety_net( ?SSH2 $ssh_connection, OutputInterface $outpu
 			}
 
 			$ssh_connection->exec( 'mv -f /htdocs/wp-content/plugins/safety-net ' . SAFETY_NET_MU_PLUGINS_PATH . '/safety-net' );
+
+			// getExitStatus() returns false when the server sent no exit-status message, which is not a
+			// failure - reporting it as `exit code ` would read as one.
 			$move_code = $ssh_connection->getExitStatus();
-			if ( 0 !== $move_code ) {
+			if ( false !== $move_code && 0 !== $move_code ) {
 				$output->writeln( "<error>Moving SafetyNet into mu-plugins failed with exit code $move_code.</error>" );
 			}
 		}

--- a/includes/functions-safety-net.php
+++ b/includes/functions-safety-net.php
@@ -94,9 +94,11 @@ function install_safety_net_files( SSH2 $ssh_connection, ?string &$failure_outpu
 	$ssh_connection->setTimeout( 600 );
 
 	// The archive lands at a mktemp-allocated path rather than a fixed, predictable one that anything else
-	// with write access to /tmp could pre-create between the download and the unpack.
+	// with write access to /tmp could pre-create between the download and the unpack. A missing or failing
+	// mktemp falls back to a per-process name instead of an empty target that would fail every install and
+	// push all clones onto the WP-CLI fallback.
 	$result = $ssh_connection->exec(
-		'ZIP=$(mktemp)'
+		'ZIP=$(mktemp) || ZIP=/tmp/safety-net.$$.zip'
 		. " ; { curl -fsSL '" . SAFETY_NET_ZIP_URL . '\' -o "$ZIP"'
 		. ' && unzip -o -q "$ZIP" -d \'' . $mu_plugins . '/\' ; } 2>&1'
 		. ' ; INSTALL=$?'

--- a/includes/functions-safety-net.php
+++ b/includes/functions-safety-net.php
@@ -241,9 +241,11 @@ function is_safety_net_confirmed_via_http( string $site_url, int $max_attempts =
 		return null;
 	}
 
+	// A 200 whose body is not the JSON report - an HTML page from a cache layer or interceptor - means the
+	// status could not be read, the same unknown the transport and non-200 branches report.
 	$report = json_decode( $body, true );
 	if ( ! is_array( $report ) ) {
-		return false;
+		return null;
 	}
 
 	// Mirrors the plugin's own semantics rather than a narrower allowlist: Safety Net treats every environment

--- a/includes/functions-safety-net.php
+++ b/includes/functions-safety-net.php
@@ -1,0 +1,201 @@
+<?php
+
+use phpseclib3\Net\SSH2;
+use Symfony\Component\Console\Output\OutputInterface;
+
+// region CONSTANTS
+
+// The mu-plugins directory sits at the same absolute path on both Pressable and WordPress.com Atomic servers.
+const SAFETY_NET_MU_PLUGINS_PATH = '/htdocs/wp-content/mu-plugins';
+
+const SAFETY_NET_ZIP_URL = 'https://github.com/a8cteam51/safety-net/releases/latest/download/safety-net.zip';
+
+// endregion
+
+// region API
+
+/**
+ * Returns whether both Safety Net and its loader are present in the mu-plugins directory of a site.
+ *
+ * Both artifacts are checked separately because the loader alone is inert: it only requires Safety Net if the
+ * plugin directory exists next to it, so a site carrying just the loader is not protected.
+ *
+ * @param   SSH2 $ssh_connection The SSH connection to the site.
+ *
+ * @return  boolean|null  True/false if it could be determined, null if the check produced no readable result.
+ */
+function is_safety_net_installed( SSH2 $ssh_connection ): ?bool {
+	$loader = SAFETY_NET_MU_PLUGINS_PATH . '/load-safety-net.php';
+	$plugin = SAFETY_NET_MU_PLUGINS_PATH . '/safety-net';
+
+	$result = $ssh_connection->exec( "test -f '$loader' && test -d '$plugin' && echo 'FILES:1' || echo 'FILES:0'" );
+	$result = is_string( $result ) ? trim( $result ) : '';
+
+	return match ( true ) {
+		str_contains( $result, 'FILES:1' ) => true,
+		str_contains( $result, 'FILES:0' ) => false,
+		default => null,
+	};
+}
+
+/**
+ * Downloads Safety Net straight into the mu-plugins directory of a site.
+ *
+ * Nothing here boots WordPress. A freshly cloned site kills any WordPress-booting command with SIGSYS under
+ * Pressable's SSH seccomp profile - `wp plugin install` included - so the release zip is unpacked in place.
+ *
+ * @param   SSH2 $ssh_connection The SSH connection to the site.
+ *
+ * @return  integer  The exit code of the download and unpack.
+ */
+function install_safety_net_files( SSH2 $ssh_connection ): int {
+	$result = $ssh_connection->exec(
+		"curl -fsSL '" . SAFETY_NET_ZIP_URL . "' -o /tmp/safety-net.zip 2>/dev/null"
+		. ' && unzip -o /tmp/safety-net.zip -d ' . SAFETY_NET_MU_PLUGINS_PATH . '/ >/dev/null 2>&1'
+		. ' ; INSTALL=$?'
+		. ' ; rm -f /tmp/safety-net.zip'
+		. ' ; echo "INSTALL:${INSTALL}"'
+	);
+	$result = is_string( $result ) ? $result : '';
+
+	// A `curl` or `unzip` missing from the image exits 127, which distinguishes a broken environment from a
+	// download that failed because the release could not be reached.
+	return preg_match( '/INSTALL:(\d+)/', $result, $matches ) ? (int) $matches[1] : 1;
+}
+
+/**
+ * Writes the Safety Net loader into the mu-plugins directory of a site, or clears a stray one.
+ *
+ * The loader is only written when Safety Net itself is in place, and removed when it is not: on its own the
+ * loader is inert but still lists as an enabled mu-plugin, which is what makes a failed install look like a
+ * successful one. The decision is made on the server so an unreadable check never deletes a live loader. A
+ * quoted heredoc is used so the scaffold lands byte for byte, without needing a second SFTP connection.
+ *
+ * @param   SSH2 $ssh_connection The SSH connection to the site.
+ *
+ * @return  boolean  False if the loader scaffold could not be read.
+ */
+function write_safety_net_loader( SSH2 $ssh_connection ): bool {
+	$loader_contents = file_get_contents( __DIR__ . '/../scaffold/load-safety-net.php' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+	if ( false === $loader_contents ) {
+		return false;
+	}
+
+	$loader = SAFETY_NET_MU_PLUGINS_PATH . '/load-safety-net.php';
+	$plugin = SAFETY_NET_MU_PLUGINS_PATH . '/safety-net';
+
+	$ssh_connection->exec(
+		"if test -d '$plugin' ; then cat > '$loader' <<'TEAM51_SAFETY_NET_LOADER'\n"
+		. rtrim( $loader_contents ) . "\n"
+		. "TEAM51_SAFETY_NET_LOADER\n"
+		. "else rm -f '$loader' ; fi\n"
+	);
+
+	return true;
+}
+
+/**
+ * Returns whether a site reports that Safety Net has actually run and scrubbed it.
+ *
+ * This is the authoritative check: unlike the file listing, it confirms that Safety Net booted and did its
+ * work. Fails closed on anything unexpected, and never follows a redirect off the site being verified.
+ *
+ * @param   string $site_url The URL of the site to check.
+ *
+ * @return  boolean
+ */
+function is_safety_net_confirmed_via_http( string $site_url ): bool {
+	if ( ! preg_match( '#^https?://#i', $site_url ) ) {
+		$site_url = "https://$site_url";
+	}
+
+	// A clone whose database still points at the production URL answers with a redirect, so following one here
+	// would verify the production site instead of the clone.
+	$context = stream_context_create(
+		array(
+			'http' => array(
+				'header'          => 'Cache-Control: no-cache',
+				'method'          => 'GET',
+				'timeout'         => 10,
+				'follow_location' => 0,
+				'ignore_errors'   => true,
+			),
+		)
+	);
+
+	$body = @file_get_contents( rtrim( $site_url, '/' ) . '/wp-json/safety-net/v1/status?_=' . time(), false, $context ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+	if ( ! is_string( $body ) ) {
+		return false;
+	}
+
+	$response_headers = function_exists( 'http_get_last_response_headers' )
+		? ( http_get_last_response_headers() ?? array() )
+		: ( $http_response_header ?? array() );
+	if ( 200 !== ( parse_http_headers( $response_headers )['http_code'] ?? 0 ) ) {
+		return false;
+	}
+
+	$report = json_decode( $body, true );
+	if ( ! is_array( $report ) ) {
+		return false;
+	}
+
+	// Allowlist the environment rather than rejecting the literal `production`, so an empty or unrecognized
+	// value fails closed too.
+	return in_array( $report['environment'] ?? '', array( 'staging', 'development', 'local' ), true )
+		&& ! empty( $report['options_scrubbed'] )
+		&& ! empty( $report['data_deleted'] );
+}
+
+/**
+ * Installs Safety Net on a site if it is not already installed, then verifies that the files are in place.
+ *
+ * @param   SSH2|null       $ssh_connection The SSH connection to the site, if one could be established.
+ * @param   OutputInterface $output         The output instance.
+ * @param   callable|null   $wp_cli_runner  Runs a WP-CLI command on the site and returns its exit code. Used
+ *                                          as a fallback if the server has no `curl` or `unzip`.
+ *
+ * @return  boolean  Whether both Safety Net and its loader are in place afterwards.
+ */
+function maybe_install_safety_net( ?SSH2 $ssh_connection, OutputInterface $output, ?callable $wp_cli_runner = null ): bool {
+	if ( is_null( $ssh_connection ) ) {
+		$output->writeln( '<error>Failed to connect to the site via SSH. Cannot install SafetyNet!</error>' );
+		return false;
+	}
+
+	$installed = is_safety_net_installed( $ssh_connection );
+	if ( true === $installed ) {
+		$output->writeln( '<comment>SafetyNet is already installed as a mu-plugin. Skipping installation...</comment>' );
+		return true;
+	}
+
+	if ( is_null( $installed ) ) {
+		$output->writeln( '<comment>Could not read the mu-plugins directory. Attempting the SafetyNet installation anyway...</comment>' );
+	}
+
+	$exit_code = install_safety_net_files( $ssh_connection );
+	if ( 0 !== $exit_code ) {
+		$output->writeln( "<comment>Downloading SafetyNet over SSH failed with exit code $exit_code.</comment>" );
+
+		if ( ! is_null( $wp_cli_runner ) ) {
+			$output->writeln( '<comment>Falling back to installing SafetyNet through WP-CLI...</comment>' );
+
+			$wp_cli_runner( 'plugin install ' . SAFETY_NET_ZIP_URL );
+			$ssh_connection->exec( 'mv -f /htdocs/wp-content/plugins/safety-net ' . SAFETY_NET_MU_PLUGINS_PATH . '/safety-net' );
+		}
+	}
+
+	if ( ! write_safety_net_loader( $ssh_connection ) ) {
+		$output->writeln( '<error>Could not read the SafetyNet loader scaffold!</error>' );
+	}
+
+	if ( true !== is_safety_net_installed( $ssh_connection ) ) {
+		$output->writeln( '<error>Failed to install SafetyNet!</error>' );
+		return false;
+	}
+
+	$output->writeln( '<fg=green;options=bold>SafetyNet installed as a mu-plugin.</>' );
+	return true;
+}
+
+// endregion

--- a/includes/functions-safety-net.php
+++ b/includes/functions-safety-net.php
@@ -246,9 +246,16 @@ function is_safety_net_confirmed_via_http( string $site_url, int $max_attempts =
 		return false;
 	}
 
-	// Allowlist the environment rather than rejecting the literal `production`, so an empty or unrecognized
-	// value fails closed too.
-	return in_array( $report['environment'] ?? '', array( 'staging', 'development', 'local' ), true )
+	// Mirrors the plugin's own semantics rather than a narrower allowlist: Safety Net treats every environment
+	// except `production` as non-production - including `sandbox`/`dev`/`develop`, which it reads from the
+	// server environment and which core's allowlist would not pass - and it bails on production before the
+	// status route is even registered, so the route answering already implies non-production. An empty or
+	// missing value still fails closed.
+	$environment = (string) ( $report['environment'] ?? '' );
+
+	return ! empty( $report['active'] )
+		&& '' !== $environment
+		&& 'production' !== $environment
 		&& ! empty( $report['options_scrubbed'] )
 		&& ! empty( $report['data_deleted'] );
 }

--- a/includes/functions-safety-net.php
+++ b/includes/functions-safety-net.php
@@ -23,15 +23,25 @@ const SAFETY_NET_ZIP_URL = 'https://github.com/a8cteam51/safety-net/releases/lat
  * @return  string
  */
 function get_ssh_site_root_path( SSH2 $ssh_connection ): string {
-	static $roots = array();
+	// A WeakMap rather than an id-keyed array: PHP reuses object ids, so a later connection could otherwise
+	// inherit the root probed for a different site.
+	static $roots = null;
 
-	$key = spl_object_id( $ssh_connection );
-	if ( ! isset( $roots[ $key ] ) ) {
-		$result        = $ssh_connection->exec( "test -d htdocs/wp-content && echo 'ROOT:REL' || echo 'ROOT:ABS'" );
-		$roots[ $key ] = str_contains( is_string( $result ) ? $result : '', 'ROOT:REL' ) ? 'htdocs' : '/htdocs';
+	$roots ??= new WeakMap();
+	if ( ! isset( $roots[ $ssh_connection ] ) ) {
+		$result = $ssh_connection->exec( "test -d htdocs/wp-content && echo 'ROOT:REL' || echo 'ROOT:ABS'" );
+		$result = is_string( $result ) ? $result : '';
+
+		// An unreadable probe is not cached, and falls back to the common layout rather than pinning the rare
+		// one for the rest of the connection's life.
+		if ( ! str_contains( $result, 'ROOT:' ) ) {
+			return 'htdocs';
+		}
+
+		$roots[ $ssh_connection ] = str_contains( $result, 'ROOT:REL' ) ? 'htdocs' : '/htdocs';
 	}
 
-	return $roots[ $key ];
+	return $roots[ $ssh_connection ];
 }
 
 /**
@@ -66,21 +76,23 @@ function is_safety_net_installed( SSH2 $ssh_connection ): ?bool {
  * Nothing here boots WordPress. A freshly cloned site kills any WordPress-booting command with SIGSYS under
  * Pressable's SSH seccomp profile - `wp plugin install` included - so the release zip is unpacked in place.
  *
- * @param   SSH2 $ssh_connection The SSH connection to the site.
+ * @param   SSH2        $ssh_connection The SSH connection to the site.
+ * @param   string|null $failure_output Receives whatever `curl`/`unzip` printed when the install failed.
  *
  * @return  integer  The exit code of the download and unpack.
  */
-function install_safety_net_files( SSH2 $ssh_connection ): int {
+function install_safety_net_files( SSH2 $ssh_connection, ?string &$failure_output = null ): int {
 	$mu_plugins = get_ssh_site_root_path( $ssh_connection ) . '/wp-content/mu-plugins';
 
-	// The command is silent until the trailing echo, and the connection's default read timeout is 10 seconds -
-	// a download slower than that would truncate the output and lose the INSTALL: marker. The generous but
-	// finite budget is restored afterwards so later commands on this connection keep a ceiling.
+	// The command produces no output before the trailing echo unless something fails, and the connection's
+	// default read timeout is 10 seconds - a download slower than that would truncate the output and lose the
+	// INSTALL: marker. The generous but finite budget is restored afterwards so later commands on this
+	// connection keep a ceiling.
 	$ssh_connection->setTimeout( 600 );
 
 	$result = $ssh_connection->exec(
-		"curl -fsSL '" . SAFETY_NET_ZIP_URL . "' -o /tmp/safety-net.zip 2>/dev/null"
-		. " && unzip -o /tmp/safety-net.zip -d $mu_plugins/ >/dev/null 2>&1"
+		"{ curl -fsSL '" . SAFETY_NET_ZIP_URL . "' -o /tmp/safety-net.zip"
+		. " && unzip -o -q /tmp/safety-net.zip -d '$mu_plugins/' ; } 2>&1"
 		. ' ; INSTALL=$?'
 		. ' ; rm -f /tmp/safety-net.zip'
 		. ' ; echo "INSTALL:${INSTALL}"'
@@ -93,7 +105,13 @@ function install_safety_net_files( SSH2 $ssh_connection ): int {
 	// The exit code is reported verbatim by the caller, so a missing `curl`/`unzip` (127) stays
 	// distinguishable from a download that failed. -1 means the marker never came back, which is a different
 	// problem again: the command did not run to completion.
-	return preg_match( '/INSTALL:(\d+)/', $result, $matches ) ? (int) $matches[1] : -1;
+	$exit_code = preg_match( '/INSTALL:(\d+)/', $result, $matches ) ? (int) $matches[1] : -1;
+
+	if ( 0 !== $exit_code ) {
+		$failure_output = trim( (string) preg_replace( '/INSTALL:\d+\s*$/', '', $result ) );
+	}
+
+	return $exit_code;
 }
 
 /**
@@ -161,12 +179,14 @@ function is_safety_net_confirmed_via_http( string $site_url ): ?bool {
 		)
 	);
 
-	$body             = false;
-	$response_headers = array();
+	$body        = false;
+	$status_code = 0;
 
+	// Retried on any non-200 as well as on transport failure: a freshly created hostname may not resolve on
+	// the first try, and a clone still warming up answers 502 - both usually clear within seconds.
 	for ( $attempt = 1; $attempt <= 2; $attempt++ ) {
 		if ( 1 < $attempt ) {
-			sleep( 5 ); // A freshly created hostname may not resolve on the first try.
+			sleep( 5 );
 		}
 
 		$body = @file_get_contents( rtrim( $site_url, '/' ) . '/wp-json/safety-net/v1/status?_=' . time(), false, $context ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
@@ -174,8 +194,9 @@ function is_safety_net_confirmed_via_http( string $site_url ): ?bool {
 		$response_headers = function_exists( 'http_get_last_response_headers' )
 			? ( http_get_last_response_headers() ?? array() )
 			: ( $http_response_header ?? array() );
+		$status_code      = parse_http_headers( $response_headers )['http_code'] ?? 0;
 
-		if ( is_string( $body ) ) {
+		if ( is_string( $body ) && 200 === $status_code ) {
 			break;
 		}
 	}
@@ -187,7 +208,7 @@ function is_safety_net_confirmed_via_http( string $site_url ): ?bool {
 	// A non-200 answer - a 403 from a private staging site, a 502 during warm-up - says the status could not
 	// be read, not that the site is unprotected, so it reports unknown just like an unreachable site does.
 	// Only a readable 200 report gets to say either way.
-	if ( 200 !== ( parse_http_headers( $response_headers )['http_code'] ?? 0 ) ) {
+	if ( 200 !== $status_code ) {
 		return null;
 	}
 
@@ -230,10 +251,19 @@ function maybe_install_safety_net( ?SSH2 $ssh_connection, OutputInterface $outpu
 		$output->writeln( '<comment>Could not read the mu-plugins directory. Attempting the SafetyNet installation anyway...</comment>' );
 	}
 
-	$exit_code = install_safety_net_files( $ssh_connection );
+	$failure_output = null;
+
+	$exit_code = install_safety_net_files( $ssh_connection, $failure_output );
 	if ( 0 !== $exit_code ) {
 		$output->writeln( "<comment>Downloading SafetyNet over SSH failed with exit code $exit_code.</comment>" );
+		if ( '' !== (string) $failure_output ) {
+			$output->writeln( '<comment>' . \Symfony\Component\Console\Formatter\OutputFormatter::escape( $failure_output ) . '</comment>' );
+		}
 		$output->writeln( '<comment>Falling back to installing SafetyNet through WP-CLI...</comment>' );
+
+		// Downloading the release and booting WordPress regularly outlasts the 10-second read ceiling the
+		// download step restored, so it is lifted for the fallback and put back after.
+		$ssh_connection->setTimeout( 600 );
 
 		// Run on the connection directly: the exit codes below are the remote ones, so each step reports its
 		// own failure. getExitStatus() returns false when the server sent no exit-status message, which is
@@ -245,11 +275,13 @@ function maybe_install_safety_net( ?SSH2 $ssh_connection, OutputInterface $outpu
 		}
 
 		$site_root = get_ssh_site_root_path( $ssh_connection );
-		$ssh_connection->exec( "mv -f $site_root/wp-content/plugins/safety-net $site_root/wp-content/mu-plugins/safety-net" );
+		$ssh_connection->exec( "mv -f '$site_root/wp-content/plugins/safety-net' '$site_root/wp-content/mu-plugins/safety-net'" );
 		$move_code = $ssh_connection->getExitStatus();
 		if ( false !== $move_code && 0 !== $move_code ) {
 			$output->writeln( "<error>Moving SafetyNet into mu-plugins failed with exit code $move_code.</error>" );
 		}
+
+		$ssh_connection->setTimeout( 10 );
 	}
 
 	if ( ! write_safety_net_loader( $ssh_connection ) ) {

--- a/includes/functions-safety-net.php
+++ b/includes/functions-safety-net.php
@@ -7,9 +7,6 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 const SAFETY_NET_ZIP_URL = 'https://github.com/a8cteam51/safety-net/releases/latest/download/safety-net.zip';
 
-// The read ceiling restored after long-running commands; mirrors the default the connection is built with.
-const SAFETY_NET_SSH_DEFAULT_TIMEOUT = 10;
-
 // endregion
 
 // region API
@@ -94,19 +91,25 @@ function install_safety_net_files( SSH2 $ssh_connection, ?string &$failure_outpu
 	$ssh_connection->setTimeout( 600 );
 
 	// The archive lands at a mktemp-allocated path rather than a fixed, predictable one that anything else
-	// with write access to /tmp could pre-create between the download and the unpack. A missing or failing
-	// mktemp falls back to a per-process name instead of an empty target that would fail every install and
-	// push all clones onto the WP-CLI fallback.
+	// with write access to /tmp could pre-create between the download and the unpack. If mktemp is missing the
+	// fallback name is created under `set -C`, so a pre-existing file aborts the allocation instead of being
+	// written through; an unusable target reports 126 rather than silently failing the download.
+	//
+	// The stale plugin directory is cleared only after the archive is in hand, and before the unpack, because
+	// `unzip -o` merges into whatever is already there and would leave files from an older release behind.
 	$result = $ssh_connection->exec(
-		'ZIP=$(mktemp) || ZIP=/tmp/safety-net.$$.zip'
-		. " ; { curl -fsSL '" . SAFETY_NET_ZIP_URL . '\' -o "$ZIP"'
+		'ZIP=$(mktemp 2>/dev/null) || { ZIP=/tmp/safety-net.$$.zip ; ( set -C ; : > "$ZIP" ) 2>/dev/null || ZIP="" ; }'
+		. ' ; if [ -z "$ZIP" ] ; then INSTALL=126 ; else'
+		. " { curl -fsSL '" . SAFETY_NET_ZIP_URL . '\' -o "$ZIP"'
+		. " && rm -rf '$mu_plugins/safety-net'"
 		. ' && unzip -o -q "$ZIP" -d \'' . $mu_plugins . '/\' ; } 2>&1'
 		. ' ; INSTALL=$?'
 		. ' ; rm -f "$ZIP"'
+		. ' ; fi'
 		. ' ; echo "INSTALL:${INSTALL}"'
 	);
 
-	$ssh_connection->setTimeout( SAFETY_NET_SSH_DEFAULT_TIMEOUT );
+	$ssh_connection->setTimeout( Abstract_Connection_Helper::SSH_TIMEOUT );
 
 	$result = is_string( $result ) ? $result : '';
 
@@ -285,14 +288,21 @@ function maybe_install_safety_net( ?SSH2 $ssh_connection, OutputInterface $outpu
 			$output->writeln( "<error>Installing SafetyNet through WP-CLI failed with exit code $install_code.</error>" );
 		}
 
-		$site_root = get_ssh_site_root_path( $ssh_connection );
-		$ssh_connection->exec( "mv -f '$site_root/wp-content/plugins/safety-net' '$site_root/wp-content/mu-plugins/safety-net'" );
+		// `mv` moves the source *into* an existing destination directory rather than replacing it, which would
+		// nest the plugin one level too deep - and exit 0 while doing so. The destination is cleared first,
+		// but only once the source is known to exist, so a failed install never destroys what is already
+		// there without a replacement.
+		$site_root   = get_ssh_site_root_path( $ssh_connection );
+		$plugin_src  = "$site_root/wp-content/plugins/safety-net";
+		$plugin_dest = "$site_root/wp-content/mu-plugins/safety-net";
+
+		$ssh_connection->exec( "test -d '$plugin_src' && rm -rf '$plugin_dest' && mv -f '$plugin_src' '$plugin_dest'" );
 		$move_code = $ssh_connection->getExitStatus();
 		if ( false !== $move_code && 0 !== $move_code ) {
 			$output->writeln( "<error>Moving SafetyNet into mu-plugins failed with exit code $move_code.</error>" );
 		}
 
-		$ssh_connection->setTimeout( SAFETY_NET_SSH_DEFAULT_TIMEOUT );
+		$ssh_connection->setTimeout( Abstract_Connection_Helper::SSH_TIMEOUT );
 	}
 
 	if ( ! write_safety_net_loader( $ssh_connection ) ) {

--- a/includes/functions-safety-net.php
+++ b/includes/functions-safety-net.php
@@ -203,7 +203,10 @@ function is_safety_net_confirmed_via_http( string $site_url, int $max_attempts =
 			sleep( 5 );
 		}
 
-		$body = @file_get_contents( rtrim( $site_url, '/' ) . '/wp-json/safety-net/v1/status?_=' . time(), false, $context ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		// The `?rest_route=` form routes regardless of the permalink structure; the pretty `/wp-json/` prefix
+		// only exists when permalinks are enabled, and a clone of a plain-permalink site would 404 on it and
+		// fail verification on every run.
+		$body = @file_get_contents( rtrim( $site_url, '/' ) . '/?rest_route=/safety-net/v1/status&_=' . time(), false, $context ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 
 		$response_headers = function_exists( 'http_get_last_response_headers' )
 			? ( http_get_last_response_headers() ?? array() )
@@ -269,7 +272,12 @@ function maybe_install_safety_net( ?SSH2 $ssh_connection, OutputInterface $outpu
 
 	$exit_code = install_safety_net_files( $ssh_connection, $failure_output );
 	if ( 0 !== $exit_code ) {
-		$output->writeln( "<comment>Downloading SafetyNet over SSH failed with exit code $exit_code.</comment>" );
+		// -1 is the no-marker sentinel, not an exit status: the command did not run to completion.
+		$output->writeln(
+			-1 === $exit_code
+				? '<comment>Downloading SafetyNet over SSH produced no readable result.</comment>'
+				: "<comment>Downloading SafetyNet over SSH failed with exit code $exit_code.</comment>"
+		);
 		if ( '' !== (string) $failure_output ) {
 			$output->writeln( '<comment>' . \Symfony\Component\Console\Formatter\OutputFormatter::escape( $failure_output ) . '</comment>' );
 		}

--- a/includes/functions-safety-net.php
+++ b/includes/functions-safety-net.php
@@ -179,12 +179,16 @@ function write_safety_net_loader( SSH2 $ssh_connection ): bool {
  * hostname may not resolve yet - so callers can say they could not verify instead of asserting the site holds
  * unscrubbed data. A site that does answer fails closed on anything unexpected.
  *
- * @param   string  $site_url     The URL of the site to check.
- * @param   integer $max_attempts The maximum number of probes, 5 seconds apart.
+ * @param   string               $site_url     The URL of the site to check.
+ * @param   OutputInterface|null $output       The output instance, for announcing the poll.
+ * @param   integer              $max_attempts The maximum number of probes, 5 seconds apart.
  *
  * @return  boolean|null  Null if the site could not be reached or did not answer with a readable report.
  */
-function is_safety_net_confirmed_via_http( string $site_url, int $max_attempts = 12 ): ?bool {
+function is_safety_net_confirmed_via_http( string $site_url, ?OutputInterface $output = null, int $max_attempts = 12 ): ?bool {
+	// Announced because the poll is otherwise silent for up to a few minutes at the very end of a run, which
+	// reads as a hang.
+	$output?->writeln( "<comment>Checking the Safety Net status endpoint on $site_url (up to $max_attempts probes, 5 seconds apart).</comment>" );
 	if ( ! preg_match( '#^https?://#i', $site_url ) ) {
 		$site_url = "https://$site_url";
 	}
@@ -328,7 +332,7 @@ function maybe_install_safety_net( ?SSH2 $ssh_connection, OutputInterface $outpu
 		$plugin_src  = "$site_root/wp-content/plugins/safety-net";
 		$plugin_dest = "$site_root/wp-content/mu-plugins/safety-net";
 
-		$move_output = $ssh_connection->exec( "if test -d '$plugin_src' ; then rm -rf '$plugin_dest' && mv -f '$plugin_src' '$plugin_dest' ; else echo 'MOVE:skipped' ; fi" );
+		$move_output = $ssh_connection->exec( "if test -d '$plugin_src' ; then test -d '$site_root/wp-content' && mkdir -p '$site_root/wp-content/mu-plugins' && rm -rf '$plugin_dest' && mv -f '$plugin_src' '$plugin_dest' ; else echo 'MOVE:skipped' ; fi" );
 		$move_code   = $ssh_connection->getExitStatus();
 		if ( is_string( $move_output ) && str_contains( $move_output, 'MOVE:skipped' ) ) {
 			$output->writeln( '<comment>Nothing to move into mu-plugins: WP-CLI did not produce the plugin directory.</comment>' );

--- a/includes/functions-safety-net.php
+++ b/includes/functions-safety-net.php
@@ -63,9 +63,10 @@ function install_safety_net_files( SSH2 $ssh_connection ): int {
 	);
 	$result = is_string( $result ) ? $result : '';
 
-	// A `curl` or `unzip` missing from the image exits 127, which distinguishes a broken environment from a
-	// download that failed because the release could not be reached.
-	return preg_match( '/INSTALL:(\d+)/', $result, $matches ) ? (int) $matches[1] : 1;
+	// The exit code is reported verbatim by the caller, so a missing `curl`/`unzip` (127) stays
+	// distinguishable from a download that failed. -1 means the marker never came back, which is a different
+	// problem again: the command did not run to completion.
+	return preg_match( '/INSTALL:(\d+)/', $result, $matches ) ? (int) $matches[1] : -1;
 }
 
 /**
@@ -103,13 +104,17 @@ function write_safety_net_loader( SSH2 $ssh_connection ): bool {
  * Returns whether a site reports that Safety Net has actually run and scrubbed it.
  *
  * This is the authoritative check: unlike the file listing, it confirms that Safety Net booted and did its
- * work. Fails closed on anything unexpected, and never follows a redirect off the site being verified.
+ * work. Never follows a redirect off the site being verified.
+ *
+ * A site that could not be reached at all is reported as unknown rather than unprotected - a brand-new clone
+ * hostname may not resolve yet - so callers can say they could not verify instead of asserting the site holds
+ * unscrubbed data. A site that does answer fails closed on anything unexpected.
  *
  * @param   string $site_url The URL of the site to check.
  *
- * @return  boolean
+ * @return  boolean|null  Null if the site could not be reached.
  */
-function is_safety_net_confirmed_via_http( string $site_url ): bool {
+function is_safety_net_confirmed_via_http( string $site_url ): ?bool {
 	if ( ! preg_match( '#^https?://#i', $site_url ) ) {
 		$site_url = "https://$site_url";
 	}
@@ -128,14 +133,29 @@ function is_safety_net_confirmed_via_http( string $site_url ): bool {
 		)
 	);
 
-	$body = @file_get_contents( rtrim( $site_url, '/' ) . '/wp-json/safety-net/v1/status?_=' . time(), false, $context ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
-	if ( ! is_string( $body ) ) {
-		return false;
+	$body             = false;
+	$response_headers = array();
+
+	for ( $attempt = 1; $attempt <= 2; $attempt++ ) {
+		if ( 1 < $attempt ) {
+			sleep( 5 ); // A freshly created hostname may not resolve on the first try.
+		}
+
+		$body = @file_get_contents( rtrim( $site_url, '/' ) . '/wp-json/safety-net/v1/status?_=' . time(), false, $context ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+
+		$response_headers = function_exists( 'http_get_last_response_headers' )
+			? ( http_get_last_response_headers() ?? array() )
+			: ( $http_response_header ?? array() );
+
+		if ( is_string( $body ) ) {
+			break;
+		}
 	}
 
-	$response_headers = function_exists( 'http_get_last_response_headers' )
-		? ( http_get_last_response_headers() ?? array() )
-		: ( $http_response_header ?? array() );
+	if ( ! is_string( $body ) ) {
+		return null;
+	}
+
 	if ( 200 !== ( parse_http_headers( $response_headers )['http_code'] ?? 0 ) ) {
 		return false;
 	}
@@ -185,8 +205,17 @@ function maybe_install_safety_net( ?SSH2 $ssh_connection, OutputInterface $outpu
 		if ( ! is_null( $wp_cli_runner ) ) {
 			$output->writeln( '<comment>Falling back to installing SafetyNet through WP-CLI...</comment>' );
 
-			$wp_cli_runner( 'plugin install ' . SAFETY_NET_ZIP_URL );
+			// Both steps are reported separately so a failure here says whether the download or the move broke.
+			$install_code = $wp_cli_runner( 'plugin install ' . SAFETY_NET_ZIP_URL );
+			if ( 0 !== $install_code ) {
+				$output->writeln( "<error>Installing SafetyNet through WP-CLI failed with exit code $install_code.</error>" );
+			}
+
 			$ssh_connection->exec( 'mv -f /htdocs/wp-content/plugins/safety-net ' . SAFETY_NET_MU_PLUGINS_PATH . '/safety-net' );
+			$move_code = $ssh_connection->getExitStatus();
+			if ( 0 !== $move_code ) {
+				$output->writeln( "<error>Moving SafetyNet into mu-plugins failed with exit code $move_code.</error>" );
+			}
 		}
 	}
 
@@ -194,7 +223,12 @@ function maybe_install_safety_net( ?SSH2 $ssh_connection, OutputInterface $outpu
 		$output->writeln( '<error>Could not read the SafetyNet loader scaffold!</error>' );
 	}
 
-	if ( true !== is_safety_net_installed( $ssh_connection ) ) {
+	$installed = is_safety_net_installed( $ssh_connection );
+	if ( is_null( $installed ) ) {
+		$output->writeln( '<error>Could not verify the SafetyNet installation.</error>' );
+		return false;
+	}
+	if ( false === $installed ) {
 		$output->writeln( '<error>Failed to install SafetyNet!</error>' );
 		return false;
 	}

--- a/includes/functions-safety-net.php
+++ b/includes/functions-safety-net.php
@@ -7,6 +7,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 const SAFETY_NET_ZIP_URL = 'https://github.com/a8cteam51/safety-net/releases/latest/download/safety-net.zip';
 
+// The read ceiling restored after long-running commands; mirrors the default the connection is built with.
+const SAFETY_NET_SSH_DEFAULT_TIMEOUT = 10;
+
 // endregion
 
 // region API
@@ -90,15 +93,18 @@ function install_safety_net_files( SSH2 $ssh_connection, ?string &$failure_outpu
 	// connection keep a ceiling.
 	$ssh_connection->setTimeout( 600 );
 
+	// The archive lands at a mktemp-allocated path rather than a fixed, predictable one that anything else
+	// with write access to /tmp could pre-create between the download and the unpack.
 	$result = $ssh_connection->exec(
-		"{ curl -fsSL '" . SAFETY_NET_ZIP_URL . "' -o /tmp/safety-net.zip"
-		. " && unzip -o -q /tmp/safety-net.zip -d '$mu_plugins/' ; } 2>&1"
+		'ZIP=$(mktemp)'
+		. " ; { curl -fsSL '" . SAFETY_NET_ZIP_URL . '\' -o "$ZIP"'
+		. ' && unzip -o -q "$ZIP" -d \'' . $mu_plugins . '/\' ; } 2>&1'
 		. ' ; INSTALL=$?'
-		. ' ; rm -f /tmp/safety-net.zip'
+		. ' ; rm -f "$ZIP"'
 		. ' ; echo "INSTALL:${INSTALL}"'
 	);
 
-	$ssh_connection->setTimeout( 10 );
+	$ssh_connection->setTimeout( SAFETY_NET_SSH_DEFAULT_TIMEOUT );
 
 	$result = is_string( $result ) ? $result : '';
 
@@ -156,11 +162,12 @@ function write_safety_net_loader( SSH2 $ssh_connection ): bool {
  * hostname may not resolve yet - so callers can say they could not verify instead of asserting the site holds
  * unscrubbed data. A site that does answer fails closed on anything unexpected.
  *
- * @param   string $site_url The URL of the site to check.
+ * @param   string  $site_url     The URL of the site to check.
+ * @param   integer $max_attempts The maximum number of probes, 5 seconds apart.
  *
  * @return  boolean|null  Null if the site could not be reached or did not answer with a readable report.
  */
-function is_safety_net_confirmed_via_http( string $site_url ): ?bool {
+function is_safety_net_confirmed_via_http( string $site_url, int $max_attempts = 12 ): ?bool {
 	if ( ! preg_match( '#^https?://#i', $site_url ) ) {
 		$site_url = "https://$site_url";
 	}
@@ -183,8 +190,10 @@ function is_safety_net_confirmed_via_http( string $site_url ): ?bool {
 	$status_code = 0;
 
 	// Retried on any non-200 as well as on transport failure: a freshly created hostname may not resolve on
-	// the first try, and a clone still warming up answers 502 - both usually clear within seconds.
-	for ( $attempt = 1; $attempt <= 2; $attempt++ ) {
+	// the first try, and a clone still warming up answers 502 - both usually clear within seconds. This check
+	// is the sole authority on the clone's verdict, so it gets patience comparable to the other waits on the
+	// path rather than failing a 20-minute provisioning run on one hiccup.
+	for ( $attempt = 1; $attempt <= $max_attempts; $attempt++ ) {
 		if ( 1 < $attempt ) {
 			sleep( 5 );
 		}
@@ -281,7 +290,7 @@ function maybe_install_safety_net( ?SSH2 $ssh_connection, OutputInterface $outpu
 			$output->writeln( "<error>Moving SafetyNet into mu-plugins failed with exit code $move_code.</error>" );
 		}
 
-		$ssh_connection->setTimeout( 10 );
+		$ssh_connection->setTimeout( SAFETY_NET_SSH_DEFAULT_TIMEOUT );
 	}
 
 	if ( ! write_safety_net_loader( $ssh_connection ) ) {

--- a/includes/functions-safety-net.php
+++ b/includes/functions-safety-net.php
@@ -8,6 +8,10 @@ use Symfony\Component\Console\Output\OutputInterface;
 // The mu-plugins directory sits at the same absolute path on both Pressable and WordPress.com Atomic servers.
 const SAFETY_NET_MU_PLUGINS_PATH = '/htdocs/wp-content/mu-plugins';
 
+// The file the loader requires. Testing for it rather than the directory keeps a half-unpacked archive from
+// reading as a working install.
+const SAFETY_NET_PLUGIN_ENTRY_FILE = SAFETY_NET_MU_PLUGINS_PATH . '/safety-net/safety-net.php';
+
 const SAFETY_NET_ZIP_URL = 'https://github.com/a8cteam51/safety-net/releases/latest/download/safety-net.zip';
 
 // endregion
@@ -18,7 +22,8 @@ const SAFETY_NET_ZIP_URL = 'https://github.com/a8cteam51/safety-net/releases/lat
  * Returns whether both Safety Net and its loader are present in the mu-plugins directory of a site.
  *
  * Both artifacts are checked separately because the loader alone is inert: it only requires Safety Net if the
- * plugin directory exists next to it, so a site carrying just the loader is not protected.
+ * plugin is there next to it, so a site carrying just the loader is not protected. The plugin is identified by
+ * the exact entry file the loader requires, so a half-unpacked directory does not read as a working install.
  *
  * @param   SSH2 $ssh_connection The SSH connection to the site.
  *
@@ -26,9 +31,9 @@ const SAFETY_NET_ZIP_URL = 'https://github.com/a8cteam51/safety-net/releases/lat
  */
 function is_safety_net_installed( SSH2 $ssh_connection ): ?bool {
 	$loader = SAFETY_NET_MU_PLUGINS_PATH . '/load-safety-net.php';
-	$plugin = SAFETY_NET_MU_PLUGINS_PATH . '/safety-net';
+	$plugin = SAFETY_NET_PLUGIN_ENTRY_FILE;
 
-	$result = $ssh_connection->exec( "test -f '$loader' && test -d '$plugin' && echo 'FILES:1' || echo 'FILES:0'" );
+	$result = $ssh_connection->exec( "test -f '$loader' && test -f '$plugin' && echo 'FILES:1' || echo 'FILES:0'" );
 	$result = is_string( $result ) ? trim( $result ) : '';
 
 	return match ( true ) {
@@ -82,10 +87,10 @@ function write_safety_net_loader( SSH2 $ssh_connection ): bool {
 	}
 
 	$loader = SAFETY_NET_MU_PLUGINS_PATH . '/load-safety-net.php';
-	$plugin = SAFETY_NET_MU_PLUGINS_PATH . '/safety-net';
+	$plugin = SAFETY_NET_PLUGIN_ENTRY_FILE;
 
 	$ssh_connection->exec(
-		"if test -d '$plugin' ; then cat > '$loader' <<'TEAM51_SAFETY_NET_LOADER'\n"
+		"if test -f '$plugin' ; then cat > '$loader' <<'TEAM51_SAFETY_NET_LOADER'\n"
 		. rtrim( $loader_contents ) . "\n"
 		. "TEAM51_SAFETY_NET_LOADER\n"
 		. "else rm -f '$loader' ; fi\n"

--- a/includes/functions-safety-net.php
+++ b/includes/functions-safety-net.php
@@ -5,18 +5,34 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 // region CONSTANTS
 
-// The mu-plugins directory sits at the same absolute path on both Pressable and WordPress.com Atomic servers.
-const SAFETY_NET_MU_PLUGINS_PATH = '/htdocs/wp-content/mu-plugins';
-
-// The file the loader requires. Testing for it rather than the directory keeps a half-unpacked archive from
-// reading as a working install.
-const SAFETY_NET_PLUGIN_ENTRY_FILE = SAFETY_NET_MU_PLUGINS_PATH . '/safety-net/safety-net.php';
-
 const SAFETY_NET_ZIP_URL = 'https://github.com/a8cteam51/safety-net/releases/latest/download/safety-net.zip';
 
 // endregion
 
 // region API
+
+/**
+ * Returns the site root directory as the SSH shell sees it.
+ *
+ * Every exec starts a fresh shell at the login directory, and both layouts exist in the wild: most servers
+ * expose the home-relative `htdocs` the previous install commands used, others only the absolute `/htdocs`.
+ * Probed once per connection so every command in an install run agrees on the prefix.
+ *
+ * @param   SSH2 $ssh_connection The SSH connection to the site.
+ *
+ * @return  string
+ */
+function get_ssh_site_root_path( SSH2 $ssh_connection ): string {
+	static $roots = array();
+
+	$key = spl_object_id( $ssh_connection );
+	if ( ! isset( $roots[ $key ] ) ) {
+		$result        = $ssh_connection->exec( "test -d htdocs/wp-content && echo 'ROOT:REL' || echo 'ROOT:ABS'" );
+		$roots[ $key ] = str_contains( is_string( $result ) ? $result : '', 'ROOT:REL' ) ? 'htdocs' : '/htdocs';
+	}
+
+	return $roots[ $key ];
+}
 
 /**
  * Returns whether both Safety Net and its loader are present in the mu-plugins directory of a site.
@@ -30,8 +46,9 @@ const SAFETY_NET_ZIP_URL = 'https://github.com/a8cteam51/safety-net/releases/lat
  * @return  boolean|null  True/false if it could be determined, null if the check produced no readable result.
  */
 function is_safety_net_installed( SSH2 $ssh_connection ): ?bool {
-	$loader = SAFETY_NET_MU_PLUGINS_PATH . '/load-safety-net.php';
-	$plugin = SAFETY_NET_PLUGIN_ENTRY_FILE;
+	$mu_plugins = get_ssh_site_root_path( $ssh_connection ) . '/wp-content/mu-plugins';
+	$loader     = "$mu_plugins/load-safety-net.php";
+	$plugin     = "$mu_plugins/safety-net/safety-net.php";
 
 	$result = $ssh_connection->exec( "test -f '$loader' && test -f '$plugin' && echo 'FILES:1' || echo 'FILES:0'" );
 	$result = is_string( $result ) ? trim( $result ) : '';
@@ -54,17 +71,23 @@ function is_safety_net_installed( SSH2 $ssh_connection ): ?bool {
  * @return  integer  The exit code of the download and unpack.
  */
 function install_safety_net_files( SSH2 $ssh_connection ): int {
+	$mu_plugins = get_ssh_site_root_path( $ssh_connection ) . '/wp-content/mu-plugins';
+
 	// The command is silent until the trailing echo, and the connection's default read timeout is 10 seconds -
-	// a download slower than that would truncate the output and lose the INSTALL: marker.
-	$ssh_connection->setTimeout( 0 );
+	// a download slower than that would truncate the output and lose the INSTALL: marker. The generous but
+	// finite budget is restored afterwards so later commands on this connection keep a ceiling.
+	$ssh_connection->setTimeout( 600 );
 
 	$result = $ssh_connection->exec(
 		"curl -fsSL '" . SAFETY_NET_ZIP_URL . "' -o /tmp/safety-net.zip 2>/dev/null"
-		. ' && unzip -o /tmp/safety-net.zip -d ' . SAFETY_NET_MU_PLUGINS_PATH . '/ >/dev/null 2>&1'
+		. " && unzip -o /tmp/safety-net.zip -d $mu_plugins/ >/dev/null 2>&1"
 		. ' ; INSTALL=$?'
 		. ' ; rm -f /tmp/safety-net.zip'
 		. ' ; echo "INSTALL:${INSTALL}"'
 	);
+
+	$ssh_connection->setTimeout( 10 );
+
 	$result = is_string( $result ) ? $result : '';
 
 	// The exit code is reported verbatim by the caller, so a missing `curl`/`unzip` (127) stays
@@ -91,8 +114,9 @@ function write_safety_net_loader( SSH2 $ssh_connection ): bool {
 		return false;
 	}
 
-	$loader = SAFETY_NET_MU_PLUGINS_PATH . '/load-safety-net.php';
-	$plugin = SAFETY_NET_PLUGIN_ENTRY_FILE;
+	$mu_plugins = get_ssh_site_root_path( $ssh_connection ) . '/wp-content/mu-plugins';
+	$loader     = "$mu_plugins/load-safety-net.php";
+	$plugin     = "$mu_plugins/safety-net/safety-net.php";
 
 	$ssh_connection->exec(
 		"if test -f '$plugin' ; then cat > '$loader' <<'TEAM51_SAFETY_NET_LOADER'\n"
@@ -116,7 +140,7 @@ function write_safety_net_loader( SSH2 $ssh_connection ): bool {
  *
  * @param   string $site_url The URL of the site to check.
  *
- * @return  boolean|null  Null if the site could not be reached.
+ * @return  boolean|null  Null if the site could not be reached or did not answer with a readable report.
  */
 function is_safety_net_confirmed_via_http( string $site_url ): ?bool {
 	if ( ! preg_match( '#^https?://#i', $site_url ) ) {
@@ -160,8 +184,11 @@ function is_safety_net_confirmed_via_http( string $site_url ): ?bool {
 		return null;
 	}
 
+	// A non-200 answer - a 403 from a private staging site, a 502 during warm-up - says the status could not
+	// be read, not that the site is unprotected, so it reports unknown just like an unreachable site does.
+	// Only a readable 200 report gets to say either way.
 	if ( 200 !== ( parse_http_headers( $response_headers )['http_code'] ?? 0 ) ) {
-		return false;
+		return null;
 	}
 
 	$report = json_decode( $body, true );
@@ -217,7 +244,8 @@ function maybe_install_safety_net( ?SSH2 $ssh_connection, OutputInterface $outpu
 			$output->writeln( "<error>Installing SafetyNet through WP-CLI failed with exit code $install_code.</error>" );
 		}
 
-		$ssh_connection->exec( 'mv -f /htdocs/wp-content/plugins/safety-net ' . SAFETY_NET_MU_PLUGINS_PATH . '/safety-net' );
+		$site_root = get_ssh_site_root_path( $ssh_connection );
+		$ssh_connection->exec( "mv -f $site_root/wp-content/plugins/safety-net $site_root/wp-content/mu-plugins/safety-net" );
 		$move_code = $ssh_connection->getExitStatus();
 		if ( false !== $move_code && 0 !== $move_code ) {
 			$output->writeln( "<error>Moving SafetyNet into mu-plugins failed with exit code $move_code.</error>" );

--- a/includes/functions-safety-net.php
+++ b/includes/functions-safety-net.php
@@ -54,6 +54,10 @@ function is_safety_net_installed( SSH2 $ssh_connection ): ?bool {
  * @return  integer  The exit code of the download and unpack.
  */
 function install_safety_net_files( SSH2 $ssh_connection ): int {
+	// The command is silent until the trailing echo, and the connection's default read timeout is 10 seconds -
+	// a download slower than that would truncate the output and lose the INSTALL: marker.
+	$ssh_connection->setTimeout( 0 );
+
 	$result = $ssh_connection->exec(
 		"curl -fsSL '" . SAFETY_NET_ZIP_URL . "' -o /tmp/safety-net.zip 2>/dev/null"
 		. ' && unzip -o /tmp/safety-net.zip -d ' . SAFETY_NET_MU_PLUGINS_PATH . '/ >/dev/null 2>&1'
@@ -175,14 +179,15 @@ function is_safety_net_confirmed_via_http( string $site_url ): ?bool {
 /**
  * Installs Safety Net on a site if it is not already installed, then verifies that the files are in place.
  *
+ * If the download-and-unpack install fails - for example because the server has no `curl` or `unzip` - the
+ * install is retried through WP-CLI over the same connection.
+ *
  * @param   SSH2|null       $ssh_connection The SSH connection to the site, if one could be established.
  * @param   OutputInterface $output         The output instance.
- * @param   callable|null   $wp_cli_runner  Runs a WP-CLI command on the site and returns its exit code. Used
- *                                          as a fallback if the server has no `curl` or `unzip`.
  *
  * @return  boolean  Whether both Safety Net and its loader are in place afterwards.
  */
-function maybe_install_safety_net( ?SSH2 $ssh_connection, OutputInterface $output, ?callable $wp_cli_runner = null ): bool {
+function maybe_install_safety_net( ?SSH2 $ssh_connection, OutputInterface $output ): bool {
 	if ( is_null( $ssh_connection ) ) {
 		$output->writeln( '<error>Failed to connect to the site via SSH. Cannot install SafetyNet!</error>' );
 		return false;
@@ -201,24 +206,21 @@ function maybe_install_safety_net( ?SSH2 $ssh_connection, OutputInterface $outpu
 	$exit_code = install_safety_net_files( $ssh_connection );
 	if ( 0 !== $exit_code ) {
 		$output->writeln( "<comment>Downloading SafetyNet over SSH failed with exit code $exit_code.</comment>" );
+		$output->writeln( '<comment>Falling back to installing SafetyNet through WP-CLI...</comment>' );
 
-		if ( ! is_null( $wp_cli_runner ) ) {
-			$output->writeln( '<comment>Falling back to installing SafetyNet through WP-CLI...</comment>' );
+		// Run on the connection directly: the exit codes below are the remote ones, so each step reports its
+		// own failure. getExitStatus() returns false when the server sent no exit-status message, which is
+		// not a failure - reporting it as `exit code ` would read as one.
+		$ssh_connection->exec( 'wp plugin install ' . SAFETY_NET_ZIP_URL );
+		$install_code = $ssh_connection->getExitStatus();
+		if ( false !== $install_code && 0 !== $install_code ) {
+			$output->writeln( "<error>Installing SafetyNet through WP-CLI failed with exit code $install_code.</error>" );
+		}
 
-			// Both steps are reported separately so a failure here says whether the download or the move broke.
-			$install_code = $wp_cli_runner( 'plugin install ' . SAFETY_NET_ZIP_URL );
-			if ( 0 !== $install_code ) {
-				$output->writeln( "<error>Installing SafetyNet through WP-CLI failed with exit code $install_code.</error>" );
-			}
-
-			$ssh_connection->exec( 'mv -f /htdocs/wp-content/plugins/safety-net ' . SAFETY_NET_MU_PLUGINS_PATH . '/safety-net' );
-
-			// getExitStatus() returns false when the server sent no exit-status message, which is not a
-			// failure - reporting it as `exit code ` would read as one.
-			$move_code = $ssh_connection->getExitStatus();
-			if ( false !== $move_code && 0 !== $move_code ) {
-				$output->writeln( "<error>Moving SafetyNet into mu-plugins failed with exit code $move_code.</error>" );
-			}
+		$ssh_connection->exec( 'mv -f /htdocs/wp-content/plugins/safety-net ' . SAFETY_NET_MU_PLUGINS_PATH . '/safety-net' );
+		$move_code = $ssh_connection->getExitStatus();
+		if ( false !== $move_code && 0 !== $move_code ) {
+			$output->writeln( "<error>Moving SafetyNet into mu-plugins failed with exit code $move_code.</error>" );
 		}
 	}
 

--- a/includes/functions-safety-net.php
+++ b/includes/functions-safety-net.php
@@ -82,7 +82,8 @@ function is_safety_net_installed( SSH2 $ssh_connection ): ?bool {
  * @return  integer  The exit code of the download and unpack.
  */
 function install_safety_net_files( SSH2 $ssh_connection, ?string &$failure_output = null ): int {
-	$mu_plugins = get_ssh_site_root_path( $ssh_connection ) . '/wp-content/mu-plugins';
+	$site_root  = get_ssh_site_root_path( $ssh_connection );
+	$mu_plugins = "$site_root/wp-content/mu-plugins";
 
 	// The command produces no output before the trailing echo unless something fails, and the connection's
 	// default read timeout is 10 seconds - a download slower than that would truncate the output and lose the
@@ -97,10 +98,12 @@ function install_safety_net_files( SSH2 $ssh_connection, ?string &$failure_outpu
 	//
 	// The archive is unpacked into a staging directory and swapped in only once the staged copy is proven to
 	// be the replacement: `unzip` exiting 0 does not guarantee a `safety-net/` root (a re-rooted release
-	// archive extracts cleanly without one), so the directory itself is tested before anything is destroyed,
-	// and the mu-plugins parent is created first because `mv` - unlike the `unzip -d` this replaced - does
-	// not create it. The swap clears the destination because `unzip -o`/`mv` into an existing directory merge
-	// rather than replace and would leave files from an older release behind.
+	// archive extracts cleanly without one), so the directory itself is tested before anything is destroyed.
+	// The site root is required to already hold a `wp-content` before the mu-plugins parent is created inside
+	// it - `mv`, unlike the `unzip -d` this replaced, creates nothing - so a mis-resolved prefix stops the
+	// chain instead of fabricating a directory tree the site never reads. The swap clears the destination
+	// because `unzip -o`/`mv` into an existing directory merge rather than replace and would leave files from
+	// an older release behind.
 	$result = $ssh_connection->exec(
 		'ZIP=$(mktemp 2>/dev/null) || { ZIP=/tmp/safety-net.$$.zip ; ( set -C ; : > "$ZIP" ) 2>/dev/null || ZIP="" ; }'
 		. ' ; DIR=$(mktemp -d 2>/dev/null) || { DIR=/tmp/safety-net-stage.$$ ; mkdir "$DIR" 2>/dev/null || DIR="" ; }'
@@ -108,6 +111,7 @@ function install_safety_net_files( SSH2 $ssh_connection, ?string &$failure_outpu
 		. " { curl -fsSL '" . SAFETY_NET_ZIP_URL . '\' -o "$ZIP"'
 		. ' && unzip -o -q "$ZIP" -d "$DIR/"'
 		. ' && test -d "$DIR/safety-net"'
+		. " && test -d '$site_root/wp-content'"
 		. " && mkdir -p '$mu_plugins'"
 		. " && rm -rf '$mu_plugins/safety-net'"
 		. ' && mv -f "$DIR/safety-net" \'' . $mu_plugins . '/safety-net\' ; } 2>&1'

--- a/includes/functions-wpcom.php
+++ b/includes/functions-wpcom.php
@@ -414,11 +414,12 @@ function rotate_wpcom_site_wp_user_password( string $site_id_or_url, string $use
 	$credentials = null;
 
 	$exit_code = run_wpcom_site_wp_cli_command( $site_id_or_url, "user reset-password $user --skip-email --porcelain", true );
-	$password  = is_string( $GLOBALS['wp_cli_output'] ?? null ) ? trim( $GLOBALS['wp_cli_output'] ) : '';
+	$password  = parse_wp_cli_porcelain_password( $GLOBALS['wp_cli_output'] ?? null );
 
-	// The password is only trusted when WP-CLI actually printed one. Without this an unreachable site yields
-	// an empty password that then overwrites a good 1Password entry.
-	if ( Command::SUCCESS === $exit_code && '' !== $password ) {
+	// The password is only trusted when WP-CLI actually printed one. Without this an unreachable site, or a
+	// reset that failed and printed an error instead, overwrites a good 1Password entry. There is no API
+	// rotation to fall back from here, so this is the only guard on the value.
+	if ( Command::SUCCESS === $exit_code && ! is_null( $password ) ) {
 		$credentials = (object) array(
 			'username' => $user,
 			'password' => $password,
@@ -499,18 +500,21 @@ function wait_until_wpcom_agency_site_state( string $agency_site_id, string $sta
  * @param   string          $site_id_or_url The ID or URL of the WordPress.com site to check the state of.
  * @param   string          $state          The state to wait for the site to reach.
  * @param   OutputInterface $output         The output instance.
+ * @param   integer         $max_attempts   The maximum number of status checks before giving up.
  *
  * @return  stdClass|null
  */
-function wait_until_wpcom_site_transfer_state( string $site_id_or_url, string $state, OutputInterface $output ): ?stdClass {
+function wait_until_wpcom_site_transfer_state( string $site_id_or_url, string $state, OutputInterface $output, int $max_attempts = 120 ): ?stdClass {
 	$output->writeln( "<comment>Waiting for the transfer of WordPress.com site $site_id_or_url to reach the `$state` state.</comment>" );
 
 	$progress_bar = new ProgressBar( $output );
 	$progress_bar->start();
 
-	for ( $try = 0, $delay = 5; true; $try++ ) {
+	$reached = false;
+	for ( $try = 0, $delay = 5; $try < $max_attempts; $try++ ) {
 		$transfer = get_wpcom_site_transfer_status( $site_id_or_url );
 		if ( is_null( $transfer ) || $state === $transfer->status ) {
+			$reached = true;
 			break;
 		}
 
@@ -520,6 +524,11 @@ function wait_until_wpcom_site_transfer_state( string $site_id_or_url, string $s
 
 	$progress_bar->finish();
 	$output->writeln( '' ); // Empty line for UX purposes.
+
+	if ( ! $reached ) {
+		$output->writeln( "<error>The transfer of WordPress.com site $site_id_or_url did not reach the `$state` state after $max_attempts checks.</error>" );
+		return null;
+	}
 
 	return $transfer;
 }

--- a/includes/functions-wpcom.php
+++ b/includes/functions-wpcom.php
@@ -475,21 +475,28 @@ function update_wpcom_site( string $site_id_or_url, array $settings ): ?stdClass
 /**
  * Periodically checks the status of a WordPress.com agency site until it reaches a given state.
  *
- * @param   string          $agency_site_id The ID of the Agency site to check the state of.
- * @param   string          $state          The state to wait for the site to reach.
- * @param   OutputInterface $output         The output instance.
+ * @param   string          $agency_site_id   The ID of the Agency site to check the state of.
+ * @param   string          $state            The state to wait for the site to reach.
+ * @param   OutputInterface $output           The output instance.
+ * @param   integer         $max_wait_seconds How long to keep checking before giving up.
  *
  * @return  stdClass|null
  */
-function wait_until_wpcom_agency_site_state( string $agency_site_id, string $state, OutputInterface $output ): ?stdClass {
+function wait_until_wpcom_agency_site_state( string $agency_site_id, string $state, OutputInterface $output, int $max_wait_seconds = 1200 ): ?stdClass {
 	$output->writeln( "<comment>Waiting for WordPress.com agency site $agency_site_id to reach the `$state` state.</comment>" );
 
 	$progress_bar = new ProgressBar( $output );
 	$progress_bar->start();
 
-	for ( $try = 0, $delay = 'provisioning' === $state ? 3 : 5; true; $try++ ) {
+	// Budgeted by wall clock, like the sibling waits, since the poll interval differs per state.
+	$delay        = 'provisioning' === $state ? 3 : 5;
+	$max_attempts = (int) ceil( $max_wait_seconds / $delay );
+
+	$reached = false;
+	for ( $try = 0; $try < $max_attempts; $try++ ) {
 		$site = get_wpcom_agency_site( $agency_site_id );
 		if ( is_null( $site ) || $state === $site->features->wpcom_atomic->state ) {
+			$reached = true;
 			break;
 		}
 
@@ -499,6 +506,12 @@ function wait_until_wpcom_agency_site_state( string $agency_site_id, string $sta
 
 	$progress_bar->finish();
 	$output->writeln( '' ); // Empty line for UX purposes.
+
+	if ( ! $reached ) {
+		$minutes = (int) round( $max_wait_seconds / 60 );
+		$output->writeln( "<error>WordPress.com agency site $agency_site_id did not reach the `$state` state within $minutes minutes. The site exists and may still be provisioning.</error>" );
+		return null;
+	}
 
 	return $site;
 }
@@ -592,12 +605,13 @@ function wait_on_wpcom_site_ssh( string $site_id_or_url, OutputInterface $output
 /**
  * Periodically checks the status of a WordPress.com site until the Jetpack user token is regenerated.
  *
- * @param   string          $site_id_or_url The ID or URL of the WordPress.com site to check the state of.
- * @param   OutputInterface $output         The output instance.
+ * @param   string          $site_id_or_url   The ID or URL of the WordPress.com site to check the state of.
+ * @param   OutputInterface $output           The output instance.
+ * @param   integer         $max_wait_seconds How long to keep checking before giving up.
  *
  * @return  boolean
  */
-function wait_until_jetpack_token_regenerated( string $site_id_or_url, OutputInterface $output ): bool {
+function wait_until_jetpack_token_regenerated( string $site_id_or_url, OutputInterface $output, int $max_wait_seconds = 300 ): bool {
 	$output->writeln( '<fg=magenta;options=bold>Pinging site to regenerate Jetpack user token. This will cause an error and the token will be regenerated.</>' );
 	$output->writeln( "<comment>Waiting for WordPress.com site $site_id_or_url to regenerate the Jetpack user token.</comment>" );
 
@@ -606,7 +620,12 @@ function wait_until_jetpack_token_regenerated( string $site_id_or_url, OutputInt
 	$progress_bar->start();
 	$progress_bar->advance();
 
-	for ( $try = 0, $delay = 5; true; $try++ ) { // Infinite loop until SSH connection is established.
+	// Bounded like the other waits: the caller already copes with a false return by skipping the repository
+	// deployment with a warning, which beats hanging the clone forever on a token that never regenerates.
+	$delay        = 5;
+	$max_attempts = (int) ceil( $max_wait_seconds / $delay );
+
+	for ( $try = 0; $try < $max_attempts; $try++ ) {
 		$wpcom_site = get_wpcom_site( $site_id_or_url );
 		if ( ! is_null( $wpcom_site ) ) {
 			$regenerated = true;
@@ -619,6 +638,11 @@ function wait_until_jetpack_token_regenerated( string $site_id_or_url, OutputInt
 
 	$progress_bar->finish();
 	$output->writeln( '' ); // Empty line for UX purposes.
+
+	if ( ! $regenerated ) {
+		$minutes = (int) round( $max_wait_seconds / 60 );
+		$output->writeln( "<error>The Jetpack user token of WordPress.com site $site_id_or_url did not regenerate within $minutes minutes.</error>" );
+	}
 
 	return $regenerated;
 }

--- a/includes/functions-wpcom.php
+++ b/includes/functions-wpcom.php
@@ -428,9 +428,10 @@ function rotate_wpcom_site_wp_user_password( string $site_id_or_url, string $use
 
 	// Whenever output was captured but no credentials are returned - a garbled token, or a connection that
 	// broke after the reset already ran and printed one - that output is the only copy of whatever the site
-	// now uses, so it is surfaced rather than dropped. A fatal WP-CLI error is the exception: it means the
-	// reset never ran, so there is no credential to preserve and the caller's failure message covers it.
-	if ( is_null( $credentials ) && '' !== trim( (string) ( $GLOBALS['wp_cli_output'] ?? '' ) ) && ! is_wp_cli_error_output( $GLOBALS['wp_cli_output'] ) ) {
+	// now uses, so it is surfaced rather than dropped. Suppressed only when a fatal WP-CLI error is present
+	// AND no token was recoverable: that combination means the reset never ran, whereas an error alongside a
+	// token means it did and the token must not be lost.
+	if ( is_null( $credentials ) && '' !== trim( (string) ( $GLOBALS['wp_cli_output'] ?? '' ) ) && ( ! is_null( $password ) || ! is_wp_cli_error_output( $GLOBALS['wp_cli_output'] ) ) ) {
 		report_unreadable_wp_cli_password( $user, $GLOBALS['wp_cli_output'] );
 	}
 

--- a/includes/functions-wpcom.php
+++ b/includes/functions-wpcom.php
@@ -416,10 +416,6 @@ function rotate_wpcom_site_wp_user_password( string $site_id_or_url, string $use
 	$exit_code = run_wpcom_site_wp_cli_command( $site_id_or_url, "user reset-password $user --skip-email --porcelain", true );
 	$password  = parse_wp_cli_porcelain_password( $GLOBALS['wp_cli_output'] ?? null );
 
-	if ( Command::SUCCESS === $exit_code && is_null( $password ) ) {
-		report_unreadable_wp_cli_password( $user, $GLOBALS['wp_cli_output'] ?? null );
-	}
-
 	// The password is only trusted when WP-CLI actually printed one. Without this an unreachable site, or a
 	// reset that failed and printed an error instead, overwrites a good 1Password entry. There is no API
 	// rotation to fall back from here, so this is the only guard on the value.
@@ -428,6 +424,13 @@ function rotate_wpcom_site_wp_user_password( string $site_id_or_url, string $use
 			'username' => $user,
 			'password' => $password,
 		);
+	}
+
+	// Whenever output was captured but no credentials are returned - a garbled token, or a connection that
+	// broke after the reset already ran and printed one - that output is the only copy of whatever the site
+	// now uses, so it is surfaced rather than dropped.
+	if ( is_null( $credentials ) && '' !== trim( (string) ( $GLOBALS['wp_cli_output'] ?? '' ) ) ) {
+		report_unreadable_wp_cli_password( $user, $GLOBALS['wp_cli_output'] );
 	}
 
 	return $credentials;

--- a/includes/functions-wpcom.php
+++ b/includes/functions-wpcom.php
@@ -416,6 +416,10 @@ function rotate_wpcom_site_wp_user_password( string $site_id_or_url, string $use
 	$exit_code = run_wpcom_site_wp_cli_command( $site_id_or_url, "user reset-password $user --skip-email --porcelain", true );
 	$password  = parse_wp_cli_porcelain_password( $GLOBALS['wp_cli_output'] ?? null );
 
+	if ( Command::SUCCESS === $exit_code && is_null( $password ) ) {
+		report_unreadable_wp_cli_password( $user, $GLOBALS['wp_cli_output'] ?? null );
+	}
+
 	// The password is only trusted when WP-CLI actually printed one. Without this an unreachable site, or a
 	// reset that failed and printed an error instead, overwrites a good 1Password entry. There is no API
 	// rotation to fall back from here, so this is the only guard on the value.

--- a/includes/functions-wpcom.php
+++ b/includes/functions-wpcom.php
@@ -506,21 +506,26 @@ function wait_until_wpcom_agency_site_state( string $agency_site_id, string $sta
 /**
  * Periodically checks on the transfer status of a WordPress.com Atomic site until it reaches a given state.
  *
- * @param   string          $site_id_or_url The ID or URL of the WordPress.com site to check the state of.
- * @param   string          $state          The state to wait for the site to reach.
- * @param   OutputInterface $output         The output instance.
- * @param   integer         $max_attempts   The maximum number of status checks before giving up.
+ * @param   string          $site_id_or_url   The ID or URL of the WordPress.com site to check the state of.
+ * @param   string          $state            The state to wait for the site to reach.
+ * @param   OutputInterface $output           The output instance.
+ * @param   integer         $max_wait_seconds How long to keep checking before giving up.
  *
  * @return  stdClass|null
  */
-function wait_until_wpcom_site_transfer_state( string $site_id_or_url, string $state, OutputInterface $output, int $max_attempts = 120 ): ?stdClass {
+function wait_until_wpcom_site_transfer_state( string $site_id_or_url, string $state, OutputInterface $output, int $max_wait_seconds = 1200 ): ?stdClass {
 	$output->writeln( "<comment>Waiting for the transfer of WordPress.com site $site_id_or_url to reach the `$state` state.</comment>" );
 
 	$progress_bar = new ProgressBar( $output );
 	$progress_bar->start();
 
+	// Budgeted by wall clock, matching the Pressable state wait, so the give-up message can say how long the
+	// command actually waited. A transfer copies the whole site, so the budget is deliberately generous.
+	$delay        = 5;
+	$max_attempts = (int) ceil( $max_wait_seconds / $delay );
+
 	$reached = false;
-	for ( $try = 0, $delay = 5; $try < $max_attempts; $try++ ) {
+	for ( $try = 0; $try < $max_attempts; $try++ ) {
 		$transfer = get_wpcom_site_transfer_status( $site_id_or_url );
 		if ( is_null( $transfer ) || $state === $transfer->status ) {
 			$reached = true;
@@ -535,7 +540,8 @@ function wait_until_wpcom_site_transfer_state( string $site_id_or_url, string $s
 	$output->writeln( '' ); // Empty line for UX purposes.
 
 	if ( ! $reached ) {
-		$output->writeln( "<error>The transfer of WordPress.com site $site_id_or_url did not reach the `$state` state after $max_attempts checks.</error>" );
+		$minutes = (int) round( $max_wait_seconds / 60 );
+		$output->writeln( "<error>The transfer of WordPress.com site $site_id_or_url did not reach the `$state` state within $minutes minutes.</error>" );
 		return null;
 	}
 

--- a/includes/functions-wpcom.php
+++ b/includes/functions-wpcom.php
@@ -492,12 +492,22 @@ function wait_until_wpcom_agency_site_state( string $agency_site_id, string $sta
 	$delay        = 'provisioning' === $state ? 3 : 5;
 	$max_attempts = (int) ceil( $max_wait_seconds / $delay );
 
-	$reached = false;
+	// A transient failed lookup is retried rather than treated as terminal - one null from the API against a
+	// freshly created site must not throw away the whole budget - and only a few in a row give up.
+	$reached      = false;
+	$null_lookups = 0;
 	for ( $try = 0; $try < $max_attempts; $try++ ) {
 		$site = get_wpcom_agency_site( $agency_site_id );
-		if ( is_null( $site ) || $state === $site->features->wpcom_atomic->state ) {
-			$reached = true;
-			break;
+		if ( is_null( $site ) ) {
+			if ( 3 <= ++$null_lookups ) {
+				break;
+			}
+		} else {
+			$null_lookups = 0;
+			if ( $state === $site->features->wpcom_atomic->state ) {
+				$reached = true;
+				break;
+			}
 		}
 
 		$progress_bar->advance();
@@ -509,7 +519,11 @@ function wait_until_wpcom_agency_site_state( string $agency_site_id, string $sta
 
 	if ( ! $reached ) {
 		$minutes = (int) round( $max_wait_seconds / 60 );
-		$output->writeln( "<error>WordPress.com agency site $agency_site_id did not reach the `$state` state within $minutes minutes. The site exists and may still be provisioning.</error>" );
+		$output->writeln(
+			3 <= $null_lookups
+				? "<error>WordPress.com agency site $agency_site_id could not be looked up ($null_lookups consecutive failed lookups).</error>"
+				: "<error>WordPress.com agency site $agency_site_id did not reach the `$state` state within $minutes minutes. The site exists and may still be provisioning.</error>"
+		);
 		return null;
 	}
 
@@ -537,12 +551,22 @@ function wait_until_wpcom_site_transfer_state( string $site_id_or_url, string $s
 	$delay        = 5;
 	$max_attempts = (int) ceil( $max_wait_seconds / $delay );
 
-	$reached = false;
+	// A transient failed lookup is retried rather than treated as terminal - one null from the API against a
+	// freshly created site must not throw away the whole budget - and only a few in a row give up.
+	$reached      = false;
+	$null_lookups = 0;
 	for ( $try = 0; $try < $max_attempts; $try++ ) {
 		$transfer = get_wpcom_site_transfer_status( $site_id_or_url );
-		if ( is_null( $transfer ) || $state === $transfer->status ) {
-			$reached = true;
-			break;
+		if ( is_null( $transfer ) ) {
+			if ( 3 <= ++$null_lookups ) {
+				break;
+			}
+		} else {
+			$null_lookups = 0;
+			if ( $state === $transfer->status ) {
+				$reached = true;
+				break;
+			}
 		}
 
 		$progress_bar->advance();
@@ -554,7 +578,11 @@ function wait_until_wpcom_site_transfer_state( string $site_id_or_url, string $s
 
 	if ( ! $reached ) {
 		$minutes = (int) round( $max_wait_seconds / 60 );
-		$output->writeln( "<error>The transfer of WordPress.com site $site_id_or_url did not reach the `$state` state within $minutes minutes.</error>" );
+		$output->writeln(
+			3 <= $null_lookups
+				? "<error>The transfer of WordPress.com site $site_id_or_url could not be looked up ($null_lookups consecutive failed lookups).</error>"
+				: "<error>The transfer of WordPress.com site $site_id_or_url did not reach the `$state` state within $minutes minutes.</error>"
+		);
 		return null;
 	}
 

--- a/includes/functions-wpcom.php
+++ b/includes/functions-wpcom.php
@@ -414,10 +414,14 @@ function rotate_wpcom_site_wp_user_password( string $site_id_or_url, string $use
 	$credentials = null;
 
 	$exit_code = run_wpcom_site_wp_cli_command( $site_id_or_url, "user reset-password $user --skip-email --porcelain", true );
-	if ( Command::SUCCESS === $exit_code ) {
+	$password  = is_string( $GLOBALS['wp_cli_output'] ?? null ) ? trim( $GLOBALS['wp_cli_output'] ) : '';
+
+	// The password is only trusted when WP-CLI actually printed one. Without this an unreachable site yields
+	// an empty password that then overwrites a good 1Password entry.
+	if ( Command::SUCCESS === $exit_code && '' !== $password ) {
 		$credentials = (object) array(
 			'username' => $user,
-			'password' => $GLOBALS['wp_cli_output'],
+			'password' => $password,
 		);
 	}
 
@@ -525,10 +529,11 @@ function wait_until_wpcom_site_transfer_state( string $site_id_or_url, string $s
  *
  * @param   string          $site_id_or_url The ID or URL of the WordPress.com site to check the state of.
  * @param   OutputInterface $output         The output instance.
+ * @param   integer         $max_attempts   The maximum number of connection attempts, 5 seconds apart.
  *
  * @return  SSH2|null
  */
-function wait_on_wpcom_site_ssh( string $site_id_or_url, OutputInterface $output ): ?SSH2 {
+function wait_on_wpcom_site_ssh( string $site_id_or_url, OutputInterface $output, int $max_attempts = 60 ): ?SSH2 {
 	$output->writeln( "<comment>Waiting for WordPress.com site $site_id_or_url to accept SSH connections.</comment>" );
 
 	$progress_bar = new ProgressBar( $output );
@@ -539,7 +544,8 @@ function wait_on_wpcom_site_ssh( string $site_id_or_url, OutputInterface $output
 	sleep( 5 );
 	$progress_bar->advance();
 
-	for ( $try = 0, $delay = 5; true; $try++ ) { // Infinite loop until SSH connection is established.
+	$ssh_connection = null;
+	for ( $try = 0, $delay = 5; $try < $max_attempts; $try++ ) {
 		$ssh_connection = WPCOM_Connection_Helper::get_ssh_connection( $site_id_or_url );
 		if ( ! is_null( $ssh_connection ) ) {
 			break;
@@ -551,6 +557,10 @@ function wait_on_wpcom_site_ssh( string $site_id_or_url, OutputInterface $output
 
 	$progress_bar->finish();
 	$output->writeln( '' ); // Empty line for UX purposes.
+
+	if ( is_null( $ssh_connection ) ) {
+		$output->writeln( "<error>WordPress.com site $site_id_or_url did not accept SSH connections after $max_attempts attempts.</error>" );
+	}
 
 	return $ssh_connection;
 }

--- a/includes/functions-wpcom.php
+++ b/includes/functions-wpcom.php
@@ -428,8 +428,9 @@ function rotate_wpcom_site_wp_user_password( string $site_id_or_url, string $use
 
 	// Whenever output was captured but no credentials are returned - a garbled token, or a connection that
 	// broke after the reset already ran and printed one - that output is the only copy of whatever the site
-	// now uses, so it is surfaced rather than dropped.
-	if ( is_null( $credentials ) && '' !== trim( (string) ( $GLOBALS['wp_cli_output'] ?? '' ) ) ) {
+	// now uses, so it is surfaced rather than dropped. A fatal WP-CLI error is the exception: it means the
+	// reset never ran, so there is no credential to preserve and the caller's failure message covers it.
+	if ( is_null( $credentials ) && '' !== trim( (string) ( $GLOBALS['wp_cli_output'] ?? '' ) ) && ! is_wp_cli_error_output( $GLOBALS['wp_cli_output'] ) ) {
 		report_unreadable_wp_cli_password( $user, $GLOBALS['wp_cli_output'] );
 	}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,6 +1,7 @@
 <?php
 
 use Symfony\Component\Console\Exception\ExceptionInterface;
+use Symfony\Component\Console\Formatter\OutputFormatter;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
@@ -189,7 +190,8 @@ function report_unreadable_wp_cli_password( string $user, mixed $output ): void 
 	console_writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
 	console_writeln( "<error>⚠  The password reset for $user ran, but its output could not be read as a password.</error>" );
 	console_writeln( '<error>    The site may already be using a new password. Raw output follows:</error>' );
-	console_writeln( '<fg=yellow;options=bold>' . ( is_string( $output ) ? trim( $output ) : '(no output captured)' ) . '</>' );
+	// Escaped so a password containing formatter syntax is printed verbatim instead of being parsed as tags.
+	console_writeln( '<fg=yellow;options=bold>' . OutputFormatter::escape( is_string( $output ) ? trim( $output ) : '(no output captured)' ) . '</>' );
 	console_writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
 }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -157,7 +157,10 @@ function parse_wp_cli_porcelain_password( mixed $output ): ?string {
 		return null;
 	}
 
-	$password = trim( $output );
+	// The reply accumulates every packet, stderr included, so a notice arriving ahead of the token must not
+	// fail a reset that succeeded. `--porcelain` prints the token last, so the last non-empty line is judged.
+	$output_lines = array_values( array_filter( array_map( 'trim', preg_split( '/\R/', $output ) ), static fn( string $line ): bool => '' !== $line ) );
+	$password     = empty( $output_lines ) ? '' : end( $output_lines );
 
 	// Checked before the shape test so prefixed message text is recognizably rejected as WP-CLI output rather
 	// than merely failing the single-token requirement.
@@ -177,16 +180,26 @@ function parse_wp_cli_porcelain_password( mixed $output ): ?string {
 /**
  * Returns whether some captured WP-CLI output is a fatal WP-CLI error message.
  *
- * A reply that starts with `Error:` means WP-CLI halted before doing anything - unlike a `Warning:`, which
- * precedes the command's real output - so callers can tell "the command never ran" apart from "the command ran
- * but its output is unreadable".
+ * An `Error:` line means WP-CLI halted before doing anything - unlike a `Warning:`, which precedes the
+ * command's real output - so callers can tell "the command never ran" apart from "the command ran but its
+ * output is unreadable". Every line is scanned because the accumulated reply may carry notices ahead of it.
  *
  * @param   mixed $output The captured WP-CLI output.
  *
  * @return  boolean
  */
 function is_wp_cli_error_output( mixed $output ): bool {
-	return is_string( $output ) && str_starts_with( ltrim( $output ), 'Error:' );
+	if ( ! is_string( $output ) ) {
+		return false;
+	}
+
+	foreach ( preg_split( '/\R/', $output ) as $line ) {
+		if ( str_starts_with( trim( $line ), 'Error:' ) ) {
+			return true;
+		}
+	}
+
+	return false;
 }
 
 /**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -145,8 +145,10 @@ function decode_json_content( string $json, bool $associative = false, int $flag
  * The WP-CLI runners report the exit code of the local console command, not the remote `wp` exit status, and
  * phpseclib folds stderr into the captured output unless quiet mode is on - which it never is. A failed reset
  * therefore leaves an `Error: ...` sentence where the password should be, and storing that as a credential
- * would overwrite a good 1Password entry while the site keeps its old password. `--porcelain` prints nothing
- * but a single whitespace-free token, so anything else is rejected.
+ * would overwrite a good 1Password entry while the site keeps its old password. `--porcelain` prints the
+ * password as a single whitespace-free token and nothing else, so the reply is read from the end backwards:
+ * recognized WP-CLI messages are stepped over, and the first line past them yields the password only if it
+ * has that shape.
  *
  * @param   mixed $output The captured WP-CLI output.
  *
@@ -157,10 +159,11 @@ function parse_wp_cli_porcelain_password( mixed $output ): ?string {
 		return null;
 	}
 
-	// The reply accumulates every packet, stderr included, so noise on either side of the token must not fail
-	// a reset that succeeded. The lines are walked in reverse - `--porcelain` prints the token last, but a
-	// message can still trail it - and the nearest-to-last line that is not a WP-CLI message and has the
-	// single-token shape is the password.
+	// The reply accumulates every packet, stderr included, so a recognized WP-CLI message trailing the token
+	// must not fail a reset that succeeded. The lines are walked in reverse, skipping those messages; the
+	// first line that is not one of them is the candidate, and it is the password only if it has the
+	// single-token shape. Anything else - an unrecognized notice, a shell diagnostic - fails closed rather
+	// than letting the search reach past it to an earlier line that merely looks like a token.
 	$output_lines = array_reverse( array_filter( array_map( 'trim', preg_split( '/\R/', $output ) ), static fn( string $line ): bool => '' !== $line ) );
 
 	foreach ( $output_lines as $output_line ) {
@@ -170,9 +173,7 @@ function parse_wp_cli_porcelain_password( mixed $output ): ?string {
 			}
 		}
 
-		if ( 1 === preg_match( '/^\S+$/', $output_line ) ) {
-			return $output_line;
-		}
+		return 1 === preg_match( '/^\S+$/', $output_line ) ? $output_line : null;
 	}
 
 	return null;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -175,6 +175,21 @@ function parse_wp_cli_porcelain_password( mixed $output ): ?string {
 }
 
 /**
+ * Returns whether some captured WP-CLI output is a fatal WP-CLI error message.
+ *
+ * A reply that starts with `Error:` means WP-CLI halted before doing anything - unlike a `Warning:`, which
+ * precedes the command's real output - so callers can tell "the command never ran" apart from "the command ran
+ * but its output is unreadable".
+ *
+ * @param   mixed $output The captured WP-CLI output.
+ *
+ * @return  boolean
+ */
+function is_wp_cli_error_output( mixed $output ): bool {
+	return is_string( $output ) && str_starts_with( ltrim( $output ), 'Error:' );
+}
+
+/**
  * Prints the raw output of a password reset whose result could not be read as a password.
  *
  * By the time the output is parsed the reset has already run, so this string is the only copy of whatever the

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -157,24 +157,25 @@ function parse_wp_cli_porcelain_password( mixed $output ): ?string {
 		return null;
 	}
 
-	// The reply accumulates every packet, stderr included, so a notice arriving ahead of the token must not
-	// fail a reset that succeeded. `--porcelain` prints the token last, so the last non-empty line is judged.
-	$output_lines = array_values( array_filter( array_map( 'trim', preg_split( '/\R/', $output ) ), static fn( string $line ): bool => '' !== $line ) );
-	$password     = empty( $output_lines ) ? '' : end( $output_lines );
+	// The reply accumulates every packet, stderr included, so noise on either side of the token must not fail
+	// a reset that succeeded. The lines are walked in reverse - `--porcelain` prints the token last, but a
+	// message can still trail it - and the nearest-to-last line that is not a WP-CLI message and has the
+	// single-token shape is the password.
+	$output_lines = array_reverse( array_filter( array_map( 'trim', preg_split( '/\R/', $output ) ), static fn( string $line ): bool => '' !== $line ) );
 
-	// Checked before the shape test so prefixed message text is recognizably rejected as WP-CLI output rather
-	// than merely failing the single-token requirement.
-	foreach ( array( 'Error:', 'Warning:', 'Success:' ) as $prefix ) {
-		if ( str_starts_with( $password, $prefix ) ) {
-			return null;
+	foreach ( $output_lines as $output_line ) {
+		foreach ( array( 'Error:', 'Warning:', 'Success:' ) as $prefix ) {
+			if ( str_starts_with( $output_line, $prefix ) ) {
+				continue 2;
+			}
+		}
+
+		if ( 1 === preg_match( '/^\S+$/', $output_line ) ) {
+			return $output_line;
 		}
 	}
 
-	if ( 1 !== preg_match( '/^\S+$/', $password ) ) {
-		return null;
-	}
-
-	return $password;
+	return null;
 }
 
 /**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -205,6 +205,30 @@ function is_wp_cli_error_output( mixed $output ): bool {
 }
 
 /**
+ * Returns whether some captured WP-CLI output contains a WP-CLI success message.
+ *
+ * Anchored to line starts, like its error counterpart, so a `Success:` occurring mid-line - in a URL, a
+ * plugin title, or an echoed diagnostic - does not read as one.
+ *
+ * @param   mixed $output The captured WP-CLI output.
+ *
+ * @return  boolean
+ */
+function is_wp_cli_success_output( mixed $output ): bool {
+	if ( ! is_string( $output ) ) {
+		return false;
+	}
+
+	foreach ( preg_split( '/\R/', $output ) as $line ) {
+		if ( str_starts_with( trim( $line ), 'Success:' ) ) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+/**
  * Prints the raw output of a password reset whose result could not be read as a password.
  *
  * By the time the output is parsed the reset has already run, so this string is the only copy of whatever the

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -157,14 +157,17 @@ function parse_wp_cli_porcelain_password( mixed $output ): ?string {
 	}
 
 	$password = trim( $output );
-	if ( 1 !== preg_match( '/^\S+$/', $password ) ) {
-		return null;
-	}
 
+	// Checked before the shape test so prefixed message text is recognizably rejected as WP-CLI output rather
+	// than merely failing the single-token requirement.
 	foreach ( array( 'Error:', 'Warning:', 'Success:' ) as $prefix ) {
 		if ( str_starts_with( $password, $prefix ) ) {
 			return null;
 		}
+	}
+
+	if ( 1 !== preg_match( '/^\S+$/', $password ) ) {
+		return null;
 	}
 
 	return $password;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -171,6 +171,26 @@ function parse_wp_cli_porcelain_password( mixed $output ): ?string {
 }
 
 /**
+ * Prints the raw output of a password reset whose result could not be read as a password.
+ *
+ * By the time the output is parsed the reset has already run, so this string is the only copy of whatever the
+ * site is now using. Passwords are otherwise kept off the console deliberately, but discarding one silently
+ * locks the user out with no record anywhere, which is the worse outcome of the two.
+ *
+ * @param   string $user   The user whose password was reset.
+ * @param   mixed  $output The raw WP-CLI output.
+ *
+ * @return  void
+ */
+function report_unreadable_wp_cli_password( string $user, mixed $output ): void {
+	console_writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
+	console_writeln( "<error>⚠  The password reset for $user ran, but its output could not be read as a password.</error>" );
+	console_writeln( '<error>    The site may already be using a new password. Raw output follows:</error>' );
+	console_writeln( '<fg=yellow;options=bold>' . ( is_string( $output ) ? trim( $output ) : '(no output captured)' ) . '</>' );
+	console_writeln( '<error>════════════════════════════════════════════════════════════════</error>' );
+}
+
+/**
  * Encodes some given data into a JSON object.
  *
  * @param   mixed   $data  The data to encode.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -139,6 +139,38 @@ function decode_json_content( string $json, bool $associative = false, int $flag
 }
 
 /**
+ * Returns the password printed by a `wp user reset-password --porcelain` run, or null if it did not print one.
+ *
+ * The WP-CLI runners report the exit code of the local console command, not the remote `wp` exit status, and
+ * phpseclib folds stderr into the captured output unless quiet mode is on - which it never is. A failed reset
+ * therefore leaves an `Error: ...` sentence where the password should be, and storing that as a credential
+ * would overwrite a good 1Password entry while the site keeps its old password. `--porcelain` prints nothing
+ * but a single whitespace-free token, so anything else is rejected.
+ *
+ * @param   mixed $output The captured WP-CLI output.
+ *
+ * @return  string|null
+ */
+function parse_wp_cli_porcelain_password( mixed $output ): ?string {
+	if ( ! is_string( $output ) ) {
+		return null;
+	}
+
+	$password = trim( $output );
+	if ( 1 !== preg_match( '/^\S+$/', $password ) ) {
+		return null;
+	}
+
+	foreach ( array( 'Error:', 'Warning:', 'Success:' ) as $prefix ) {
+		if ( str_starts_with( $password, $prefix ) ) {
+			return null;
+		}
+	}
+
+	return $password;
+}
+
+/**
  * Encodes some given data into a JSON object.
  *
  * @param   mixed   $data  The data to encode.


### PR DESCRIPTION
## Summary

- Stop writing the Safety Net loader when the plugin itself is not there. The reported failure was `wp plugin install` dying silently on a fresh clone; the `mv` then had nothing to move, the mu-plugins listing correctly reported `Failed to install SafetyNet!`, and the very next branch copied `load-safety-net.php` in anyway — leaving Safety Net Loader listed as an enabled mu-plugin with no Safety Net behind it. The loader is now written only when the plugin is in place, and a stray loader is cleared instead.
- Fix the mu-plugins check that reads a site as protected when it is not. `str_contains( $stream, 'safety-net' )` is also satisfied by the string `load-safety-net.php`, so a site left in the state above reports as already installed on the next run and skips the install — turning a one-off failure into a permanent one. Detection now tests for the loader file and the plugin's entry file separately.
- Extract the install/verify logic that was duplicated between `Pressable_Site_Clone` and `WPCOM_Site_Clone` into `includes/functions-safety-net.php`.
- Install the release without booting WordPress (curl + `unzip` straight into mu-plugins). A freshly cloned Pressable site kills WordPress-booting commands — `wp plugin install` included — with SIGSYS under the SSH seccomp profile. Falls back to the previous WP-CLI path, run over the same SSH connection so remote exit codes are what gets reported, if the server has no `curl`/`unzip`.
- Write the loader only when the plugin is in place, and clear a stray loader otherwise, so a failed install stops looking like a successful one. The decision is made server-side so an unreadable check never deletes a live loader.
- Verify against the site's own `safety-net/v1/status` endpoint on every run — it is the only signal that Safety Net actually booted and scrubbed, so it decides the final verdict rather than the file listing. Both clone commands return `Command::FAILURE` with an explicit warning when the clone is unprotected or could not be verified, instead of reporting success.
- Provision the `concierge@wordpress.com` collaborator in `Pressable_Connection_Helper` when a clone did not inherit one, rather than failing every SSH/SFTP connection with `SFTP user not found.` The first few lookups are allowed to fail first, since that error usually just means the clone's own SFTP user has not finished provisioning and will appear within seconds.
- Bound `wait_on_pressable_site_ssh()` and `wait_on_wpcom_site_ssh()`, which were infinite loops with no exit.
- Return `Command::FAILURE` from `Pressable_Site_WP_CLI_Command_Run` when a site could not be reached, and reset `$GLOBALS['wp_cli_output']` before each run in both WP-CLI runners.
- Require a non-empty WP-CLI password before building credentials in `rotate_pressable_site_wp_user_password()` and `rotate_wpcom_site_wp_user_password()`.

Refs T51ENG-2073.

## Notes

- The unconditional `Command::SUCCESS` from the Pressable WP-CLI runner had two downstream effects worth calling out: an unreachable site produced an empty password that then overwrote the 1Password entry, and `WPCOM_Site_WP_User_Delete` could proceed to delete users based on stale admin output from an earlier command. Both are addressed by the runner change plus the `$GLOBALS['wp_cli_output']` reset.
- The collaborator-provisioning path and the SSH wait timeout are unexercised in testing — the clone used for verification inherited a working SFTP user, so neither triggered.
- Deleting a clone that ends up unprotected is deliberately out of scope. The command reports loudly and exits non-zero, leaving the site for a human to deal with.

## Test plan

- [ ] `team51 --dev pressable:clone-site <site> <label>` — clone completes and `/htdocs/wp-content/mu-plugins` contains both `safety-net/` and `load-safety-net.php`.
- [ ] `GET https://<clone>/wp-json/safety-net/v1/status` reports an `environment` of staging/development/local with `options_scrubbed` and `data_deleted` true.
- [ ] On a clone, `rm -rf mu-plugins/safety-net` leaving the loader behind, then re-run the install — it detects the plugin as missing (the old check reported it as installed) and reinstalls.
- [ ] With the plugin absent, confirm `load-safety-net.php` is removed rather than left listed as an enabled mu-plugin.
- [ ] `team51 --dev wpcom:clone-site <site>` — same mu-plugins and endpoint checks against the staging site.
- [ ] Rotate a WP user password on a reachable site and confirm a non-empty password still reaches 1Password.
- [ ] `composer run lint:php`
