### PR TITLE
Add pressable/wpcom:download-site-database commands

### DIFF
--- a/commands/Pressable_Site_Database_Download.php
+++ b/commands/Pressable_Site_Database_Download.php
@@ -120,11 +120,12 @@ final class Pressable_Site_Database_Download extends Command {
 				. 'wp db export "${dump_path%.gz}" --add-drop-table --single-transaction && '
 				. 'gzip -f "${dump_path%.gz}"; '
 				. 'exit $?';
-			$dump_output  = (string) $dump_ssh->exec( $dump_command );
-			$dump_failed  = ( 0 !== $dump_ssh->getExitStatus() );
-			// A MySQL error, an exhausted /tmp and a failed gzip are indistinguishable without this,
+			// exec() already folds the channel's stderr into its return value - quiet mode, which would
+			// suppress that, is never enabled here - so getStdError() would only repeat it.
+			// Without this a MySQL error, an exhausted /tmp and a failed gzip are indistinguishable,
 			// and the operator has already paid the full export time by the time it fails.
-			$dump_error = \trim( $dump_output . "\n" . (string) $dump_ssh->getStdError() );
+			$dump_error  = \trim( (string) $dump_ssh->exec( $dump_command ) );
+			$dump_failed = ( 0 !== $dump_ssh->getExitStatus() );
 		} finally {
 			$dump_ssh->disconnect();
 		}
@@ -177,6 +178,7 @@ final class Pressable_Site_Database_Download extends Command {
 		}
 
 		if ( \is_null( $sftp ) ) {
+			$this->discard_temp_archive( $output, $local_gz_path );
 			$output->writeln( "<error>Failed to connect to the site via SFTP. The dump is still at $used_remote_path on the server.</error>" );
 			return Command::FAILURE;
 		}
@@ -251,9 +253,12 @@ final class Pressable_Site_Database_Download extends Command {
 	 */
 	private function create_owner_only_file( OutputInterface $output, string $path ): void {
 		$handle = \fopen( $path, 'wb' );
-		if ( false !== $handle ) {
-			\fclose( $handle );
+		if ( false === $handle ) {
+			$output->writeln( "<comment>Could not pre-create $path. The transfer will create it with default permissions.</comment>" );
+			return;
 		}
+
+		\fclose( $handle );
 
 		// A filesystem that cannot honour the mode - exFAT, an SMB mount - would otherwise make this
 		// hardening a silent no-op.

--- a/commands/Pressable_Site_Database_Download.php
+++ b/commands/Pressable_Site_Database_Download.php
@@ -89,6 +89,7 @@ final class Pressable_Site_Database_Download extends Command {
 			"tmp/$dump_filename",
 		);
 		$dump_failed         = false;
+		$dump_error          = '';
 		$download_successful = false;
 		$download_valid      = false;
 		$remote_size         = null;
@@ -119,8 +120,11 @@ final class Pressable_Site_Database_Download extends Command {
 				. 'wp db export "${dump_path%.gz}" --add-drop-table --single-transaction && '
 				. 'gzip -f "${dump_path%.gz}"; '
 				. 'exit $?';
-			$dump_ssh->exec( $dump_command );
-			$dump_failed = ( 0 !== $dump_ssh->getExitStatus() );
+			$dump_output  = (string) $dump_ssh->exec( $dump_command );
+			$dump_failed  = ( 0 !== $dump_ssh->getExitStatus() );
+			// A MySQL error, an exhausted /tmp and a failed gzip are indistinguishable without this,
+			// and the operator has already paid the full export time by the time it fails.
+			$dump_error = \trim( $dump_output . "\n" . (string) $dump_ssh->getStdError() );
 		} finally {
 			$dump_ssh->disconnect();
 		}
@@ -128,12 +132,19 @@ final class Pressable_Site_Database_Download extends Command {
 		if ( $dump_failed ) {
 			// `wp db export` may have written the plaintext dump before `gzip` failed, so sweep before leaving.
 			$output->writeln( '<error>Failed to create the remote database dump.</error>' );
+			if ( '' !== $dump_error ) {
+				$output->writeln( "<error>$dump_error</error>" );
+			}
 			if ( ! $this->remove_remote_dumps( $remote_dump_paths ) ) {
 				$output->writeln( "<error>Anything it left behind is still on the server at {$remote_dump_paths[0]} or its .sql counterpart; remove it manually.</error>" );
 			}
 
 			return Command::FAILURE;
 		}
+
+		// Create the temp file 0600 up front: SFTP truncates an existing file rather than recreating it,
+		// so chmod-ing afterwards would leave the archive world-readable for the whole transfer.
+		$this->create_owner_only_file( $output, $local_gz_path );
 
 		$sftp = \Pressable_Connection_Helper::get_sftp_connection( (string) $this->site->id );
 		if ( ! \is_null( $sftp ) ) {
@@ -150,7 +161,6 @@ final class Pressable_Site_Database_Download extends Command {
 					$used_remote_path = $sftp_path;
 
 					if ( $sftp->get( $sftp_path, $local_gz_path ) ) {
-						\chmod( $local_gz_path, 0600 );
 						$download_successful = true;
 						$remote_size         = $remote_stat['size'] ?? null;
 						break;
@@ -227,6 +237,28 @@ final class Pressable_Site_Database_Download extends Command {
 	private function discard_temp_archive( OutputInterface $output, string $local_gz_path ): void {
 		if ( \is_file( $local_gz_path ) && ! \unlink( $local_gz_path ) ) {
 			$output->writeln( "<comment>Could not remove the temporary archive at $local_gz_path. Delete it manually - it holds a copy of the database.</comment>" );
+		}
+	}
+
+	/**
+	 * Creates an empty file readable only by its owner, so the dump is never briefly exposed to other
+	 * users of the machine while it downloads.
+	 *
+	 * @param   OutputInterface $output The output object.
+	 * @param   string          $path   The file to create.
+	 *
+	 * @return  void
+	 */
+	private function create_owner_only_file( OutputInterface $output, string $path ): void {
+		$handle = \fopen( $path, 'wb' );
+		if ( false !== $handle ) {
+			\fclose( $handle );
+		}
+
+		// A filesystem that cannot honour the mode - exFAT, an SMB mount - would otherwise make this
+		// hardening a silent no-op.
+		if ( ! \chmod( $path, 0600 ) ) {
+			$output->writeln( "<comment>Could not restrict permissions on $path. Other users of this machine may be able to read the dump.</comment>" );
 		}
 	}
 

--- a/commands/Pressable_Site_Database_Download.php
+++ b/commands/Pressable_Site_Database_Download.php
@@ -54,6 +54,8 @@ final class Pressable_Site_Database_Download extends Command {
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * @throws  \InvalidArgumentException If the destination directory does not exist or is not writable.
 	 */
 	protected function initialize( InputInterface $input, OutputInterface $output ): void {
 		$this->site = get_pressable_site_input( $input, fn() => $this->prompt_site_input( $input, $output ) );
@@ -61,6 +63,12 @@ final class Pressable_Site_Database_Download extends Command {
 
 		$this->destination = get_string_input( $input, 'destination', fn() => $this->prompt_destination_input( $input, $output ) );
 		$input->setOption( 'destination', $this->destination );
+
+		// Fail here rather than after spending minutes on the remote export and transfer.
+		$destination_dir = \dirname( $this->destination );
+		if ( ! \is_dir( $destination_dir ) || ! \is_writable( $destination_dir ) ) {
+			throw new \InvalidArgumentException( "The destination directory $destination_dir does not exist or is not writable." );
+		}
 	}
 
 	/**
@@ -77,15 +85,15 @@ final class Pressable_Site_Database_Download extends Command {
 			"tmp/$dump_filename",
 		);
 		$remote_cleanup_error = false;
-		$dump_created         = false;
 		$download_successful  = false;
 		$download_valid       = false;
+		$remote_size          = null;
 
 		// Keep the compressed dump next to the destination so the decompression step below is a plain
-		// local file copy. Downloading straight to the destination would leave a gzipped file behind
-		// under a `.sql` name if the process died between transfer and decompression.
+		// local file copy. The temp name is scoped to this process because a plain `<destination>.gz`
+		// would overwrite - and then delete - a compressed dump the user deliberately kept earlier.
 		$keep_compressed = \str_ends_with( \strtolower( $this->destination ), '.gz' );
-		$local_gz_path   = $keep_compressed ? $this->destination : $this->destination . '.gz';
+		$local_gz_path   = $keep_compressed ? $this->destination : $this->destination . '.' . \getmypid() . '.gz';
 
 		$dump_ssh = \Pressable_Connection_Helper::get_ssh_connection( (string) $this->site->id );
 		if ( \is_null( $dump_ssh ) ) {
@@ -98,11 +106,14 @@ final class Pressable_Site_Database_Download extends Command {
 
 			// Run wp from the login directory: wp-cli resolves the site path from the host's own
 			// config there, and cd-ing into htdocs first breaks that resolution.
+			// umask 077 because, unlike a plugin archive, this dump holds password hashes, auth tokens
+			// and customer PII, and it sits in a shared /tmp for the whole export and transfer.
 			// --single-transaction keeps the export from locking a live production database.
-			$dump_command = 'if [ -d /tmp ]; then dump_path=' . escapeshellarg( $remote_dump_paths[0] ) . '; else dump_path=' . escapeshellarg( $remote_dump_paths[1] ) . '; fi; '
+			$dump_command = 'umask 077; '
+				. 'if [ -d /tmp ]; then dump_path=' . escapeshellarg( $remote_dump_paths[0] ) . '; else dump_path=' . escapeshellarg( $remote_dump_paths[1] ) . '; fi; '
 				. 'wp db export "${dump_path%.gz}" --add-drop-table --single-transaction && '
 				. 'gzip -f "${dump_path%.gz}"; '
-				. 'exit $? 2>&1';
+				. 'exit $?';
 			$dump_ssh->exec( $dump_command );
 			if ( 0 !== $dump_ssh->getExitStatus() ) {
 				$output->writeln( '<error>Failed to create the remote database dump.</error>' );
@@ -112,45 +123,51 @@ final class Pressable_Site_Database_Download extends Command {
 			$dump_ssh->disconnect();
 		}
 
-		$dump_created = true;
-
 		$sftp = \Pressable_Connection_Helper::get_sftp_connection( (string) $this->site->id );
 		if ( ! \is_null( $sftp ) ) {
 			try {
 				$sftp->setTimeout( 0 );
 
 				foreach ( $remote_dump_paths as $sftp_path ) {
+					$remote_stat = $sftp->stat( $sftp_path );
+					if ( false === $remote_stat ) {
+						continue;
+					}
+
 					if ( $sftp->get( $sftp_path, $local_gz_path ) ) {
 						$download_successful = true;
+						$remote_size         = $remote_stat['size'] ?? null;
 						break;
 					}
 				}
 
-				$download_valid = $download_successful && \is_file( $local_gz_path ) && 0 < \filesize( $local_gz_path );
+				// Compare against the remote size so a short transfer fails while the remote dump,
+				// which is deleted immediately below, is still recoverable.
+				$download_valid = $download_successful && \is_file( $local_gz_path ) && 0 < \filesize( $local_gz_path )
+					&& ( \is_null( $remote_size ) || \filesize( $local_gz_path ) === $remote_size );
 			} finally {
 				$sftp->disconnect();
 			}
 		}
 
-		if ( $dump_created ) { // Always cleanup after dump creation.
-			$cleanup_ssh = \Pressable_Connection_Helper::get_ssh_connection( (string) $this->site->id );
-			if ( \is_null( $cleanup_ssh ) ) {
-				$remote_cleanup_error = true;
-			} else {
-				try {
-					$cleanup_ssh->setTimeout( 0 );
-					$cleanup_command = 'rm -f '
-						. escapeshellarg( $remote_dump_paths[0] )
-						. ' '
-						. escapeshellarg( $remote_dump_paths[1] )
-						. ' 2>&1';
-					$cleanup_ssh->exec( $cleanup_command );
-					if ( 0 !== $cleanup_ssh->getExitStatus() ) {
-						$remote_cleanup_error = true;
-					}
-				} finally {
-					$cleanup_ssh->disconnect();
+		// Always cleanup: the dump exists on the server from this point on, whatever happened above.
+		$cleanup_ssh = \Pressable_Connection_Helper::get_ssh_connection( (string) $this->site->id );
+		if ( \is_null( $cleanup_ssh ) ) {
+			$remote_cleanup_error = true;
+		} else {
+			try {
+				$cleanup_ssh->setTimeout( 0 );
+				$cleanup_command = 'rm -f '
+					. escapeshellarg( $remote_dump_paths[0] )
+					. ' '
+					. escapeshellarg( $remote_dump_paths[1] )
+					. ' 2>&1';
+				$cleanup_ssh->exec( $cleanup_command );
+				if ( 0 !== $cleanup_ssh->getExitStatus() ) {
+					$remote_cleanup_error = true;
 				}
+			} finally {
+				$cleanup_ssh->disconnect();
 			}
 		}
 
@@ -160,12 +177,14 @@ final class Pressable_Site_Database_Download extends Command {
 		}
 
 		if ( ! $download_successful ) {
+			$this->discard_temp_archive( $keep_compressed, $local_gz_path );
 			$output->writeln( '<error>Failed to download the database dump via SFTP.</error>' );
 			return Command::FAILURE;
 		}
 
 		if ( ! $download_valid ) {
-			$output->writeln( '<error>Downloaded database dump appears invalid or empty.</error>' );
+			$this->discard_temp_archive( $keep_compressed, $local_gz_path );
+			$output->writeln( '<error>Downloaded database dump is truncated or empty.</error>' );
 			return Command::FAILURE;
 		}
 
@@ -186,6 +205,21 @@ final class Pressable_Site_Database_Download extends Command {
 	// endregion
 
 	// region HELPERS
+
+	/**
+	 * Removes the process-scoped compressed download after a failure. Skipped when the user asked to
+	 * keep the compressed file, since that path is their own destination rather than a temp file.
+	 *
+	 * @param   boolean $keep_compressed Whether the destination is itself the compressed file.
+	 * @param   string  $local_gz_path   The path the archive was downloaded to.
+	 *
+	 * @return  void
+	 */
+	private function discard_temp_archive( bool $keep_compressed, string $local_gz_path ): void {
+		if ( ! $keep_compressed && \is_file( $local_gz_path ) ) {
+			\unlink( $local_gz_path );
+		}
+	}
 
 	/**
 	 * Prompts the user for a site.

--- a/commands/Pressable_Site_Database_Download.php
+++ b/commands/Pressable_Site_Database_Download.php
@@ -77,17 +77,17 @@ final class Pressable_Site_Database_Download extends Command {
 	protected function execute( InputInterface $input, OutputInterface $output ): int {
 		$output->writeln( "<fg=magenta;options=bold>Downloading the database from Pressable site {$this->site->displayName} (ID {$this->site->id}, URL {$this->site->url}) to {$this->destination}.</>" );
 
-		$site_slug            = slugify( (string) $this->site->name );
-		$timestamp            = \gmdate( 'Y-m-d-H-i-s' );
-		$dump_filename        = "team51-pressable-db-$site_slug-$timestamp.sql.gz";
-		$remote_dump_paths    = array(
+		$site_slug           = slugify( (string) $this->site->name );
+		$timestamp           = \gmdate( 'Y-m-d-H-i-s' );
+		$dump_filename       = "team51-pressable-db-$site_slug-$timestamp.sql.gz";
+		$remote_dump_paths   = array(
 			"/tmp/$dump_filename",
 			"tmp/$dump_filename",
 		);
-		$remote_cleanup_error = false;
-		$download_successful  = false;
-		$download_valid       = false;
-		$remote_size          = null;
+		$dump_failed         = false;
+		$download_successful = false;
+		$download_valid      = false;
+		$remote_size         = null;
 
 		// Keep the compressed dump next to the destination so the decompression step below is a plain
 		// local file copy. The temp name is scoped to this process because a plain `<destination>.gz`
@@ -115,12 +115,19 @@ final class Pressable_Site_Database_Download extends Command {
 				. 'gzip -f "${dump_path%.gz}"; '
 				. 'exit $?';
 			$dump_ssh->exec( $dump_command );
-			if ( 0 !== $dump_ssh->getExitStatus() ) {
-				$output->writeln( '<error>Failed to create the remote database dump.</error>' );
-				return Command::FAILURE;
-			}
+			$dump_failed = ( 0 !== $dump_ssh->getExitStatus() );
 		} finally {
 			$dump_ssh->disconnect();
+		}
+
+		if ( $dump_failed ) {
+			// `wp db export` may have written the plaintext dump before `gzip` failed, so sweep before leaving.
+			$output->writeln( '<error>Failed to create the remote database dump.</error>' );
+			if ( ! $this->remove_remote_dumps( $remote_dump_paths ) ) {
+				$output->writeln( "<error>Anything it left behind is still on the server at {$remote_dump_paths[0]} or its .sql counterpart; remove it manually.</error>" );
+			}
+
+			return Command::FAILURE;
 		}
 
 		$sftp = \Pressable_Connection_Helper::get_sftp_connection( (string) $this->site->id );
@@ -141,8 +148,8 @@ final class Pressable_Site_Database_Download extends Command {
 					}
 				}
 
-				// Compare against the remote size so a short transfer fails while the remote dump,
-				// which is deleted immediately below, is still recoverable.
+				// Compare against the remote size so a short transfer is caught while the remote dump,
+				// which is only deleted once the local copy is known good, can still be re-fetched.
 				$download_valid = $download_successful && \is_file( $local_gz_path ) && 0 < \filesize( $local_gz_path )
 					&& ( \is_null( $remote_size ) || \filesize( $local_gz_path ) === $remote_size );
 			} finally {
@@ -150,51 +157,35 @@ final class Pressable_Site_Database_Download extends Command {
 			}
 		}
 
-		// Always cleanup: the dump exists on the server from this point on, whatever happened above.
-		$cleanup_ssh = \Pressable_Connection_Helper::get_ssh_connection( (string) $this->site->id );
-		if ( \is_null( $cleanup_ssh ) ) {
-			$remote_cleanup_error = true;
-		} else {
-			try {
-				$cleanup_ssh->setTimeout( 0 );
-				$cleanup_command = 'rm -f '
-					. escapeshellarg( $remote_dump_paths[0] )
-					. ' '
-					. escapeshellarg( $remote_dump_paths[1] )
-					. ' 2>&1';
-				$cleanup_ssh->exec( $cleanup_command );
-				if ( 0 !== $cleanup_ssh->getExitStatus() ) {
-					$remote_cleanup_error = true;
-				}
-			} finally {
-				$cleanup_ssh->disconnect();
-			}
-		}
-
 		if ( \is_null( $sftp ) ) {
-			$output->writeln( '<error>Failed to connect to the site via SFTP.</error>' );
+			$output->writeln( "<error>Failed to connect to the site via SFTP. The dump is still at {$remote_dump_paths[0]} on the server.</error>" );
 			return Command::FAILURE;
 		}
 
 		if ( ! $download_successful ) {
 			$this->discard_temp_archive( $keep_compressed, $local_gz_path );
-			$output->writeln( '<error>Failed to download the database dump via SFTP.</error>' );
+			$output->writeln( "<error>Failed to download the database dump via SFTP. The dump is still at {$remote_dump_paths[0]} on the server.</error>" );
 			return Command::FAILURE;
 		}
 
 		if ( ! $download_valid ) {
 			$this->discard_temp_archive( $keep_compressed, $local_gz_path );
-			$output->writeln( '<error>Downloaded database dump is truncated or empty.</error>' );
+			$output->writeln( "<error>Downloaded database dump is truncated. The remote dump has been kept at {$remote_dump_paths[0]} so the transfer can be retried without re-exporting.</error>" );
 			return Command::FAILURE;
 		}
 
-		if ( ! $keep_compressed && ! decompress_gzip_file( $local_gz_path, $this->destination ) ) {
-			$output->writeln( "<error>Failed to decompress the downloaded dump. The compressed file is still at $local_gz_path.</error>" );
-			return Command::FAILURE;
+		if ( ! $keep_compressed ) {
+			if ( ! decompress_gzip_file( $local_gz_path, $this->destination ) ) {
+				$output->writeln( "<error>Failed to decompress the downloaded dump. The compressed copy is at $local_gz_path and the remote dump at {$remote_dump_paths[0]}.</error>" );
+				return Command::FAILURE;
+			}
+
+			$this->discard_temp_archive( $keep_compressed, $local_gz_path );
 		}
 
-		if ( $remote_cleanup_error ) {
-			$output->writeln( '<error>Database downloaded, but failed to clean up the temporary remote dump.</error>' );
+		// Only now is the local copy known good, so the remote dump can go.
+		if ( ! $this->remove_remote_dumps( $remote_dump_paths ) ) {
+			$output->writeln( "<error>Database downloaded to {$this->destination}, but the temporary remote dump at {$remote_dump_paths[0]} could not be removed. Delete it manually - it holds password hashes and customer data.</error>" );
 			return Command::FAILURE;
 		}
 
@@ -218,6 +209,37 @@ final class Pressable_Site_Database_Download extends Command {
 	private function discard_temp_archive( bool $keep_compressed, string $local_gz_path ): void {
 		if ( ! $keep_compressed && \is_file( $local_gz_path ) ) {
 			\unlink( $local_gz_path );
+		}
+	}
+
+	/**
+	 * Removes the temporary dump from the server. Targets the plaintext `.sql` as well as the gzipped
+	 * path, because a failure between `wp db export` and `gzip` leaves the uncompressed dump - password
+	 * hashes, auth tokens and customer PII - sitting in a shared /tmp with nothing else to clean it up.
+	 *
+	 * @param   string[] $remote_dump_paths The candidate remote paths of the gzipped dump.
+	 *
+	 * @return  boolean
+	 */
+	private function remove_remote_dumps( array $remote_dump_paths ): bool {
+		$cleanup_ssh = \Pressable_Connection_Helper::get_ssh_connection( (string) $this->site->id );
+		if ( \is_null( $cleanup_ssh ) ) {
+			return false;
+		}
+
+		try {
+			$cleanup_ssh->setTimeout( 0 );
+
+			$targets = array();
+			foreach ( $remote_dump_paths as $path ) {
+				$targets[] = escapeshellarg( $path );
+				$targets[] = escapeshellarg( \preg_replace( '/\.gz$/', '', $path ) );
+			}
+
+			$cleanup_ssh->exec( 'rm -f ' . \implode( ' ', $targets ) . ' 2>&1' );
+			return 0 === $cleanup_ssh->getExitStatus();
+		} finally {
+			$cleanup_ssh->disconnect();
 		}
 	}
 

--- a/commands/Pressable_Site_Database_Download.php
+++ b/commands/Pressable_Site_Database_Download.php
@@ -65,6 +65,10 @@ final class Pressable_Site_Database_Download extends Command {
 		$input->setOption( 'destination', $this->destination );
 
 		// Fail here rather than after spending minutes on the remote export and transfer.
+		if ( \is_dir( $this->destination ) ) {
+			throw new \InvalidArgumentException( "The destination {$this->destination} is a directory. Pass the full path of the file to write." );
+		}
+
 		$destination_dir = \dirname( $this->destination );
 		if ( ! \is_dir( $destination_dir ) || ! \is_writable( $destination_dir ) ) {
 			throw new \InvalidArgumentException( "The destination directory $destination_dir does not exist or is not writable." );
@@ -88,12 +92,13 @@ final class Pressable_Site_Database_Download extends Command {
 		$download_successful = false;
 		$download_valid      = false;
 		$remote_size         = null;
+		$used_remote_path    = $remote_dump_paths[0];
 
-		// Keep the compressed dump next to the destination so the decompression step below is a plain
-		// local file copy. The temp name is scoped to this process because a plain `<destination>.gz`
-		// would overwrite - and then delete - a compressed dump the user deliberately kept earlier.
+		// Always transfer into a process-scoped temp file and only move it onto the destination once the
+		// download has been verified. Writing straight to the destination would let a dropped connection
+		// replace an earlier dump - possibly the last copy of a deleted site - with a partial one.
 		$keep_compressed = \str_ends_with( \strtolower( $this->destination ), '.gz' );
-		$local_gz_path   = $keep_compressed ? $this->destination : $this->destination . '.' . \getmypid() . '.gz';
+		$local_gz_path   = $this->destination . '.' . \getmypid() . '.gz';
 
 		$dump_ssh = \Pressable_Connection_Helper::get_ssh_connection( (string) $this->site->id );
 		if ( \is_null( $dump_ssh ) ) {
@@ -141,7 +146,11 @@ final class Pressable_Site_Database_Download extends Command {
 						continue;
 					}
 
+					// The dump is here, so this is the path to name in any recovery message from now on.
+					$used_remote_path = $sftp_path;
+
 					if ( $sftp->get( $sftp_path, $local_gz_path ) ) {
+						\chmod( $local_gz_path, 0600 );
 						$download_successful = true;
 						$remote_size         = $remote_stat['size'] ?? null;
 						break;
@@ -158,34 +167,44 @@ final class Pressable_Site_Database_Download extends Command {
 		}
 
 		if ( \is_null( $sftp ) ) {
-			$output->writeln( "<error>Failed to connect to the site via SFTP. The dump is still at {$remote_dump_paths[0]} on the server.</error>" );
+			$output->writeln( "<error>Failed to connect to the site via SFTP. The dump is still at $used_remote_path on the server.</error>" );
 			return Command::FAILURE;
 		}
 
 		if ( ! $download_successful ) {
-			$this->discard_temp_archive( $keep_compressed, $local_gz_path );
-			$output->writeln( "<error>Failed to download the database dump via SFTP. The dump is still at {$remote_dump_paths[0]} on the server.</error>" );
+			$this->discard_temp_archive( $output, $local_gz_path );
+			$output->writeln( "<error>Failed to download the database dump via SFTP. The dump is still at $used_remote_path on the server.</error>" );
 			return Command::FAILURE;
+		}
+
+		if ( \is_null( $remote_size ) ) {
+			$output->writeln( '<comment>The server did not report the dump size, so the transfer could not be checked for truncation.</comment>' );
 		}
 
 		if ( ! $download_valid ) {
-			$this->discard_temp_archive( $keep_compressed, $local_gz_path );
-			$output->writeln( "<error>Downloaded database dump is truncated. The remote dump has been kept at {$remote_dump_paths[0]} so the transfer can be retried without re-exporting.</error>" );
+			$this->discard_temp_archive( $output, $local_gz_path );
+			$output->writeln( "<error>Downloaded database dump is truncated. The remote dump has been kept at $used_remote_path so the transfer can be retried without re-exporting.</error>" );
 			return Command::FAILURE;
 		}
 
-		if ( ! $keep_compressed ) {
+		if ( $keep_compressed ) {
+			if ( ! \rename( $local_gz_path, $this->destination ) ) {
+				$this->discard_temp_archive( $output, $local_gz_path );
+				$output->writeln( "<error>Failed to move the downloaded archive to {$this->destination}. The remote dump is still at $used_remote_path.</error>" );
+				return Command::FAILURE;
+			}
+		} else {
 			if ( ! decompress_gzip_file( $local_gz_path, $this->destination ) ) {
-				$output->writeln( "<error>Failed to decompress the downloaded dump. The compressed copy is at $local_gz_path and the remote dump at {$remote_dump_paths[0]}.</error>" );
+				$output->writeln( "<error>Failed to decompress the downloaded dump. The compressed copy is at $local_gz_path and the remote dump at $used_remote_path.</error>" );
 				return Command::FAILURE;
 			}
 
-			$this->discard_temp_archive( $keep_compressed, $local_gz_path );
+			$this->discard_temp_archive( $output, $local_gz_path );
 		}
 
 		// Only now is the local copy known good, so the remote dump can go.
 		if ( ! $this->remove_remote_dumps( $remote_dump_paths ) ) {
-			$output->writeln( "<error>Database downloaded to {$this->destination}, but the temporary remote dump at {$remote_dump_paths[0]} could not be removed. Delete it manually - it holds password hashes and customer data.</error>" );
+			$output->writeln( "<error>Database downloaded to {$this->destination}, but the temporary remote dump at $used_remote_path could not be removed. Delete it manually - it holds password hashes and customer data.</error>" );
 			return Command::FAILURE;
 		}
 
@@ -198,17 +217,16 @@ final class Pressable_Site_Database_Download extends Command {
 	// region HELPERS
 
 	/**
-	 * Removes the process-scoped compressed download after a failure. Skipped when the user asked to
-	 * keep the compressed file, since that path is their own destination rather than a temp file.
+	 * Removes the process-scoped compressed download.
 	 *
-	 * @param   boolean $keep_compressed Whether the destination is itself the compressed file.
-	 * @param   string  $local_gz_path   The path the archive was downloaded to.
+	 * @param   OutputInterface $output        The output object.
+	 * @param   string          $local_gz_path The path the archive was downloaded to.
 	 *
 	 * @return  void
 	 */
-	private function discard_temp_archive( bool $keep_compressed, string $local_gz_path ): void {
-		if ( ! $keep_compressed && \is_file( $local_gz_path ) ) {
-			\unlink( $local_gz_path );
+	private function discard_temp_archive( OutputInterface $output, string $local_gz_path ): void {
+		if ( \is_file( $local_gz_path ) && ! \unlink( $local_gz_path ) ) {
+			$output->writeln( "<comment>Could not remove the temporary archive at $local_gz_path. Delete it manually - it holds a copy of the database.</comment>" );
 		}
 	}
 

--- a/commands/Pressable_Site_Database_Download.php
+++ b/commands/Pressable_Site_Database_Download.php
@@ -1,0 +1,236 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WPCOMSpecialProjects\CLI\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use WPCOMSpecialProjects\CLI\Helper\AutocompleteTrait;
+
+/**
+ * Downloads a SQL dump of the database from a Pressable site.
+ */
+#[AsCommand( name: 'pressable:download-site-database' )]
+final class Pressable_Site_Database_Download extends Command {
+	use AutocompleteTrait;
+
+	// region FIELDS AND CONSTANTS
+
+	/**
+	 * Pressable site definition to download the database from.
+	 *
+	 * @var \stdClass|null
+	 */
+	private ?\stdClass $site = null;
+
+	/**
+	 * Local path to save the dump to.
+	 *
+	 * @var string|null
+	 */
+	private ?string $destination = null;
+
+	// endregion
+
+	// region INHERITED METHODS
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function configure(): void {
+		$this->setDescription( 'Download a SQL dump of the database from a Pressable site.' )
+			->setHelp( 'Use this command to export and download the database of a Pressable site. The dump is gzipped on the server before transfer, and decompressed locally unless the destination ends in `.gz`.' );
+
+		$this->addArgument( 'site', InputArgument::REQUIRED, 'Domain or Pressable site ID to download the database from.' )
+			->addOption( 'destination', null, InputOption::VALUE_REQUIRED, 'The destination path where the SQL dump will be saved. Ends in `.gz` to keep it compressed.' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function initialize( InputInterface $input, OutputInterface $output ): void {
+		$this->site = get_pressable_site_input( $input, fn() => $this->prompt_site_input( $input, $output ) );
+		$input->setArgument( 'site', $this->site );
+
+		$this->destination = get_string_input( $input, 'destination', fn() => $this->prompt_destination_input( $input, $output ) );
+		$input->setOption( 'destination', $this->destination );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( InputInterface $input, OutputInterface $output ): int {
+		$output->writeln( "<fg=magenta;options=bold>Downloading the database from Pressable site {$this->site->displayName} (ID {$this->site->id}, URL {$this->site->url}) to {$this->destination}.</>" );
+
+		$site_slug            = slugify( (string) $this->site->name );
+		$timestamp            = \gmdate( 'Y-m-d-H-i-s' );
+		$dump_filename        = "team51-pressable-db-$site_slug-$timestamp.sql.gz";
+		$remote_dump_paths    = array(
+			"/tmp/$dump_filename",
+			"tmp/$dump_filename",
+		);
+		$remote_cleanup_error = false;
+		$dump_created         = false;
+		$download_successful  = false;
+		$download_valid       = false;
+
+		// Keep the compressed dump next to the destination so the decompression step below is a plain
+		// local file copy. Downloading straight to the destination would leave a gzipped file behind
+		// under a `.sql` name if the process died between transfer and decompression.
+		$keep_compressed = \str_ends_with( \strtolower( $this->destination ), '.gz' );
+		$local_gz_path   = $keep_compressed ? $this->destination : $this->destination . '.gz';
+
+		$dump_ssh = \Pressable_Connection_Helper::get_ssh_connection( (string) $this->site->id );
+		if ( \is_null( $dump_ssh ) ) {
+			$output->writeln( '<error>Failed to connect to the site via SSH.</error>' );
+			return Command::FAILURE;
+		}
+
+		try {
+			$dump_ssh->setTimeout( 0 );
+
+			// Run wp from the login directory: wp-cli resolves the site path from the host's own
+			// config there, and cd-ing into htdocs first breaks that resolution.
+			// --single-transaction keeps the export from locking a live production database.
+			$dump_command = 'if [ -d /tmp ]; then dump_path=' . escapeshellarg( $remote_dump_paths[0] ) . '; else dump_path=' . escapeshellarg( $remote_dump_paths[1] ) . '; fi; '
+				. 'wp db export "${dump_path%.gz}" --add-drop-table --single-transaction && '
+				. 'gzip -f "${dump_path%.gz}"; '
+				. 'exit $? 2>&1';
+			$dump_ssh->exec( $dump_command );
+			if ( 0 !== $dump_ssh->getExitStatus() ) {
+				$output->writeln( '<error>Failed to create the remote database dump.</error>' );
+				return Command::FAILURE;
+			}
+		} finally {
+			$dump_ssh->disconnect();
+		}
+
+		$dump_created = true;
+
+		$sftp = \Pressable_Connection_Helper::get_sftp_connection( (string) $this->site->id );
+		if ( ! \is_null( $sftp ) ) {
+			try {
+				$sftp->setTimeout( 0 );
+
+				foreach ( $remote_dump_paths as $sftp_path ) {
+					if ( $sftp->get( $sftp_path, $local_gz_path ) ) {
+						$download_successful = true;
+						break;
+					}
+				}
+
+				$download_valid = $download_successful && \is_file( $local_gz_path ) && 0 < \filesize( $local_gz_path );
+			} finally {
+				$sftp->disconnect();
+			}
+		}
+
+		if ( $dump_created ) { // Always cleanup after dump creation.
+			$cleanup_ssh = \Pressable_Connection_Helper::get_ssh_connection( (string) $this->site->id );
+			if ( \is_null( $cleanup_ssh ) ) {
+				$remote_cleanup_error = true;
+			} else {
+				try {
+					$cleanup_ssh->setTimeout( 0 );
+					$cleanup_command = 'rm -f '
+						. escapeshellarg( $remote_dump_paths[0] )
+						. ' '
+						. escapeshellarg( $remote_dump_paths[1] )
+						. ' 2>&1';
+					$cleanup_ssh->exec( $cleanup_command );
+					if ( 0 !== $cleanup_ssh->getExitStatus() ) {
+						$remote_cleanup_error = true;
+					}
+				} finally {
+					$cleanup_ssh->disconnect();
+				}
+			}
+		}
+
+		if ( \is_null( $sftp ) ) {
+			$output->writeln( '<error>Failed to connect to the site via SFTP.</error>' );
+			return Command::FAILURE;
+		}
+
+		if ( ! $download_successful ) {
+			$output->writeln( '<error>Failed to download the database dump via SFTP.</error>' );
+			return Command::FAILURE;
+		}
+
+		if ( ! $download_valid ) {
+			$output->writeln( '<error>Downloaded database dump appears invalid or empty.</error>' );
+			return Command::FAILURE;
+		}
+
+		if ( ! $keep_compressed && ! decompress_gzip_file( $local_gz_path, $this->destination ) ) {
+			$output->writeln( "<error>Failed to decompress the downloaded dump. The compressed file is still at $local_gz_path.</error>" );
+			return Command::FAILURE;
+		}
+
+		if ( $remote_cleanup_error ) {
+			$output->writeln( '<error>Database downloaded, but failed to clean up the temporary remote dump.</error>' );
+			return Command::FAILURE;
+		}
+
+		$output->writeln( "<fg=green;options=bold>Database downloaded successfully to {$this->destination}.</>" );
+		return Command::SUCCESS;
+	}
+
+	// endregion
+
+	// region HELPERS
+
+	/**
+	 * Prompts the user for a site.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  string|null
+	 */
+	private function prompt_site_input( InputInterface $input, OutputInterface $output ): ?string {
+		$question = new Question( '<question>Enter the domain or Pressable site ID to download the database from:</question> ' );
+		if ( ! $input->getOption( 'no-autocomplete' ) ) {
+			$question->setAutocompleterValues( \array_column( get_pressable_sites( include_aliases: true ) ?? array(), 'url' ) );
+		}
+
+		/**
+		 * The Symfony question helper.
+		 *
+		 * @var QuestionHelper $question_helper
+		 */
+		$question_helper = $this->getHelper( 'question' );
+		return $question_helper->ask( $input, $output, $question );
+	}
+
+	/**
+	 * Prompts the user for destination path.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  string|null
+	 */
+	private function prompt_destination_input( InputInterface $input, OutputInterface $output ): ?string {
+		$site_slug = \is_null( $this->site ) ? 'unknown-site' : slugify( (string) $this->site->name );
+		$default   = get_user_folder_path( "Downloads/pressable-db-$site_slug-" . \gmdate( 'Y-m-d-H-i-s' ) . '.sql' );
+		$question  = new Question( "<question>Please enter the path to save the database dump [$default]:</question> ", $default );
+
+		/**
+		 * The Symfony question helper.
+		 *
+		 * @var QuestionHelper $question_helper
+		 */
+		$question_helper = $this->getHelper( 'question' );
+		return $question_helper->ask( $input, $output, $question );
+	}
+
+	// endregion
+}

--- a/commands/WPCOM_Site_Database_Download.php
+++ b/commands/WPCOM_Site_Database_Download.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WPCOMSpecialProjects\CLI\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\QuestionHelper;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\Question;
+use WPCOMSpecialProjects\CLI\Helper\AutocompleteTrait;
+
+/**
+ * Downloads a SQL dump of the database from a WPCOM site.
+ */
+#[AsCommand( name: 'wpcom:download-site-database' )]
+final class WPCOM_Site_Database_Download extends Command {
+	use AutocompleteTrait;
+
+	// region FIELDS AND CONSTANTS
+
+	/**
+	 * WPCOM site definition to download the database from.
+	 *
+	 * @var \stdClass|null
+	 */
+	private ?\stdClass $site = null;
+
+	/**
+	 * Local path to save the dump to.
+	 *
+	 * @var string|null
+	 */
+	private ?string $destination = null;
+
+	// endregion
+
+	// region INHERITED METHODS
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function configure(): void {
+		$this->setDescription( 'Download a SQL dump of the database from a WPCOM site.' )
+			->setHelp( 'Use this command to export and download the database of a WPCOM site. The dump is gzipped on the server before transfer, and decompressed locally unless the destination ends in `.gz`.' );
+
+		$this->addArgument( 'site', InputArgument::REQUIRED, 'Domain or WPCOM site ID to download the database from.' )
+			->addOption( 'destination', null, InputOption::VALUE_REQUIRED, 'The destination path where the SQL dump will be saved. Ends in `.gz` to keep it compressed.' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function initialize( InputInterface $input, OutputInterface $output ): void {
+		$this->site = get_wpcom_site_input( $input, fn() => $this->prompt_site_input( $input, $output ) );
+		$input->setArgument( 'site', $this->site );
+
+		$this->destination = get_string_input( $input, 'destination', fn() => $this->prompt_destination_input( $input, $output ) );
+		$input->setOption( 'destination', $this->destination );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( InputInterface $input, OutputInterface $output ): int {
+		$output->writeln( "<fg=magenta;options=bold>Downloading the database from WPCOM site {$this->site->name} (ID {$this->site->ID}, URL {$this->site->URL}) to {$this->destination}.</>" );
+
+		$site_slug            = slugify( (string) $this->site->name );
+		$timestamp            = \gmdate( 'Y-m-d-H-i-s' );
+		$dump_filename        = "team51-wpcom-db-$site_slug-$timestamp.sql.gz";
+		$remote_dump_paths    = array(
+			"/tmp/$dump_filename",
+			"tmp/$dump_filename",
+		);
+		$remote_cleanup_error = false;
+		$dump_created         = false;
+		$download_successful  = false;
+		$download_valid       = false;
+
+		// Keep the compressed dump next to the destination so the decompression step below is a plain
+		// local file copy. Downloading straight to the destination would leave a gzipped file behind
+		// under a `.sql` name if the process died between transfer and decompression.
+		$keep_compressed = \str_ends_with( \strtolower( $this->destination ), '.gz' );
+		$local_gz_path   = $keep_compressed ? $this->destination : $this->destination . '.gz';
+
+		$dump_ssh = \WPCOM_Connection_Helper::get_ssh_connection( (string) $this->site->ID );
+		if ( \is_null( $dump_ssh ) ) {
+			$output->writeln( '<error>Failed to connect to the site via SSH.</error>' );
+			return Command::FAILURE;
+		}
+
+		try {
+			$dump_ssh->setTimeout( 0 );
+
+			// Run wp from the login directory: wp-cli resolves the site path from the host's own
+			// config there, and cd-ing into htdocs first breaks that resolution.
+			// --single-transaction keeps the export from locking a live production database.
+			$dump_command = 'if [ -d /tmp ]; then dump_path=' . escapeshellarg( $remote_dump_paths[0] ) . '; else dump_path=' . escapeshellarg( $remote_dump_paths[1] ) . '; fi; '
+				. 'wp db export "${dump_path%.gz}" --add-drop-table --single-transaction && '
+				. 'gzip -f "${dump_path%.gz}"; '
+				. 'exit $? 2>&1';
+			$dump_ssh->exec( $dump_command );
+			if ( 0 !== $dump_ssh->getExitStatus() ) {
+				$output->writeln( '<error>Failed to create the remote database dump.</error>' );
+				return Command::FAILURE;
+			}
+		} finally {
+			$dump_ssh->disconnect();
+		}
+
+		$dump_created = true;
+
+		$sftp = \WPCOM_Connection_Helper::get_sftp_connection( (string) $this->site->ID );
+		if ( ! \is_null( $sftp ) ) {
+			try {
+				$sftp->setTimeout( 0 );
+
+				foreach ( $remote_dump_paths as $sftp_path ) {
+					if ( $sftp->get( $sftp_path, $local_gz_path ) ) {
+						$download_successful = true;
+						break;
+					}
+				}
+
+				$download_valid = $download_successful && \is_file( $local_gz_path ) && 0 < \filesize( $local_gz_path );
+			} finally {
+				$sftp->disconnect();
+			}
+		}
+
+		if ( $dump_created ) { // Always cleanup after dump creation.
+			$cleanup_ssh = \WPCOM_Connection_Helper::get_ssh_connection( (string) $this->site->ID );
+			if ( \is_null( $cleanup_ssh ) ) {
+				$remote_cleanup_error = true;
+			} else {
+				try {
+					$cleanup_ssh->setTimeout( 0 );
+					$cleanup_command = 'rm -f '
+						. escapeshellarg( $remote_dump_paths[0] )
+						. ' '
+						. escapeshellarg( $remote_dump_paths[1] )
+						. ' 2>&1';
+					$cleanup_ssh->exec( $cleanup_command );
+					if ( 0 !== $cleanup_ssh->getExitStatus() ) {
+						$remote_cleanup_error = true;
+					}
+				} finally {
+					$cleanup_ssh->disconnect();
+				}
+			}
+		}
+
+		if ( \is_null( $sftp ) ) {
+			$output->writeln( '<error>Failed to connect to the site via SFTP.</error>' );
+			return Command::FAILURE;
+		}
+
+		if ( ! $download_successful ) {
+			$output->writeln( '<error>Failed to download the database dump via SFTP.</error>' );
+			return Command::FAILURE;
+		}
+
+		if ( ! $download_valid ) {
+			$output->writeln( '<error>Downloaded database dump appears invalid or empty.</error>' );
+			return Command::FAILURE;
+		}
+
+		if ( ! $keep_compressed && ! decompress_gzip_file( $local_gz_path, $this->destination ) ) {
+			$output->writeln( "<error>Failed to decompress the downloaded dump. The compressed file is still at $local_gz_path.</error>" );
+			return Command::FAILURE;
+		}
+
+		if ( $remote_cleanup_error ) {
+			$output->writeln( '<error>Database downloaded, but failed to clean up the temporary remote dump.</error>' );
+			return Command::FAILURE;
+		}
+
+		$output->writeln( "<fg=green;options=bold>Database downloaded successfully to {$this->destination}.</>" );
+		return Command::SUCCESS;
+	}
+
+	// endregion
+
+	// region HELPERS
+
+	/**
+	 * Prompts the user for a site.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  string|null
+	 */
+	private function prompt_site_input( InputInterface $input, OutputInterface $output ): ?string {
+		$question = new Question( '<question>Enter the domain or WPCOM site ID to download the database from:</question> ' );
+		if ( ! $input->getOption( 'no-autocomplete' ) ) {
+			$question->setAutocompleterValues(
+				\array_map(
+					static fn( string $url ) => \parse_url( $url, PHP_URL_HOST ),
+					\array_column( get_wpcom_sites( array( 'fields' => 'ID,URL' ) ) ?? array(), 'URL' )
+				)
+			);
+		}
+
+		/**
+		 * The Symfony question helper.
+		 *
+		 * @var QuestionHelper $question_helper
+		 */
+		$question_helper = $this->getHelper( 'question' );
+		return $question_helper->ask( $input, $output, $question );
+	}
+
+	/**
+	 * Prompts the user for destination path.
+	 *
+	 * @param   InputInterface  $input  The input object.
+	 * @param   OutputInterface $output The output object.
+	 *
+	 * @return  string|null
+	 */
+	private function prompt_destination_input( InputInterface $input, OutputInterface $output ): ?string {
+		$site_slug = \is_null( $this->site ) ? 'unknown-site' : slugify( (string) $this->site->name );
+		$default   = get_user_folder_path( "Downloads/wpcom-db-$site_slug-" . \gmdate( 'Y-m-d-H-i-s' ) . '.sql' );
+		$question  = new Question( "<question>Please enter the path to save the database dump [$default]:</question> ", $default );
+
+		/**
+		 * The Symfony question helper.
+		 *
+		 * @var QuestionHelper $question_helper
+		 */
+		$question_helper = $this->getHelper( 'question' );
+		return $question_helper->ask( $input, $output, $question );
+	}
+
+	// endregion
+}

--- a/commands/WPCOM_Site_Database_Download.php
+++ b/commands/WPCOM_Site_Database_Download.php
@@ -77,17 +77,17 @@ final class WPCOM_Site_Database_Download extends Command {
 	protected function execute( InputInterface $input, OutputInterface $output ): int {
 		$output->writeln( "<fg=magenta;options=bold>Downloading the database from WPCOM site {$this->site->name} (ID {$this->site->ID}, URL {$this->site->URL}) to {$this->destination}.</>" );
 
-		$site_slug            = slugify( (string) $this->site->name );
-		$timestamp            = \gmdate( 'Y-m-d-H-i-s' );
-		$dump_filename        = "team51-wpcom-db-$site_slug-$timestamp.sql.gz";
-		$remote_dump_paths    = array(
+		$site_slug           = slugify( (string) $this->site->name );
+		$timestamp           = \gmdate( 'Y-m-d-H-i-s' );
+		$dump_filename       = "team51-wpcom-db-$site_slug-$timestamp.sql.gz";
+		$remote_dump_paths   = array(
 			"/tmp/$dump_filename",
 			"tmp/$dump_filename",
 		);
-		$remote_cleanup_error = false;
-		$download_successful  = false;
-		$download_valid       = false;
-		$remote_size          = null;
+		$dump_failed         = false;
+		$download_successful = false;
+		$download_valid      = false;
+		$remote_size         = null;
 
 		// Keep the compressed dump next to the destination so the decompression step below is a plain
 		// local file copy. The temp name is scoped to this process because a plain `<destination>.gz`
@@ -115,12 +115,19 @@ final class WPCOM_Site_Database_Download extends Command {
 				. 'gzip -f "${dump_path%.gz}"; '
 				. 'exit $?';
 			$dump_ssh->exec( $dump_command );
-			if ( 0 !== $dump_ssh->getExitStatus() ) {
-				$output->writeln( '<error>Failed to create the remote database dump.</error>' );
-				return Command::FAILURE;
-			}
+			$dump_failed = ( 0 !== $dump_ssh->getExitStatus() );
 		} finally {
 			$dump_ssh->disconnect();
+		}
+
+		if ( $dump_failed ) {
+			// `wp db export` may have written the plaintext dump before `gzip` failed, so sweep before leaving.
+			$output->writeln( '<error>Failed to create the remote database dump.</error>' );
+			if ( ! $this->remove_remote_dumps( $remote_dump_paths ) ) {
+				$output->writeln( "<error>Anything it left behind is still on the server at {$remote_dump_paths[0]} or its .sql counterpart; remove it manually.</error>" );
+			}
+
+			return Command::FAILURE;
 		}
 
 		$sftp = \WPCOM_Connection_Helper::get_sftp_connection( (string) $this->site->ID );
@@ -141,8 +148,8 @@ final class WPCOM_Site_Database_Download extends Command {
 					}
 				}
 
-				// Compare against the remote size so a short transfer fails while the remote dump,
-				// which is deleted immediately below, is still recoverable.
+				// Compare against the remote size so a short transfer is caught while the remote dump,
+				// which is only deleted once the local copy is known good, can still be re-fetched.
 				$download_valid = $download_successful && \is_file( $local_gz_path ) && 0 < \filesize( $local_gz_path )
 					&& ( \is_null( $remote_size ) || \filesize( $local_gz_path ) === $remote_size );
 			} finally {
@@ -150,51 +157,35 @@ final class WPCOM_Site_Database_Download extends Command {
 			}
 		}
 
-		// Always cleanup: the dump exists on the server from this point on, whatever happened above.
-		$cleanup_ssh = \WPCOM_Connection_Helper::get_ssh_connection( (string) $this->site->ID );
-		if ( \is_null( $cleanup_ssh ) ) {
-			$remote_cleanup_error = true;
-		} else {
-			try {
-				$cleanup_ssh->setTimeout( 0 );
-				$cleanup_command = 'rm -f '
-					. escapeshellarg( $remote_dump_paths[0] )
-					. ' '
-					. escapeshellarg( $remote_dump_paths[1] )
-					. ' 2>&1';
-				$cleanup_ssh->exec( $cleanup_command );
-				if ( 0 !== $cleanup_ssh->getExitStatus() ) {
-					$remote_cleanup_error = true;
-				}
-			} finally {
-				$cleanup_ssh->disconnect();
-			}
-		}
-
 		if ( \is_null( $sftp ) ) {
-			$output->writeln( '<error>Failed to connect to the site via SFTP.</error>' );
+			$output->writeln( "<error>Failed to connect to the site via SFTP. The dump is still at {$remote_dump_paths[0]} on the server.</error>" );
 			return Command::FAILURE;
 		}
 
 		if ( ! $download_successful ) {
 			$this->discard_temp_archive( $keep_compressed, $local_gz_path );
-			$output->writeln( '<error>Failed to download the database dump via SFTP.</error>' );
+			$output->writeln( "<error>Failed to download the database dump via SFTP. The dump is still at {$remote_dump_paths[0]} on the server.</error>" );
 			return Command::FAILURE;
 		}
 
 		if ( ! $download_valid ) {
 			$this->discard_temp_archive( $keep_compressed, $local_gz_path );
-			$output->writeln( '<error>Downloaded database dump is truncated or empty.</error>' );
+			$output->writeln( "<error>Downloaded database dump is truncated. The remote dump has been kept at {$remote_dump_paths[0]} so the transfer can be retried without re-exporting.</error>" );
 			return Command::FAILURE;
 		}
 
-		if ( ! $keep_compressed && ! decompress_gzip_file( $local_gz_path, $this->destination ) ) {
-			$output->writeln( "<error>Failed to decompress the downloaded dump. The compressed file is still at $local_gz_path.</error>" );
-			return Command::FAILURE;
+		if ( ! $keep_compressed ) {
+			if ( ! decompress_gzip_file( $local_gz_path, $this->destination ) ) {
+				$output->writeln( "<error>Failed to decompress the downloaded dump. The compressed copy is at $local_gz_path and the remote dump at {$remote_dump_paths[0]}.</error>" );
+				return Command::FAILURE;
+			}
+
+			$this->discard_temp_archive( $keep_compressed, $local_gz_path );
 		}
 
-		if ( $remote_cleanup_error ) {
-			$output->writeln( '<error>Database downloaded, but failed to clean up the temporary remote dump.</error>' );
+		// Only now is the local copy known good, so the remote dump can go.
+		if ( ! $this->remove_remote_dumps( $remote_dump_paths ) ) {
+			$output->writeln( "<error>Database downloaded to {$this->destination}, but the temporary remote dump at {$remote_dump_paths[0]} could not be removed. Delete it manually - it holds password hashes and customer data.</error>" );
 			return Command::FAILURE;
 		}
 
@@ -218,6 +209,37 @@ final class WPCOM_Site_Database_Download extends Command {
 	private function discard_temp_archive( bool $keep_compressed, string $local_gz_path ): void {
 		if ( ! $keep_compressed && \is_file( $local_gz_path ) ) {
 			\unlink( $local_gz_path );
+		}
+	}
+
+	/**
+	 * Removes the temporary dump from the server. Targets the plaintext `.sql` as well as the gzipped
+	 * path, because a failure between `wp db export` and `gzip` leaves the uncompressed dump - password
+	 * hashes, auth tokens and customer PII - sitting in a shared /tmp with nothing else to clean it up.
+	 *
+	 * @param   string[] $remote_dump_paths The candidate remote paths of the gzipped dump.
+	 *
+	 * @return  boolean
+	 */
+	private function remove_remote_dumps( array $remote_dump_paths ): bool {
+		$cleanup_ssh = \WPCOM_Connection_Helper::get_ssh_connection( (string) $this->site->ID );
+		if ( \is_null( $cleanup_ssh ) ) {
+			return false;
+		}
+
+		try {
+			$cleanup_ssh->setTimeout( 0 );
+
+			$targets = array();
+			foreach ( $remote_dump_paths as $path ) {
+				$targets[] = escapeshellarg( $path );
+				$targets[] = escapeshellarg( \preg_replace( '/\.gz$/', '', $path ) );
+			}
+
+			$cleanup_ssh->exec( 'rm -f ' . \implode( ' ', $targets ) . ' 2>&1' );
+			return 0 === $cleanup_ssh->getExitStatus();
+		} finally {
+			$cleanup_ssh->disconnect();
 		}
 	}
 

--- a/commands/WPCOM_Site_Database_Download.php
+++ b/commands/WPCOM_Site_Database_Download.php
@@ -120,11 +120,12 @@ final class WPCOM_Site_Database_Download extends Command {
 				. 'wp db export "${dump_path%.gz}" --add-drop-table --single-transaction && '
 				. 'gzip -f "${dump_path%.gz}"; '
 				. 'exit $?';
-			$dump_output  = (string) $dump_ssh->exec( $dump_command );
-			$dump_failed  = ( 0 !== $dump_ssh->getExitStatus() );
-			// A MySQL error, an exhausted /tmp and a failed gzip are indistinguishable without this,
+			// exec() already folds the channel's stderr into its return value - quiet mode, which would
+			// suppress that, is never enabled here - so getStdError() would only repeat it.
+			// Without this a MySQL error, an exhausted /tmp and a failed gzip are indistinguishable,
 			// and the operator has already paid the full export time by the time it fails.
-			$dump_error = \trim( $dump_output . "\n" . (string) $dump_ssh->getStdError() );
+			$dump_error  = \trim( (string) $dump_ssh->exec( $dump_command ) );
+			$dump_failed = ( 0 !== $dump_ssh->getExitStatus() );
 		} finally {
 			$dump_ssh->disconnect();
 		}
@@ -178,6 +179,7 @@ final class WPCOM_Site_Database_Download extends Command {
 		}
 
 		if ( \is_null( $sftp ) ) {
+			$this->discard_temp_archive( $output, $local_gz_path );
 			$output->writeln( "<error>Failed to connect to the site via SFTP. The dump is still at $used_remote_path on the server.</error>" );
 			return Command::FAILURE;
 		}
@@ -252,9 +254,12 @@ final class WPCOM_Site_Database_Download extends Command {
 	 */
 	private function create_owner_only_file( OutputInterface $output, string $path ): void {
 		$handle = \fopen( $path, 'wb' );
-		if ( false !== $handle ) {
-			\fclose( $handle );
+		if ( false === $handle ) {
+			$output->writeln( "<comment>Could not pre-create $path. The transfer will create it with default permissions.</comment>" );
+			return;
 		}
+
+		\fclose( $handle );
 
 		// A filesystem that cannot honour the mode - exFAT, an SMB mount - would otherwise make this
 		// hardening a silent no-op.

--- a/commands/WPCOM_Site_Database_Download.php
+++ b/commands/WPCOM_Site_Database_Download.php
@@ -89,6 +89,7 @@ final class WPCOM_Site_Database_Download extends Command {
 			"tmp/$dump_filename",
 		);
 		$dump_failed         = false;
+		$dump_error          = '';
 		$download_successful = false;
 		$download_valid      = false;
 		$remote_size         = null;
@@ -119,8 +120,11 @@ final class WPCOM_Site_Database_Download extends Command {
 				. 'wp db export "${dump_path%.gz}" --add-drop-table --single-transaction && '
 				. 'gzip -f "${dump_path%.gz}"; '
 				. 'exit $?';
-			$dump_ssh->exec( $dump_command );
-			$dump_failed = ( 0 !== $dump_ssh->getExitStatus() );
+			$dump_output  = (string) $dump_ssh->exec( $dump_command );
+			$dump_failed  = ( 0 !== $dump_ssh->getExitStatus() );
+			// A MySQL error, an exhausted /tmp and a failed gzip are indistinguishable without this,
+			// and the operator has already paid the full export time by the time it fails.
+			$dump_error = \trim( $dump_output . "\n" . (string) $dump_ssh->getStdError() );
 		} finally {
 			$dump_ssh->disconnect();
 		}
@@ -128,12 +132,20 @@ final class WPCOM_Site_Database_Download extends Command {
 		if ( $dump_failed ) {
 			// `wp db export` may have written the plaintext dump before `gzip` failed, so sweep before leaving.
 			$output->writeln( '<error>Failed to create the remote database dump.</error>' );
+			if ( '' !== $dump_error ) {
+				$output->writeln( "<error>$dump_error</error>" );
+			}
+
 			if ( ! $this->remove_remote_dumps( $remote_dump_paths ) ) {
 				$output->writeln( "<error>Anything it left behind is still on the server at {$remote_dump_paths[0]} or its .sql counterpart; remove it manually.</error>" );
 			}
 
 			return Command::FAILURE;
 		}
+
+		// Create the temp file 0600 up front: SFTP truncates an existing file rather than recreating it,
+		// so chmod-ing afterwards would leave the archive world-readable for the whole transfer.
+		$this->create_owner_only_file( $output, $local_gz_path );
 
 		$sftp = \WPCOM_Connection_Helper::get_sftp_connection( (string) $this->site->ID );
 		if ( ! \is_null( $sftp ) ) {
@@ -150,7 +162,6 @@ final class WPCOM_Site_Database_Download extends Command {
 					$used_remote_path = $sftp_path;
 
 					if ( $sftp->get( $sftp_path, $local_gz_path ) ) {
-						\chmod( $local_gz_path, 0600 );
 						$download_successful = true;
 						$remote_size         = $remote_stat['size'] ?? null;
 						break;
@@ -227,6 +238,28 @@ final class WPCOM_Site_Database_Download extends Command {
 	private function discard_temp_archive( OutputInterface $output, string $local_gz_path ): void {
 		if ( \is_file( $local_gz_path ) && ! \unlink( $local_gz_path ) ) {
 			$output->writeln( "<comment>Could not remove the temporary archive at $local_gz_path. Delete it manually - it holds a copy of the database.</comment>" );
+		}
+	}
+
+	/**
+	 * Creates an empty file readable only by its owner, so the dump is never briefly exposed to other
+	 * users of the machine while it downloads.
+	 *
+	 * @param   OutputInterface $output The output object.
+	 * @param   string          $path   The file to create.
+	 *
+	 * @return  void
+	 */
+	private function create_owner_only_file( OutputInterface $output, string $path ): void {
+		$handle = \fopen( $path, 'wb' );
+		if ( false !== $handle ) {
+			\fclose( $handle );
+		}
+
+		// A filesystem that cannot honour the mode - exFAT, an SMB mount - would otherwise make this
+		// hardening a silent no-op.
+		if ( ! \chmod( $path, 0600 ) ) {
+			$output->writeln( "<comment>Could not restrict permissions on $path. Other users of this machine may be able to read the dump.</comment>" );
 		}
 	}
 

--- a/commands/WPCOM_Site_Database_Download.php
+++ b/commands/WPCOM_Site_Database_Download.php
@@ -54,6 +54,8 @@ final class WPCOM_Site_Database_Download extends Command {
 
 	/**
 	 * {@inheritDoc}
+	 *
+	 * @throws  \InvalidArgumentException If the destination directory does not exist or is not writable.
 	 */
 	protected function initialize( InputInterface $input, OutputInterface $output ): void {
 		$this->site = get_wpcom_site_input( $input, fn() => $this->prompt_site_input( $input, $output ) );
@@ -61,6 +63,12 @@ final class WPCOM_Site_Database_Download extends Command {
 
 		$this->destination = get_string_input( $input, 'destination', fn() => $this->prompt_destination_input( $input, $output ) );
 		$input->setOption( 'destination', $this->destination );
+
+		// Fail here rather than after spending minutes on the remote export and transfer.
+		$destination_dir = \dirname( $this->destination );
+		if ( ! \is_dir( $destination_dir ) || ! \is_writable( $destination_dir ) ) {
+			throw new \InvalidArgumentException( "The destination directory $destination_dir does not exist or is not writable." );
+		}
 	}
 
 	/**
@@ -77,15 +85,15 @@ final class WPCOM_Site_Database_Download extends Command {
 			"tmp/$dump_filename",
 		);
 		$remote_cleanup_error = false;
-		$dump_created         = false;
 		$download_successful  = false;
 		$download_valid       = false;
+		$remote_size          = null;
 
 		// Keep the compressed dump next to the destination so the decompression step below is a plain
-		// local file copy. Downloading straight to the destination would leave a gzipped file behind
-		// under a `.sql` name if the process died between transfer and decompression.
+		// local file copy. The temp name is scoped to this process because a plain `<destination>.gz`
+		// would overwrite - and then delete - a compressed dump the user deliberately kept earlier.
 		$keep_compressed = \str_ends_with( \strtolower( $this->destination ), '.gz' );
-		$local_gz_path   = $keep_compressed ? $this->destination : $this->destination . '.gz';
+		$local_gz_path   = $keep_compressed ? $this->destination : $this->destination . '.' . \getmypid() . '.gz';
 
 		$dump_ssh = \WPCOM_Connection_Helper::get_ssh_connection( (string) $this->site->ID );
 		if ( \is_null( $dump_ssh ) ) {
@@ -98,11 +106,14 @@ final class WPCOM_Site_Database_Download extends Command {
 
 			// Run wp from the login directory: wp-cli resolves the site path from the host's own
 			// config there, and cd-ing into htdocs first breaks that resolution.
+			// umask 077 because, unlike a plugin archive, this dump holds password hashes, auth tokens
+			// and customer PII, and it sits in a shared /tmp for the whole export and transfer.
 			// --single-transaction keeps the export from locking a live production database.
-			$dump_command = 'if [ -d /tmp ]; then dump_path=' . escapeshellarg( $remote_dump_paths[0] ) . '; else dump_path=' . escapeshellarg( $remote_dump_paths[1] ) . '; fi; '
+			$dump_command = 'umask 077; '
+				. 'if [ -d /tmp ]; then dump_path=' . escapeshellarg( $remote_dump_paths[0] ) . '; else dump_path=' . escapeshellarg( $remote_dump_paths[1] ) . '; fi; '
 				. 'wp db export "${dump_path%.gz}" --add-drop-table --single-transaction && '
 				. 'gzip -f "${dump_path%.gz}"; '
-				. 'exit $? 2>&1';
+				. 'exit $?';
 			$dump_ssh->exec( $dump_command );
 			if ( 0 !== $dump_ssh->getExitStatus() ) {
 				$output->writeln( '<error>Failed to create the remote database dump.</error>' );
@@ -112,45 +123,51 @@ final class WPCOM_Site_Database_Download extends Command {
 			$dump_ssh->disconnect();
 		}
 
-		$dump_created = true;
-
 		$sftp = \WPCOM_Connection_Helper::get_sftp_connection( (string) $this->site->ID );
 		if ( ! \is_null( $sftp ) ) {
 			try {
 				$sftp->setTimeout( 0 );
 
 				foreach ( $remote_dump_paths as $sftp_path ) {
+					$remote_stat = $sftp->stat( $sftp_path );
+					if ( false === $remote_stat ) {
+						continue;
+					}
+
 					if ( $sftp->get( $sftp_path, $local_gz_path ) ) {
 						$download_successful = true;
+						$remote_size         = $remote_stat['size'] ?? null;
 						break;
 					}
 				}
 
-				$download_valid = $download_successful && \is_file( $local_gz_path ) && 0 < \filesize( $local_gz_path );
+				// Compare against the remote size so a short transfer fails while the remote dump,
+				// which is deleted immediately below, is still recoverable.
+				$download_valid = $download_successful && \is_file( $local_gz_path ) && 0 < \filesize( $local_gz_path )
+					&& ( \is_null( $remote_size ) || \filesize( $local_gz_path ) === $remote_size );
 			} finally {
 				$sftp->disconnect();
 			}
 		}
 
-		if ( $dump_created ) { // Always cleanup after dump creation.
-			$cleanup_ssh = \WPCOM_Connection_Helper::get_ssh_connection( (string) $this->site->ID );
-			if ( \is_null( $cleanup_ssh ) ) {
-				$remote_cleanup_error = true;
-			} else {
-				try {
-					$cleanup_ssh->setTimeout( 0 );
-					$cleanup_command = 'rm -f '
-						. escapeshellarg( $remote_dump_paths[0] )
-						. ' '
-						. escapeshellarg( $remote_dump_paths[1] )
-						. ' 2>&1';
-					$cleanup_ssh->exec( $cleanup_command );
-					if ( 0 !== $cleanup_ssh->getExitStatus() ) {
-						$remote_cleanup_error = true;
-					}
-				} finally {
-					$cleanup_ssh->disconnect();
+		// Always cleanup: the dump exists on the server from this point on, whatever happened above.
+		$cleanup_ssh = \WPCOM_Connection_Helper::get_ssh_connection( (string) $this->site->ID );
+		if ( \is_null( $cleanup_ssh ) ) {
+			$remote_cleanup_error = true;
+		} else {
+			try {
+				$cleanup_ssh->setTimeout( 0 );
+				$cleanup_command = 'rm -f '
+					. escapeshellarg( $remote_dump_paths[0] )
+					. ' '
+					. escapeshellarg( $remote_dump_paths[1] )
+					. ' 2>&1';
+				$cleanup_ssh->exec( $cleanup_command );
+				if ( 0 !== $cleanup_ssh->getExitStatus() ) {
+					$remote_cleanup_error = true;
 				}
+			} finally {
+				$cleanup_ssh->disconnect();
 			}
 		}
 
@@ -160,12 +177,14 @@ final class WPCOM_Site_Database_Download extends Command {
 		}
 
 		if ( ! $download_successful ) {
+			$this->discard_temp_archive( $keep_compressed, $local_gz_path );
 			$output->writeln( '<error>Failed to download the database dump via SFTP.</error>' );
 			return Command::FAILURE;
 		}
 
 		if ( ! $download_valid ) {
-			$output->writeln( '<error>Downloaded database dump appears invalid or empty.</error>' );
+			$this->discard_temp_archive( $keep_compressed, $local_gz_path );
+			$output->writeln( '<error>Downloaded database dump is truncated or empty.</error>' );
 			return Command::FAILURE;
 		}
 
@@ -186,6 +205,21 @@ final class WPCOM_Site_Database_Download extends Command {
 	// endregion
 
 	// region HELPERS
+
+	/**
+	 * Removes the process-scoped compressed download after a failure. Skipped when the user asked to
+	 * keep the compressed file, since that path is their own destination rather than a temp file.
+	 *
+	 * @param   boolean $keep_compressed Whether the destination is itself the compressed file.
+	 * @param   string  $local_gz_path   The path the archive was downloaded to.
+	 *
+	 * @return  void
+	 */
+	private function discard_temp_archive( bool $keep_compressed, string $local_gz_path ): void {
+		if ( ! $keep_compressed && \is_file( $local_gz_path ) ) {
+			\unlink( $local_gz_path );
+		}
+	}
 
 	/**
 	 * Prompts the user for a site.

--- a/commands/WPCOM_Site_Database_Download.php
+++ b/commands/WPCOM_Site_Database_Download.php
@@ -65,6 +65,10 @@ final class WPCOM_Site_Database_Download extends Command {
 		$input->setOption( 'destination', $this->destination );
 
 		// Fail here rather than after spending minutes on the remote export and transfer.
+		if ( \is_dir( $this->destination ) ) {
+			throw new \InvalidArgumentException( "The destination {$this->destination} is a directory. Pass the full path of the file to write." );
+		}
+
 		$destination_dir = \dirname( $this->destination );
 		if ( ! \is_dir( $destination_dir ) || ! \is_writable( $destination_dir ) ) {
 			throw new \InvalidArgumentException( "The destination directory $destination_dir does not exist or is not writable." );
@@ -88,12 +92,13 @@ final class WPCOM_Site_Database_Download extends Command {
 		$download_successful = false;
 		$download_valid      = false;
 		$remote_size         = null;
+		$used_remote_path    = $remote_dump_paths[0];
 
-		// Keep the compressed dump next to the destination so the decompression step below is a plain
-		// local file copy. The temp name is scoped to this process because a plain `<destination>.gz`
-		// would overwrite - and then delete - a compressed dump the user deliberately kept earlier.
+		// Always transfer into a process-scoped temp file and only move it onto the destination once the
+		// download has been verified. Writing straight to the destination would let a dropped connection
+		// replace an earlier dump - possibly the last copy of a deleted site - with a partial one.
 		$keep_compressed = \str_ends_with( \strtolower( $this->destination ), '.gz' );
-		$local_gz_path   = $keep_compressed ? $this->destination : $this->destination . '.' . \getmypid() . '.gz';
+		$local_gz_path   = $this->destination . '.' . \getmypid() . '.gz';
 
 		$dump_ssh = \WPCOM_Connection_Helper::get_ssh_connection( (string) $this->site->ID );
 		if ( \is_null( $dump_ssh ) ) {
@@ -141,7 +146,11 @@ final class WPCOM_Site_Database_Download extends Command {
 						continue;
 					}
 
+					// The dump is here, so this is the path to name in any recovery message from now on.
+					$used_remote_path = $sftp_path;
+
 					if ( $sftp->get( $sftp_path, $local_gz_path ) ) {
+						\chmod( $local_gz_path, 0600 );
 						$download_successful = true;
 						$remote_size         = $remote_stat['size'] ?? null;
 						break;
@@ -158,34 +167,44 @@ final class WPCOM_Site_Database_Download extends Command {
 		}
 
 		if ( \is_null( $sftp ) ) {
-			$output->writeln( "<error>Failed to connect to the site via SFTP. The dump is still at {$remote_dump_paths[0]} on the server.</error>" );
+			$output->writeln( "<error>Failed to connect to the site via SFTP. The dump is still at $used_remote_path on the server.</error>" );
 			return Command::FAILURE;
 		}
 
 		if ( ! $download_successful ) {
-			$this->discard_temp_archive( $keep_compressed, $local_gz_path );
-			$output->writeln( "<error>Failed to download the database dump via SFTP. The dump is still at {$remote_dump_paths[0]} on the server.</error>" );
+			$this->discard_temp_archive( $output, $local_gz_path );
+			$output->writeln( "<error>Failed to download the database dump via SFTP. The dump is still at $used_remote_path on the server.</error>" );
 			return Command::FAILURE;
+		}
+
+		if ( \is_null( $remote_size ) ) {
+			$output->writeln( '<comment>The server did not report the dump size, so the transfer could not be checked for truncation.</comment>' );
 		}
 
 		if ( ! $download_valid ) {
-			$this->discard_temp_archive( $keep_compressed, $local_gz_path );
-			$output->writeln( "<error>Downloaded database dump is truncated. The remote dump has been kept at {$remote_dump_paths[0]} so the transfer can be retried without re-exporting.</error>" );
+			$this->discard_temp_archive( $output, $local_gz_path );
+			$output->writeln( "<error>Downloaded database dump is truncated. The remote dump has been kept at $used_remote_path so the transfer can be retried without re-exporting.</error>" );
 			return Command::FAILURE;
 		}
 
-		if ( ! $keep_compressed ) {
+		if ( $keep_compressed ) {
+			if ( ! \rename( $local_gz_path, $this->destination ) ) {
+				$this->discard_temp_archive( $output, $local_gz_path );
+				$output->writeln( "<error>Failed to move the downloaded archive to {$this->destination}. The remote dump is still at $used_remote_path.</error>" );
+				return Command::FAILURE;
+			}
+		} else {
 			if ( ! decompress_gzip_file( $local_gz_path, $this->destination ) ) {
-				$output->writeln( "<error>Failed to decompress the downloaded dump. The compressed copy is at $local_gz_path and the remote dump at {$remote_dump_paths[0]}.</error>" );
+				$output->writeln( "<error>Failed to decompress the downloaded dump. The compressed copy is at $local_gz_path and the remote dump at $used_remote_path.</error>" );
 				return Command::FAILURE;
 			}
 
-			$this->discard_temp_archive( $keep_compressed, $local_gz_path );
+			$this->discard_temp_archive( $output, $local_gz_path );
 		}
 
 		// Only now is the local copy known good, so the remote dump can go.
 		if ( ! $this->remove_remote_dumps( $remote_dump_paths ) ) {
-			$output->writeln( "<error>Database downloaded to {$this->destination}, but the temporary remote dump at {$remote_dump_paths[0]} could not be removed. Delete it manually - it holds password hashes and customer data.</error>" );
+			$output->writeln( "<error>Database downloaded to {$this->destination}, but the temporary remote dump at $used_remote_path could not be removed. Delete it manually - it holds password hashes and customer data.</error>" );
 			return Command::FAILURE;
 		}
 
@@ -198,17 +217,16 @@ final class WPCOM_Site_Database_Download extends Command {
 	// region HELPERS
 
 	/**
-	 * Removes the process-scoped compressed download after a failure. Skipped when the user asked to
-	 * keep the compressed file, since that path is their own destination rather than a temp file.
+	 * Removes the process-scoped compressed download.
 	 *
-	 * @param   boolean $keep_compressed Whether the destination is itself the compressed file.
-	 * @param   string  $local_gz_path   The path the archive was downloaded to.
+	 * @param   OutputInterface $output        The output object.
+	 * @param   string          $local_gz_path The path the archive was downloaded to.
 	 *
 	 * @return  void
 	 */
-	private function discard_temp_archive( bool $keep_compressed, string $local_gz_path ): void {
-		if ( ! $keep_compressed && \is_file( $local_gz_path ) ) {
-			\unlink( $local_gz_path );
+	private function discard_temp_archive( OutputInterface $output, string $local_gz_path ): void {
+		if ( \is_file( $local_gz_path ) && ! \unlink( $local_gz_path ) ) {
+			$output->writeln( "<comment>Could not remove the temporary archive at $local_gz_path. Delete it manually - it holds a copy of the database.</comment>" );
 		}
 	}
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -623,4 +623,47 @@ function get_file_handle( string $filename, string $extension, string $mode = 'w
 	return $handle;
 }
 
+/**
+ * Decompresses a gzip file, streaming it so that database dumps larger than the memory limit still work.
+ * The source file is removed once the destination has been written.
+ *
+ * @param   string $source      The path to the gzipped file.
+ * @param   string $destination The path to write the decompressed file to.
+ *
+ * @return  boolean
+ */
+function decompress_gzip_file( string $source, string $destination ): bool {
+	$in = gzopen( $source, 'rb' );
+	if ( false === $in ) {
+		return false;
+	}
+
+	$out = fopen( $destination, 'wb' );
+	if ( false === $out ) {
+		gzclose( $in );
+		return false;
+	}
+
+	$failed = false;
+	while ( ! gzeof( $in ) ) {
+		$chunk = gzread( $in, 1048576 );
+		if ( false === $chunk || false === fwrite( $out, $chunk ) ) {
+			$failed = true;
+			break;
+		}
+	}
+
+	gzclose( $in );
+	fclose( $out );
+
+	if ( $failed ) {
+		// A partial dump is worse than none: it imports without error and leaves the database half-populated.
+		unlink( $destination );
+		return false;
+	}
+
+	unlink( $source );
+	return true;
+}
+
 // endregion

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -676,6 +676,10 @@ function decompress_gzip_file( string $source, string $destination ): bool {
 		return false;
 	}
 
+	// A decompressed database dump holds password hashes, auth tokens and PII, and unlike the remote
+	// copy it persists indefinitely. rename() preserves the mode, so the destination inherits this.
+	chmod( $partial, 0600 );
+
 	$failed        = false;
 	$written_total = 0;
 	while ( ! gzeof( $in ) ) {

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -624,8 +624,35 @@ function get_file_handle( string $filename, string $extension, string $mode = 'w
 }
 
 /**
+ * Reads the uncompressed size gzip stores in the last four bytes of an archive.
+ *
+ * @param   string $path The path to the gzipped file.
+ *
+ * @return  integer|null Null when the trailer cannot be read.
+ */
+function read_gzip_uncompressed_size( string $path ): ?int {
+	$handle = fopen( $path, 'rb' );
+	if ( false === $handle ) {
+		return null;
+	}
+
+	$size = null;
+	if ( 0 === fseek( $handle, -4, SEEK_END ) ) {
+		$trailer = fread( $handle, 4 );
+		if ( is_string( $trailer ) && 4 === strlen( $trailer ) ) {
+			$unpacked = unpack( 'V', $trailer );
+			$size     = false === $unpacked ? null : $unpacked[1];
+		}
+	}
+
+	fclose( $handle );
+	return $size;
+}
+
+/**
  * Decompresses a gzip file, streaming it so that database dumps larger than the memory limit still work.
- * The source file is removed once the destination has been written.
+ * The destination is only replaced once the whole stream has been written, and the source is left for
+ * the caller to remove.
  *
  * @param   string $source      The path to the gzipped file.
  * @param   string $destination The path to write the decompressed file to.
@@ -638,13 +665,19 @@ function decompress_gzip_file( string $source, string $destination ): bool {
 		return false;
 	}
 
-	$out = fopen( $destination, 'wb' );
+	// Stream into a sibling file and rename it into place at the end. Opening $destination directly
+	// would truncate whatever is already there before a single byte has been read, so a failure
+	// halfway through would destroy a good dump the caller never asked to replace.
+	$partial = $destination . '.' . getmypid() . '.part';
+
+	$out = fopen( $partial, 'wb' );
 	if ( false === $out ) {
 		gzclose( $in );
 		return false;
 	}
 
-	$failed = false;
+	$failed        = false;
+	$written_total = 0;
 	while ( ! gzeof( $in ) ) {
 		$chunk = gzread( $in, 1048576 );
 		if ( false === $chunk ) {
@@ -659,22 +692,35 @@ function decompress_gzip_file( string $source, string $destination ): bool {
 			$failed = true;
 			break;
 		}
+
+		$written_total += $written;
 	}
 
 	gzclose( $in );
+
+	// gzread() reports no error on an archive whose stream simply stops early, so a truncated download
+	// would otherwise decompress "successfully" into a partial dump. Compare what was written against
+	// the uncompressed size gzip records in the last four bytes. Single-member archives only, which is
+	// what gzip produces; a concatenated archive would report only its final member's size.
+	$expected_size = read_gzip_uncompressed_size( $source );
+	if ( ! is_null( $expected_size ) && ( $written_total % 4294967296 ) !== $expected_size ) {
+		$failed = true;
+	}
 
 	// Buffered bytes are flushed on close, so a write error can surface here rather than above.
 	if ( ! fclose( $out ) ) {
 		$failed = true;
 	}
 
-	if ( $failed ) {
-		// A partial dump is worse than none: it imports without error and leaves the database half-populated.
-		unlink( $destination );
+	// A partial dump is worse than none: it imports without error and leaves the database half-populated.
+	if ( $failed || ! rename( $partial, $destination ) ) {
+		if ( is_file( $partial ) ) {
+			unlink( $partial );
+		}
+
 		return false;
 	}
 
-	unlink( $source );
 	return true;
 }
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -647,14 +647,26 @@ function decompress_gzip_file( string $source, string $destination ): bool {
 	$failed = false;
 	while ( ! gzeof( $in ) ) {
 		$chunk = gzread( $in, 1048576 );
-		if ( false === $chunk || false === fwrite( $out, $chunk ) ) {
+		if ( false === $chunk ) {
+			$failed = true;
+			break;
+		}
+
+		// A disk that fills mid-write returns a short byte count rather than false, so comparing
+		// against false alone would treat a truncated dump as a complete one.
+		$written = fwrite( $out, $chunk );
+		if ( false === $written || strlen( $chunk ) !== $written ) {
 			$failed = true;
 			break;
 		}
 	}
 
 	gzclose( $in );
-	fclose( $out );
+
+	// Buffered bytes are flushed on close, so a write error can surface here rather than above.
+	if ( ! fclose( $out ) ) {
+		$failed = true;
+	}
 
 	if ( $failed ) {
 		// A partial dump is worse than none: it imports without error and leaves the database half-populated.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -706,8 +706,10 @@ function decompress_gzip_file( string $source, string $destination ): bool {
 	// would otherwise decompress "successfully" into a partial dump. Compare what was written against
 	// the uncompressed size gzip records in the last four bytes. Single-member archives only, which is
 	// what gzip produces; a concatenated archive would report only its final member's size.
+	// An unreadable trailer fails closed: a valid member always has one, so its absence means the
+	// archive is damaged rather than that the check does not apply.
 	$expected_size = read_gzip_uncompressed_size( $source );
-	if ( ! is_null( $expected_size ) && ( $written_total % 4294967296 ) !== $expected_size ) {
+	if ( is_null( $expected_size ) || ( $written_total % 4294967296 ) !== $expected_size ) {
 		$failed = true;
 	}
 


### PR DESCRIPTION
## Summary

- Add `pressable:download-site-database` and `wpcom:download-site-database`, which export a site's database and download it locally. Both mirror the existing `download-site-plugins` commands: SSH creates the dump, SFTP transfers it, SSH removes the remote temp file.
- Dump is created with `wp db export --add-drop-table --single-transaction` so exporting does not lock a live production database, and under `umask 077` so it is not world-readable in a shared `/tmp` while it holds password hashes, auth tokens and customer PII. On failure the remote command's output is printed, so a MySQL error, an exhausted `/tmp` and a failed `gzip` are distinguishable.
- The remote dump is deleted only once the local copy has been downloaded, size-verified and decompressed, so a truncated transfer can be retried without a second multi-minute export. Cleanup covers the plaintext `.sql` as well as the gzipped path, since a failure between `wp db export` and `gzip` would otherwise strand an unencrypted dump on the host.
- The local dump is created `0600` before the transfer starts. It holds the same hashes, tokens and PII as the remote copy and persists indefinitely.
- Dump is gzipped on the server to keep the transfer small, and decompressed locally unless `--destination` ends in `.gz`. The transfer always lands in a process-scoped temp path and is renamed onto the destination only after it has been size-verified, so a dropped connection cannot replace an earlier dump with a partial one.
- `--destination` is validated in `initialize()` — rejected if it is a directory, or if its parent does not exist or is not writable — so a typo'd path fails immediately instead of after minutes of remote export.
- Run `wp` from the login directory rather than `cd`-ing into `htdocs` — wp-cli resolves the site path from the host's own config there, and changing directory first breaks it.
- Add `decompress_gzip_file()` and `read_gzip_uncompressed_size()` to `includes/functions.php`. Decompression streams in 1 MiB chunks so dumps larger than the PHP memory limit still work, writes to a sibling `.part` file and renames it into place so a mid-stream failure cannot truncate a good file already at the destination, and verifies the bytes written against the uncompressed size in the gzip trailer — `gzread()` reports no error on a stream that stops early, and passes non-gzip data straight through, so without that check a truncated archive decompresses "successfully" into a partial dump. An unreadable trailer fails closed.

## Notes

- Destination defaults to `~/Downloads/<host>-db-<slug>-<timestamp>.sql`, i.e. ready to import without a manual decompress step.
- No search-replace or import step — these commands only pull the dump. Rewriting URLs is left to the caller.
- The gzip-trailer check assumes a single-member archive, which is what `gzip` produces. A concatenated archive would report only its final member's size.

## Test plan

Verified against live sites on both hosts:

- [x] Pressable — 623 MB dump, 51 tables, ends with `-- Dump completed on`.
- [x] WPCOM — `itkandevelopment.wpcomstaging.com`: 18 MB dump, 122 tables, valid terminator.
- [x] `--destination` ending in `.gz` stays compressed and passes `gzip -t`.
- [x] Local dump and `.gz` archive are both written `-rw-------`.
- [x] Remote `/tmp` contains no `.sql` or `.gz` dump files after a successful run, confirmed over SSH.
- [x] No process-scoped `.gz` or `.part` file left behind after a successful run.
- [x] Sidecar-clobbering regression check: download to `db.sql.gz`, record its SHA-256, then download to `db.sql`. The kept `.gz` is byte-identical afterwards and the `.sql` is a complete dump.
- [x] `--destination` pointing at a directory, or into a non-existent directory, aborts before any SSH connection.
- [x] `decompress_gzip_file()` unit checks — a truncated gzip, a non-gzip file, and an archive with an unreadable trailer all return `false` and leave a pre-existing destination untouched; a valid archive is byte-identical to the original, is written `0600`, and leaves the source in place.
- [x] `composer run lint:php` — both new commands clean; `includes/functions.php` unchanged from its `trunk` baseline.

Not exercised:

- [ ] `umask 077` on the remote dump is verified by inspection only — the file is removed at the end of the run, leaving no window to stat it without adding throwaway code.
